### PR TITLE
Install node deps before running unit tests, run on all branches

### DIFF
--- a/.github/workflows/run-unit-test.yml
+++ b/.github/workflows/run-unit-test.yml
@@ -22,5 +22,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: |
-          cd deployment
-          chmod +x ./run-unit-tests.sh && DEBUG=true ./run-unit-tests.sh
+          cd source
+          npm ci
+          cd ../deployment
+          DEBUG=true ./run-unit-tests.sh

--- a/.github/workflows/run-unit-test.yml
+++ b/.github/workflows/run-unit-test.yml
@@ -3,8 +3,6 @@ name: Unit Test
 
 on:
   push:
-    branches:
-      - "*"
   pull_request:
     types: [opened, edited, reopened, synchronize]
 


### PR DESCRIPTION
- Install node deps before running unit tests
- Use `npm ci` for better repeatability
- Run workflow on all branches

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.