### PR TITLE
Fix import-time problems in unit tests

### DIFF
--- a/source/Orchestrator/test/test_exec_ssm_doc.py
+++ b/source/Orchestrator/test/test_exec_ssm_doc.py
@@ -12,9 +12,6 @@ from botocore.stub import Stubber, ANY
 from exec_ssm_doc import lambda_handler
 from pytest_mock import mocker
 
-my_session = boto3.session.Session()
-my_region = my_session.region_name
-os.environ['AWS_REGION'] = my_region
 
 def test_exec_runbook(mocker):
     """
@@ -39,14 +36,14 @@ def test_exec_runbook(mocker):
                 "Product": 0,
                 "Label": "INFORMATIONAL",
                 "Normalized": 0,
-                "Original": "INFORMATIONAL"
+                "Original": "INFORMATIONAL",
             },
             "Title": "AutoScaling.1 Auto scaling groups associated with a load balancer should use load balancer health checks",
             "Description": "This control checks whether your Auto Scaling groups that are associated with a load balancer are using Elastic Load Balancing health checks.",
             "Remediation": {
                 "Recommendation": {
                     "Text": "For directions on how to fix this issue, please consult the AWS Security Hub Foundational Security Best Practices documentation.",
-                    "Url": "https://docs.aws.amazon.com/console/securityhub/AutoScaling.1/remediation"
+                    "Url": "https://docs.aws.amazon.com/console/securityhub/AutoScaling.1/remediation",
                 }
             },
             "ProductFields": {
@@ -60,14 +57,14 @@ def test_exec_runbook(mocker):
                 "aws/securityhub/ProductName": "Security Hub",
                 "aws/securityhub/CompanyName": "AWS",
                 "aws/securityhub/annotation": "AWS Config evaluated your resources against the rule. The rule did not apply to the AWS resources in its scope, the specified resources were deleted, or the evaluation results were deleted.",
-                "aws/securityhub/FindingId": "arn:aws:securityhub:us-east-1::product/aws/securityhub/arn:aws:securityhub:us-east-1:111111111111:subscription/aws-foundational-security-best-practices/v/1.0.0/AutoScaling.1/finding/635ceb5d-3dfd-4458-804e-48a42cd723e4"
+                "aws/securityhub/FindingId": "arn:aws:securityhub:us-east-1::product/aws/securityhub/arn:aws:securityhub:us-east-1:111111111111:subscription/aws-foundational-security-best-practices/v/1.0.0/AutoScaling.1/finding/635ceb5d-3dfd-4458-804e-48a42cd723e4",
             },
             "Resources": [
                 {
                     "Type": "AwsAccount",
                     "Id": "arn:aws:autoscaling:us-east-1:111111111111:autoScalingGroup:785df3481e1-cd66-435d-96de-d6ed5416defd:autoScalingGroupName/sharr-test-autoscaling-1",
                     "Partition": "aws",
-                    "Region": "us-east-1"
+                    "Region": "us-east-1",
                 }
             ],
             "Compliance": {
@@ -75,80 +72,64 @@ def test_exec_runbook(mocker):
                 "StatusReasons": [
                     {
                         "ReasonCode": "CONFIG_EVALUATIONS_EMPTY",
-                        "Description": "AWS Config evaluated your resources against the rule. The rule did not apply to the AWS resources in its scope, the specified resources were deleted, or the evaluation results were deleted."
+                        "Description": "AWS Config evaluated your resources against the rule. The rule did not apply to the AWS resources in its scope, the specified resources were deleted, or the evaluation results were deleted.",
                     }
-                ]
+                ],
             },
             "WorkflowState": "NEW",
-            "Workflow": {
-                "Status": "NEW"
-            },
-            "RecordState": "ACTIVE"
+            "Workflow": {"Status": "NEW"},
+            "RecordState": "ACTIVE",
         },
         "AutomationDocument": {
             "DocState": "ACTIVE",
             "SecurityStandardVersion": "1.0.0",
             "AccountId": "111111111111",
-            "Message": "Document Status is not \"Active\": unknown",
+            "Message": 'Document Status is not "Active": unknown',
             "AutomationDocId": "SHARR-AFSBP_1.0.0_AutoScaling.1",
             "RemediationRole": "SO0111-Remediate-AFSBP-1.0.0-AutoScaling.1",
             "ControlId": "AutoScaling.1",
             "SecurityStandard": "AFSBP",
-            "SecurityStandardSupported": "True"
+            "SecurityStandardSupported": "True",
         },
         "SSMExecution": {
-            "workflow_data": {
-                "impact": "nondestructive",
-                "approvalrequired": "false"
-            }
-        }
+            "workflow_data": {"impact": "nondestructive", "approvalrequired": "false"}
+        },
     }
 
     expected_result = {
-        'executionid': '43374019-a309-4627-b8a2-c641e0140262',
-        'logdata': [],
-        'message': 'AutoScaling.1 remediation was successfully invoked via AWS Systems Manager in account 111111111111: 43374019-a309-4627-b8a2-c641e0140262',
-        'remediation_status': '',
-        'status': 'QUEUED'
+        "executionid": "43374019-a309-4627-b8a2-c641e0140262",
+        "logdata": [],
+        "message": "AutoScaling.1 remediation was successfully invoked via AWS Systems Manager in account 111111111111: 43374019-a309-4627-b8a2-c641e0140262",
+        "remediation_status": "",
+        "status": "QUEUED",
     }
 
-    account = '111111111111'
-    step_input['AutomationDocument']['AccountId'] = account
-    iam_c = boto3.client('iam')
+    account = "111111111111"
+    step_input["AutomationDocument"]["AccountId"] = account
+    iam_c = boto3.client("iam")
     iamc_stub = Stubber(iam_c)
-    iamc_stub.add_client_error(
-        'get_role',
-        'NoSuchEntity'
-    )
+    iamc_stub.add_client_error("get_role", "NoSuchEntity")
     iamc_stub.activate()
 
-    ssm_c = boto3.client('ssm')
+    ssm_c = boto3.client("ssm")
     ssmc_stub = Stubber(ssm_c)
     ssmc_stub.add_response(
-        'start_automation_execution',
+        "start_automation_execution",
+        {"AutomationExecutionId": "43374019-a309-4627-b8a2-c641e0140262"},
         {
-            'AutomationExecutionId': '43374019-a309-4627-b8a2-c641e0140262'
+            "DocumentName": "SHARR-AFSBP_1.0.0_AutoScaling.1",
+            "Parameters": {"Finding": [ANY], "AutomationAssumeRole": [ANY]},
         },
-        {
-            'DocumentName': 'SHARR-AFSBP_1.0.0_AutoScaling.1',
-            'Parameters': {
-                "Finding": [
-                    ANY
-                ],
-                "AutomationAssumeRole": [
-                    ANY
-                ]
-            }
-        })
+    )
 
     ssmc_stub.activate()
-    mocker.patch('exec_ssm_doc._get_ssm_client', return_value=ssm_c)
-    mocker.patch('exec_ssm_doc._get_iam_client', return_value=iam_c)
-    mocker.patch('sechub_findings.SHARRNotification.notify')
+    mocker.patch("exec_ssm_doc._get_ssm_client", return_value=ssm_c)
+    mocker.patch("exec_ssm_doc._get_iam_client", return_value=iam_c)
+    mocker.patch("sechub_findings.SHARRNotification.notify")
 
     response = lambda_handler(step_input, {})
-    assert response['executionid'] == expected_result['executionid']
-    assert response['remediation_status'] == expected_result['remediation_status']
-    assert response['status'] == expected_result['status']
+    assert response["executionid"] == expected_result["executionid"]
+    assert response["remediation_status"] == expected_result["remediation_status"]
+    assert response["status"] == expected_result["status"]
     ssmc_stub.deactivate()
     iamc_stub.deactivate()

--- a/source/remediation_runbooks/scripts/test/test_createcloudtrailmultiregiontrail.py
+++ b/source/remediation_runbooks/scripts/test/test_createcloudtrailmultiregiontrail.py
@@ -14,145 +14,130 @@ import CreateCloudTrailMultiRegionTrail_createloggingbucket as createloggingbuck
 import CreateCloudTrailMultiRegionTrail_enablecloudtrail as enablecloudtrail
 import CreateCloudTrailMultiRegionTrail_process_results as process_results
 
-my_session = boto3.session.Session()
-my_region = my_session.region_name
 
-#=====================================================================================
+def get_region() -> str:
+    my_session = boto3.session.Session()
+    return my_session.region_name
+
+
+# =====================================================================================
 # CreateCloudTrailMultiRegionTrail_createcloudtrailbucket
-#=====================================================================================
+# =====================================================================================
 def test_create_encrypted_bucket(mocker):
     event = {
-        'SolutionId': 'SO0000',
-        'SolutionVersion': '1.2.3',
-        'region': my_region,
-        'kms_key_arn': 'arn:aws:kms:us-east-1:111111111111:key/1234abcd-12ab-34cd-56ef-1234567890ab',
-        'account': '111111111111',
-        'logging_bucket': 'mah-loggin-bukkit'
+        "SolutionId": "SO0000",
+        "SolutionVersion": "1.2.3",
+        "region": get_region(),
+        "kms_key_arn": "arn:aws:kms:us-east-1:111111111111:key/1234abcd-12ab-34cd-56ef-1234567890ab",
+        "account": "111111111111",
+        "logging_bucket": "mah-loggin-bukkit",
     }
-    BOTO_CONFIG = Config(
-        retries ={
-          'mode': 'standard'
-        },
-        region_name=my_region
-    )
-    s3 = botocore.session.get_session().create_client('s3', config=BOTO_CONFIG)
+    BOTO_CONFIG = Config(retries={"mode": "standard"}, region_name=get_region())
+    s3 = botocore.session.get_session().create_client("s3", config=BOTO_CONFIG)
 
     s3_stubber = Stubber(s3)
-    kwargs = {
-        'Bucket': 'so0111-aws-cloudtrail-111111111111',
-        'ACL': 'private'
-    }
-    if my_region != 'us-east-1':
-        kwargs['CreateBucketConfiguration'] = {
-            'LocationConstraint': my_region
-        }
+    kwargs = {"Bucket": "so0111-aws-cloudtrail-111111111111", "ACL": "private"}
+    if get_region() != "us-east-1":
+        kwargs["CreateBucketConfiguration"] = {"LocationConstraint": get_region()}
+
+    s3_stubber.add_response("create_bucket", {}, kwargs)
 
     s3_stubber.add_response(
-        'create_bucket',
-        {},
-        kwargs
-    )
-
-    s3_stubber.add_response(
-        'put_bucket_encryption',
+        "put_bucket_encryption",
         {},
         {
-            'Bucket': 'so0111-aws-cloudtrail-111111111111',
-            'ServerSideEncryptionConfiguration': {
-                'Rules': [
+            "Bucket": "so0111-aws-cloudtrail-111111111111",
+            "ServerSideEncryptionConfiguration": {
+                "Rules": [
                     {
-                        'ApplyServerSideEncryptionByDefault': {
-                            'SSEAlgorithm': 'aws:kms',
-                            'KMSMasterKeyID': '1234abcd-12ab-34cd-56ef-1234567890ab'
-
+                        "ApplyServerSideEncryptionByDefault": {
+                            "SSEAlgorithm": "aws:kms",
+                            "KMSMasterKeyID": "1234abcd-12ab-34cd-56ef-1234567890ab",
                         }
                     }
                 ]
-            }
-        }
+            },
+        },
     )
 
     s3_stubber.add_response(
-        'put_public_access_block',
+        "put_public_access_block",
         {},
         {
-            'Bucket': 'so0111-aws-cloudtrail-111111111111',
-            'PublicAccessBlockConfiguration': {
-                'BlockPublicAcls': True,
-                'IgnorePublicAcls': True,
-                'BlockPublicPolicy': True,
-                'RestrictPublicBuckets': True
-            }
-        }
+            "Bucket": "so0111-aws-cloudtrail-111111111111",
+            "PublicAccessBlockConfiguration": {
+                "BlockPublicAcls": True,
+                "IgnorePublicAcls": True,
+                "BlockPublicPolicy": True,
+                "RestrictPublicBuckets": True,
+            },
+        },
     )
 
     s3_stubber.add_response(
-        'put_bucket_logging',
+        "put_bucket_logging",
         {},
         {
-            'Bucket': 'so0111-aws-cloudtrail-111111111111',
-            'BucketLoggingStatus': {
-                'LoggingEnabled': {
-                    'TargetBucket': event['logging_bucket'],
-                    'TargetPrefix': 'cloudtrail-access-logs'
+            "Bucket": "so0111-aws-cloudtrail-111111111111",
+            "BucketLoggingStatus": {
+                "LoggingEnabled": {
+                    "TargetBucket": event["logging_bucket"],
+                    "TargetPrefix": "cloudtrail-access-logs",
                 }
-            }
-        }
+            },
+        },
     )
     s3_stubber.activate()
-    mocker.patch('CreateCloudTrailMultiRegionTrail_createcloudtrailbucket.connect_to_s3', return_value=s3)
+    mocker.patch(
+        "CreateCloudTrailMultiRegionTrail_createcloudtrailbucket.connect_to_s3",
+        return_value=s3,
+    )
     createcloudtrailbucket.create_encrypted_bucket(event, {})
     s3_stubber.assert_no_pending_responses()
     s3_stubber.deactivate()
 
+
 def test_bucket_already_exists(mocker):
     event = {
-        'SolutionId': 'SO0000',
-        'SolutionVersion': '1.2.3',
-        'region': my_region,
-        'kms_key_arn': 'arn:aws:kms:us-east-1:111111111111:key/1234abcd-12ab-34cd-56ef-1234567890ab',
-        'account': '111111111111',
-        'logging_bucket': 'mah-loggin-bukkit'
+        "SolutionId": "SO0000",
+        "SolutionVersion": "1.2.3",
+        "region": get_region(),
+        "kms_key_arn": "arn:aws:kms:us-east-1:111111111111:key/1234abcd-12ab-34cd-56ef-1234567890ab",
+        "account": "111111111111",
+        "logging_bucket": "mah-loggin-bukkit",
     }
-    BOTO_CONFIG = Config(
-        retries ={
-          'mode': 'standard'
-        },
-        region_name=my_region
-    )
-    s3 = botocore.session.get_session().create_client('s3', config=BOTO_CONFIG)
+    BOTO_CONFIG = Config(retries={"mode": "standard"}, region_name=get_region())
+    s3 = botocore.session.get_session().create_client("s3", config=BOTO_CONFIG)
 
     s3_stubber = Stubber(s3)
-    kwargs = {
-        'Bucket': 'so0111-aws-cloudtrail-111111111111',
-        'ACL': 'private'
-    }
-    if my_region != 'us-east-1':
-        kwargs['CreateBucketConfiguration'] = {
-            'LocationConstraint': my_region
-        }
+    kwargs = {"Bucket": "so0111-aws-cloudtrail-111111111111", "ACL": "private"}
+    if get_region() != "us-east-1":
+        kwargs["CreateBucketConfiguration"] = {"LocationConstraint": get_region()}
 
-    s3_stubber.add_client_error(
-        'create_bucket',
-        'BucketAlreadyExists'
-    )
+    s3_stubber.add_client_error("create_bucket", "BucketAlreadyExists")
 
     s3_stubber.activate()
-    mocker.patch('CreateCloudTrailMultiRegionTrail_createcloudtrailbucket.connect_to_s3', return_value=s3)
-    assert createcloudtrailbucket.create_encrypted_bucket(event, {}) == { 'cloudtrail_bucket': 'so0111-aws-cloudtrail-111111111111' }
+    mocker.patch(
+        "CreateCloudTrailMultiRegionTrail_createcloudtrailbucket.connect_to_s3",
+        return_value=s3,
+    )
+    assert createcloudtrailbucket.create_encrypted_bucket(event, {}) == {
+        "cloudtrail_bucket": "so0111-aws-cloudtrail-111111111111"
+    }
     s3_stubber.deactivate()
 
-#=====================================================================================
+
+# =====================================================================================
 # CreateCloudTrailMultiRegionTrail_createcloudtrailbucketpolicy
-#=====================================================================================
+# =====================================================================================
 def test_create_bucket_policy(mocker):
     event = {
-        'SolutionId': 'SO0000',
-        'SolutionVersion': '1.2.3',
-        'region': my_region,
-        'partition': 'aws',
-        'account': '111111111111',
-        'cloudtrail_bucket': 'mahbukkit'
+        "SolutionId": "SO0000",
+        "SolutionVersion": "1.2.3",
+        "region": get_region(),
+        "partition": "aws",
+        "account": "111111111111",
+        "cloudtrail_bucket": "mahbukkit",
     }
     bucket_policy = {
         "Version": "2012-10-17",
@@ -160,317 +145,273 @@ def test_create_bucket_policy(mocker):
             {
                 "Sid": "AWSCloudTrailAclCheck20150319",
                 "Effect": "Allow",
-                "Principal": {
-                    "Service": [
-                        "cloudtrail.amazonaws.com"
-                    ]
-                },
+                "Principal": {"Service": ["cloudtrail.amazonaws.com"]},
                 "Action": "s3:GetBucketAcl",
-                "Resource": "arn:aws:s3:::mahbukkit"
+                "Resource": "arn:aws:s3:::mahbukkit",
             },
             {
                 "Sid": "AWSCloudTrailWrite20150319",
                 "Effect": "Allow",
-                "Principal": {
-                    "Service": [
-                        "cloudtrail.amazonaws.com"
-                    ]
-                },
+                "Principal": {"Service": ["cloudtrail.amazonaws.com"]},
                 "Action": "s3:PutObject",
                 "Resource": "arn:aws:s3:::mahbukkit/AWSLogs/111111111111/*",
                 "Condition": {
-                    "StringEquals": {
-                        "s3:x-amz-acl": "bucket-owner-full-control"
-                    }
-                }
+                    "StringEquals": {"s3:x-amz-acl": "bucket-owner-full-control"}
+                },
             },
             {
                 "Sid": "AllowSSLRequestsOnly",
                 "Effect": "Deny",
                 "Principal": "*",
                 "Action": "s3:*",
-                "Resource": [
-                    "arn:aws:s3:::mahbukkit",
-                    "arn:aws:s3:::mahbukkit/*"
-                ],
-                "Condition": {
-                    "Bool":
-                        {
-                            "aws:SecureTransport": "false"
-                        }
-                }
-            }
-        ]
+                "Resource": ["arn:aws:s3:::mahbukkit", "arn:aws:s3:::mahbukkit/*"],
+                "Condition": {"Bool": {"aws:SecureTransport": "false"}},
+            },
+        ],
     }
-    BOTO_CONFIG = Config(
-        retries ={
-          'mode': 'standard'
-        },
-        region_name=my_region
-    )
-    s3 = botocore.session.get_session().create_client('s3', config=BOTO_CONFIG)
+    BOTO_CONFIG = Config(retries={"mode": "standard"}, region_name=get_region())
+    s3 = botocore.session.get_session().create_client("s3", config=BOTO_CONFIG)
 
     s3_stubber = Stubber(s3)
-    kwargs = {
-        'Bucket': 'so0111-aws-cloudtrail-111111111111',
-        'ACL': 'private'
-    }
-    if my_region != 'us-east-1':
-        kwargs['CreateBucketConfiguration'] = {
-            'LocationConstraint': my_region
-        }
+    kwargs = {"Bucket": "so0111-aws-cloudtrail-111111111111", "ACL": "private"}
+    if get_region() != "us-east-1":
+        kwargs["CreateBucketConfiguration"] = {"LocationConstraint": get_region()}
 
     s3_stubber.add_response(
-        'put_bucket_policy',
+        "put_bucket_policy",
         {},
-        {
-            'Bucket': 'mahbukkit',
-            'Policy': json.dumps(bucket_policy)
-        }
+        {"Bucket": "mahbukkit", "Policy": json.dumps(bucket_policy)},
     )
 
     s3_stubber.activate()
-    mocker.patch('CreateCloudTrailMultiRegionTrail_createcloudtrailbucketpolicy.connect_to_s3', return_value=s3)
+    mocker.patch(
+        "CreateCloudTrailMultiRegionTrail_createcloudtrailbucketpolicy.connect_to_s3",
+        return_value=s3,
+    )
     createcloudtrailbucketpolicy.create_bucket_policy(event, {})
     s3_stubber.assert_no_pending_responses()
     s3_stubber.deactivate()
 
-#=====================================================================================
+
+# =====================================================================================
 # CreateCloudTrailMultiRegionTrail_createloggingbucket
-#=====================================================================================
+# =====================================================================================
 def test_create_logging_bucket(mocker):
     event = {
-        'SolutionId': 'SO0000',
-        'SolutionVersion': '1.2.3',
-        'region': my_region,
-        'kms_key_arn': 'arn:aws:kms:us-east-1:111111111111:key/1234abcd-12ab-34cd-56ef-1234567890ab',
-        'account': '111111111111'
+        "SolutionId": "SO0000",
+        "SolutionVersion": "1.2.3",
+        "region": get_region(),
+        "kms_key_arn": "arn:aws:kms:us-east-1:111111111111:key/1234abcd-12ab-34cd-56ef-1234567890ab",
+        "account": "111111111111",
     }
     bucket_policy = {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "AWSCloudTrailAclCheck20150319",
-            "Effect": "Allow",
-            "Principal": {
-                "Service": [
-                    "cloudtrail.amazonaws.com"
-                ]
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "AWSCloudTrailAclCheck20150319",
+                "Effect": "Allow",
+                "Principal": {"Service": ["cloudtrail.amazonaws.com"]},
+                "Action": "s3:GetBucketAcl",
+                "Resource": "arn:aws:s3:::mahbukkit",
             },
-            "Action": "s3:GetBucketAcl",
-            "Resource": "arn:aws:s3:::mahbukkit"
-        },
-        {
-            "Sid": "AWSCloudTrailWrite20150319",
-            "Effect": "Allow",
-            "Principal": {
-                "Service": [
-                    "cloudtrail.amazonaws.com"
-                ]
+            {
+                "Sid": "AWSCloudTrailWrite20150319",
+                "Effect": "Allow",
+                "Principal": {"Service": ["cloudtrail.amazonaws.com"]},
+                "Action": "s3:PutObject",
+                "Resource": "arn:aws:s3:::mahbukkit/AWSLogs/111111111111/*",
+                "Condition": {
+                    "StringEquals": {"s3:x-amz-acl": "bucket-owner-full-control"}
+                },
             },
-            "Action": "s3:PutObject",
-            "Resource": "arn:aws:s3:::mahbukkit/AWSLogs/111111111111/*",
-            "Condition": {
-                "StringEquals": {
-                    "s3:x-amz-acl": "bucket-owner-full-control"
-                }
-            }
-        }
-    ]}
-    BOTO_CONFIG = Config(
-        retries ={
-          'mode': 'standard'
-        },
-        region_name=my_region
-    )
-    s3 = botocore.session.get_session().create_client('s3', config=BOTO_CONFIG)
+        ],
+    }
+    BOTO_CONFIG = Config(retries={"mode": "standard"}, region_name=get_region())
+    s3 = botocore.session.get_session().create_client("s3", config=BOTO_CONFIG)
 
     kwargs = {
-        'Bucket': 'so0111-access-logs-' + my_region + '-111111111111',
-        'ACL': 'private'
+        "Bucket": "so0111-access-logs-" + get_region() + "-111111111111",
+        "ACL": "private",
     }
-    if my_region != 'us-east-1':
-        kwargs['CreateBucketConfiguration'] = {
-            'LocationConstraint': my_region
-        }
+    if get_region() != "us-east-1":
+        kwargs["CreateBucketConfiguration"] = {"LocationConstraint": get_region()}
     s3_stubber = Stubber(s3)
 
-    s3_stubber.add_response(
-        'create_bucket',
-        {},
-        kwargs
-    )
+    s3_stubber.add_response("create_bucket", {}, kwargs)
 
     s3_stubber.add_response(
-        'put_bucket_encryption',
+        "put_bucket_encryption",
         {},
         {
-            'Bucket': 'so0111-access-logs-' + my_region + '-111111111111',
-            'ServerSideEncryptionConfiguration': {
-                'Rules': [
+            "Bucket": "so0111-access-logs-" + get_region() + "-111111111111",
+            "ServerSideEncryptionConfiguration": {
+                "Rules": [
                     {
-                        'ApplyServerSideEncryptionByDefault': {
-                            'SSEAlgorithm': 'aws:kms',
-                            'KMSMasterKeyID': '1234abcd-12ab-34cd-56ef-1234567890ab'
-
+                        "ApplyServerSideEncryptionByDefault": {
+                            "SSEAlgorithm": "aws:kms",
+                            "KMSMasterKeyID": "1234abcd-12ab-34cd-56ef-1234567890ab",
                         }
                     }
                 ]
-            }
-        }
+            },
+        },
     )
 
     s3_stubber.add_response(
-        'put_public_access_block',
+        "put_public_access_block",
         {},
         {
-            'Bucket': 'so0111-access-logs-' + my_region + '-111111111111',
-            'PublicAccessBlockConfiguration': {
-                'BlockPublicAcls': True,
-                'IgnorePublicAcls': True,
-                'BlockPublicPolicy': True,
-                'RestrictPublicBuckets': True
-            }
-        }
+            "Bucket": "so0111-access-logs-" + get_region() + "-111111111111",
+            "PublicAccessBlockConfiguration": {
+                "BlockPublicAcls": True,
+                "IgnorePublicAcls": True,
+                "BlockPublicPolicy": True,
+                "RestrictPublicBuckets": True,
+            },
+        },
     )
 
     s3_stubber.add_response(
-        'put_bucket_acl',
+        "put_bucket_acl",
         {},
         {
-            'Bucket': 'so0111-access-logs-' + my_region + '-111111111111',
-            'GrantReadACP': 'uri=http://acs.amazonaws.com/groups/s3/LogDelivery',
-            'GrantWrite': 'uri=http://acs.amazonaws.com/groups/s3/LogDelivery'
-        }
+            "Bucket": "so0111-access-logs-" + get_region() + "-111111111111",
+            "GrantReadACP": "uri=http://acs.amazonaws.com/groups/s3/LogDelivery",
+            "GrantWrite": "uri=http://acs.amazonaws.com/groups/s3/LogDelivery",
+        },
     )
 
     s3_stubber.activate()
-    mocker.patch('CreateCloudTrailMultiRegionTrail_createloggingbucket.connect_to_s3', return_value=s3)
+    mocker.patch(
+        "CreateCloudTrailMultiRegionTrail_createloggingbucket.connect_to_s3",
+        return_value=s3,
+    )
     createloggingbucket.create_logging_bucket(event, {})
     s3_stubber.assert_no_pending_responses()
     s3_stubber.deactivate()
 
-#=====================================================================================
+
+# =====================================================================================
 # CreateCloudTrailMultiRegionTrail_enablecloudtrail
-#=====================================================================================
+# =====================================================================================
 def test_enable_cloudtrail(mocker):
     event = {
-        'SolutionId': 'SO0000',
-        'SolutionVersion': '1.2.3',
-        'region': my_region,
-        'kms_key_arn': 'arn:aws:kms:us-east-1:111111111111:key/1234abcd-12ab-34cd-56ef-1234567890ab',
-        'cloudtrail_bucket': 'mahbukkit'
+        "SolutionId": "SO0000",
+        "SolutionVersion": "1.2.3",
+        "region": get_region(),
+        "kms_key_arn": "arn:aws:kms:us-east-1:111111111111:key/1234abcd-12ab-34cd-56ef-1234567890ab",
+        "cloudtrail_bucket": "mahbukkit",
     }
-    BOTO_CONFIG = Config(
-        retries ={
-          'mode': 'standard'
-        },
-        region_name=my_region
+    BOTO_CONFIG = Config(retries={"mode": "standard"}, region_name=get_region())
+    ct_client = botocore.session.get_session().create_client(
+        "cloudtrail", config=BOTO_CONFIG
     )
-    ct_client = botocore.session.get_session().create_client('cloudtrail', config=BOTO_CONFIG)
     ct_stubber = Stubber(ct_client)
 
     ct_stubber.add_response(
-        'create_trail',
+        "create_trail",
         {},
         {
-            'Name': 'multi-region-cloud-trail',
-            'S3BucketName': 'mahbukkit',
-            'IncludeGlobalServiceEvents': True,
-            'EnableLogFileValidation': True,
-            'IsMultiRegionTrail': True,
-            'KmsKeyId': 'arn:aws:kms:us-east-1:111111111111:key/1234abcd-12ab-34cd-56ef-1234567890ab'
-        }
+            "Name": "multi-region-cloud-trail",
+            "S3BucketName": "mahbukkit",
+            "IncludeGlobalServiceEvents": True,
+            "EnableLogFileValidation": True,
+            "IsMultiRegionTrail": True,
+            "KmsKeyId": "arn:aws:kms:us-east-1:111111111111:key/1234abcd-12ab-34cd-56ef-1234567890ab",
+        },
     )
 
-    ct_stubber.add_response(
-        'start_logging',
-        {},
-        {
-            'Name': 'multi-region-cloud-trail'
-        }
-    )
+    ct_stubber.add_response("start_logging", {}, {"Name": "multi-region-cloud-trail"})
 
     ct_stubber.activate()
-    mocker.patch('CreateCloudTrailMultiRegionTrail_enablecloudtrail.connect_to_cloudtrail', return_value=ct_client)
+    mocker.patch(
+        "CreateCloudTrailMultiRegionTrail_enablecloudtrail.connect_to_cloudtrail",
+        return_value=ct_client,
+    )
     enablecloudtrail.enable_cloudtrail(event, {})
     ct_stubber.assert_no_pending_responses()
     ct_stubber.deactivate()
 
-#=====================================================================================
+
+# =====================================================================================
 # CreateCloudTrailMultiRegionTrail_process_results
-#=====================================================================================
+# =====================================================================================
 def test_process_results():
     event = {
-        'cloudtrail_bucket': 'cloudtrail_logs_bucket',
-        'logging_bucket': 'access_logs_bucket'
+        "cloudtrail_bucket": "cloudtrail_logs_bucket",
+        "logging_bucket": "access_logs_bucket",
     }
     assert process_results.process_results(event, {}) == {
         "response": {
             "message": "AWS CloudTrail successfully enabled",
-            "status": "Success"
+            "status": "Success",
         }
     }
 
-#=====================================================================================
+
+# =====================================================================================
 # Test inputs
-#=====================================================================================
+# =====================================================================================
 def test_put_bucket_acl_fails():
     """
     Verify proper exit when put_bucket_acl fails
     """
 
-    s3 = botocore.session.get_session().create_client('s3')
+    s3 = botocore.session.get_session().create_client("s3")
     s3_stubber = Stubber(s3)
-    s3_stubber.add_client_error(
-        'put_bucket_acl',
-        'ADoorIsAjar'
-    )
+    s3_stubber.add_client_error("put_bucket_acl", "ADoorIsAjar")
     s3_stubber.activate()
 
     with pytest.raises(SystemExit) as pytest_wrapped_e:
-        parsed_event = createloggingbucket.put_bucket_acl(s3, 'mahbukkit')
+        parsed_event = createloggingbucket.put_bucket_acl(s3, "mahbukkit")
     assert pytest_wrapped_e.type == SystemExit
-    assert pytest_wrapped_e.value.code == 'Error setting ACL for bucket mahbukkit: An error occurred (ADoorIsAjar) when calling the PutBucketAcl operation: '
+    assert (
+        pytest_wrapped_e.value.code
+        == "Error setting ACL for bucket mahbukkit: An error occurred (ADoorIsAjar) when calling the PutBucketAcl operation: "
+    )
 
     s3_stubber.deactivate()
+
 
 def test_put_access_blocks_fails():
     """
     Verify proper exit when put_public_access_blocks fails
     """
 
-    s3 = botocore.session.get_session().create_client('s3')
+    s3 = botocore.session.get_session().create_client("s3")
     s3_stubber = Stubber(s3)
-    s3_stubber.add_client_error(
-        'put_public_access_block',
-        'ADoorIsAjar'
-    )
+    s3_stubber.add_client_error("put_public_access_block", "ADoorIsAjar")
     s3_stubber.activate()
 
     with pytest.raises(SystemExit) as pytest_wrapped_e:
-        parsed_event = createloggingbucket.put_access_block(s3, 'mahbukkit')
+        parsed_event = createloggingbucket.put_access_block(s3, "mahbukkit")
     assert pytest_wrapped_e.type == SystemExit
-    assert pytest_wrapped_e.value.code == 'Error setting public access block for bucket mahbukkit: An error occurred (ADoorIsAjar) when calling the PutPublicAccessBlock operation: '
+    assert (
+        pytest_wrapped_e.value.code
+        == "Error setting public access block for bucket mahbukkit: An error occurred (ADoorIsAjar) when calling the PutPublicAccessBlock operation: "
+    )
 
     s3_stubber.deactivate()
+
 
 def test_encrypt_bucket_fails():
     """
     Verify proper exit when put_bucket_encryption fails
     """
 
-    s3 = botocore.session.get_session().create_client('s3')
+    s3 = botocore.session.get_session().create_client("s3")
     s3_stubber = Stubber(s3)
-    s3_stubber.add_client_error(
-        'put_bucket_encryption',
-        'ADoorIsAjar'
-    )
+    s3_stubber.add_client_error("put_bucket_encryption", "ADoorIsAjar")
     s3_stubber.activate()
 
     with pytest.raises(SystemExit) as pytest_wrapped_e:
-        parsed_event = createloggingbucket.encrypt_bucket(s3, 'mahbukkit', 'arn:aws:kms:us-east-1:111111111111:key/mahcryptionkey')
+        parsed_event = createloggingbucket.encrypt_bucket(
+            s3, "mahbukkit", "arn:aws:kms:us-east-1:111111111111:key/mahcryptionkey"
+        )
     assert pytest_wrapped_e.type == SystemExit
-    assert pytest_wrapped_e.value.code == 'Error encrypting bucket mahbukkit: An error occurred (ADoorIsAjar) when calling the PutBucketEncryption operation: '
+    assert (
+        pytest_wrapped_e.value.code
+        == "Error encrypting bucket mahbukkit: An error occurred (ADoorIsAjar) when calling the PutBucketEncryption operation: "
+    )
 
     s3_stubber.deactivate()

--- a/source/remediation_runbooks/scripts/test/test_replacecodebuildcleartextcredentials.py
+++ b/source/remediation_runbooks/scripts/test/test_replacecodebuildcleartextcredentials.py
@@ -9,22 +9,24 @@ import pytest
 
 import ReplaceCodeBuildClearTextCredentials as remediation
 
-my_session = boto3.session.Session()
-my_region = my_session.region_name
+def get_region() -> str:
+    my_session = boto3.session.Session()
+    return my_session.region_name
 
-BOTO_CONFIG = Config(
-    retries = {
-        'mode': 'standard'
-    },
-    region_name = my_region
-)
+def get_config() -> Config:
+    return Config(
+        retries = {
+            'mode': 'standard'
+        },
+        region_name = get_region()
+    )
 
 class Case:
     def __init__(self, env_vars):
         self._env_vars = env_vars
         self._project_name = 'invoke-codebuild-2'
         self._service_role = f'codebuild-{ self._project_name }-service-role'
-        self._policy_name = f'CodeBuildSSMParameterPolicy-{ self._project_name }-{ my_region }'
+        self._policy_name = f'CodeBuildSSMParameterPolicy-{ self._project_name }-{ get_region() }'
         self._policy_arn = f'arn:aws:iam::111111111111:policy/{ self._policy_name }'
         self._policy_modtime = datetime.now()
 
@@ -32,7 +34,7 @@ class Case:
         return {
             'ProjectInfo': {
                 'name': self._project_name,
-                'arn': f'arn:aws:codebuild:{my_region}:111111111111:project/{ self._project_name }',
+                'arn': f'arn:aws:codebuild:{get_region()}:111111111111:project/{ self._project_name }',
                 'source': {
                     'type': 'NO_SOURCE',
                     'gitCloneDepth': 1,
@@ -59,7 +61,7 @@ class Case:
                 'serviceRole': f'arn:aws:iam::111111111111:role/service-role/{ self._service_role }',
                 'timeoutInMinutes': 60,
                 'queuedTimeoutInMinutes': 480,
-                'encryptionKey': f'arn:aws:kms:{my_region}:111111111111:alias/aws/s3',
+                'encryptionKey': f'arn:aws:kms:{get_region()}:111111111111:alias/aws/s3',
                 'tags': [],
                 'created': '2022-01-28T21:59:12.932000+00:00',
                 'lastModified': '2022-02-02T19:16:05.722000+00:00',
@@ -138,7 +140,7 @@ def test_success(mocker):
         }
     ]
 
-    ssm_client = botocore.session.get_session().create_client('ssm', config = BOTO_CONFIG)
+    ssm_client = botocore.session.get_session().create_client('ssm', config = get_config())
     ssm_stubber = Stubber(ssm_client)
 
     ssm_stubber.add_response(
@@ -156,7 +158,7 @@ def test_success(mocker):
 
     ssm_stubber.activate()
 
-    iam_client = botocore.session.get_session().create_client('iam', config=BOTO_CONFIG)
+    iam_client = botocore.session.get_session().create_client('iam', config=get_config())
     iam_stubber = Stubber(iam_client)
 
     iam_stubber.add_response(
@@ -228,7 +230,7 @@ def test_multiple_params(mocker):
         }
     ]
 
-    ssm_client = botocore.session.get_session().create_client('ssm', config = BOTO_CONFIG)
+    ssm_client = botocore.session.get_session().create_client('ssm', config = get_config())
     ssm_stubber = Stubber(ssm_client)
 
     for env_var in env_vars[0:2]:
@@ -247,7 +249,7 @@ def test_multiple_params(mocker):
 
     ssm_stubber.activate()
 
-    iam_client = botocore.session.get_session().create_client('iam', config=BOTO_CONFIG)
+    iam_client = botocore.session.get_session().create_client('iam', config=get_config())
     iam_stubber = Stubber(iam_client)
 
     iam_stubber.add_response(
@@ -299,7 +301,7 @@ def test_param_exists(mocker):
         }
     ]
 
-    ssm_client = botocore.session.get_session().create_client('ssm', config = BOTO_CONFIG)
+    ssm_client = botocore.session.get_session().create_client('ssm', config = get_config())
     ssm_stubber = Stubber(ssm_client)
 
     ssm_stubber.add_client_error(
@@ -317,7 +319,7 @@ def test_param_exists(mocker):
 
     ssm_stubber.activate()
 
-    iam_client = botocore.session.get_session().create_client('iam', config=BOTO_CONFIG)
+    iam_client = botocore.session.get_session().create_client('iam', config=get_config())
     iam_stubber = Stubber(iam_client)
 
     iam_stubber.add_response(
@@ -369,7 +371,7 @@ def test_policy_exists(mocker):
         }
     ]
 
-    ssm_client = botocore.session.get_session().create_client('ssm', config = BOTO_CONFIG)
+    ssm_client = botocore.session.get_session().create_client('ssm', config = get_config())
     ssm_stubber = Stubber(ssm_client)
 
     ssm_stubber.add_response(
@@ -387,7 +389,7 @@ def test_policy_exists(mocker):
 
     ssm_stubber.activate()
 
-    iam_client = botocore.session.get_session().create_client('iam', config=BOTO_CONFIG)
+    iam_client = botocore.session.get_session().create_client('iam', config=get_config())
     iam_stubber = Stubber(iam_client)
 
     iam_stubber.add_client_error(
@@ -453,7 +455,7 @@ def test_new_param(mocker):
         }
     ]
 
-    ssm_client = botocore.session.get_session().create_client('ssm', config = BOTO_CONFIG)
+    ssm_client = botocore.session.get_session().create_client('ssm', config = get_config())
     ssm_stubber = Stubber(ssm_client)
 
     ssm_stubber.add_response(
@@ -471,7 +473,7 @@ def test_new_param(mocker):
 
     ssm_stubber.activate()
 
-    iam_client = botocore.session.get_session().create_client('iam', config=BOTO_CONFIG)
+    iam_client = botocore.session.get_session().create_client('iam', config=get_config())
     iam_stubber = Stubber(iam_client)
 
     iam_stubber.add_response(
@@ -515,7 +517,7 @@ def test_put_parameter_fails(mocker):
 
     test_case = Case(env_vars)
 
-    ssm_client = botocore.session.get_session().create_client('ssm', config = BOTO_CONFIG)
+    ssm_client = botocore.session.get_session().create_client('ssm', config = get_config())
     ssm_stubber = Stubber(ssm_client)
 
     ssm_stubber.add_client_error(
@@ -562,7 +564,7 @@ def test_create_policy_fails(mocker):
         }
     ]
 
-    ssm_client = botocore.session.get_session().create_client('ssm', config = BOTO_CONFIG)
+    ssm_client = botocore.session.get_session().create_client('ssm', config = get_config())
     ssm_stubber = Stubber(ssm_client)
 
     ssm_stubber.add_response(
@@ -580,7 +582,7 @@ def test_create_policy_fails(mocker):
 
     ssm_stubber.activate()
 
-    iam_client = botocore.session.get_session().create_client('iam', config=BOTO_CONFIG)
+    iam_client = botocore.session.get_session().create_client('iam', config=get_config())
     iam_stubber = Stubber(iam_client)
 
     iam_stubber.add_client_error(
@@ -620,7 +622,7 @@ def test_attach_policy_fails(mocker):
         }
     ]
 
-    ssm_client = botocore.session.get_session().create_client('ssm', config = BOTO_CONFIG)
+    ssm_client = botocore.session.get_session().create_client('ssm', config = get_config())
     ssm_stubber = Stubber(ssm_client)
 
     ssm_stubber.add_response(
@@ -638,7 +640,7 @@ def test_attach_policy_fails(mocker):
 
     ssm_stubber.activate()
 
-    iam_client = botocore.session.get_session().create_client('iam', config=BOTO_CONFIG)
+    iam_client = botocore.session.get_session().create_client('iam', config=get_config())
     iam_stubber = Stubber(iam_client)
 
     iam_stubber.add_response(

--- a/source/solution_deploy/source/test/test_action_target_provider.py
+++ b/source/solution_deploy/source/test/test_action_target_provider.py
@@ -21,7 +21,6 @@ from botocore.config import Config
 
 os.environ["AWS_REGION"] = "us-east-1"
 os.environ["AWS_PARTITION"] = "aws"
-sechub = boto3.client("securityhub")
 
 
 @pytest.fixture(autouse=True)
@@ -85,6 +84,7 @@ def test_create(mocker):
     """
     Test that the correct API call is executed
     """
+    sechub = boto3.client("securityhub")
     sechub_stub = Stubber(sechub)
     # Note: boto mock appears to be broken for the Sec Hub API
     # It only works if the response containts "ActionTargetArn"
@@ -108,6 +108,7 @@ def test_create_already_exists(mocker):
     """
     Test that there is no error when it already exists
     """
+    sechub = boto3.client("securityhub")
     sechub_stub = Stubber(sechub)
     # Note: boto mock appears to be broken for the Sec Hub API
     # It only works if the response containts "ActionTargetArn"
@@ -129,6 +130,7 @@ def test_create_already_exists(mocker):
 
 
 def test_create_no_sechub(mocker):
+    sechub = boto3.client("securityhub")
     sechub_stub = Stubber(sechub)
     # Note: boto mock appears to be broken for the Sec Hub API
     # It only works if the response containts "ActionTargetArn"
@@ -150,6 +152,7 @@ def test_create_no_sechub(mocker):
 
 
 def test_create_other_client_error(mocker):
+    sechub = boto3.client("securityhub")
     sechub_stub = Stubber(sechub)
     # Note: boto mock appears to be broken for the Sec Hub API
     # It only works if the response containts "ActionTargetArn"
@@ -171,6 +174,7 @@ def test_create_other_client_error(mocker):
 
 
 def test_delete(mocker):
+    sechub = boto3.client("securityhub")
     sechub_stub = Stubber(sechub)
     # Note: boto mock appears to be broken for the Sec Hub API
     # It only works if the response containts "ActionTargetArn"
@@ -196,6 +200,7 @@ def test_delete(mocker):
 
 
 def test_delete_already_exists(mocker):
+    sechub = boto3.client("securityhub")
     sechub_stub = Stubber(sechub)
     # Note: boto mock appears to be broken for the Sec Hub API
     # It only works if the response containts "ActionTargetArn"
@@ -216,6 +221,7 @@ def test_delete_already_exists(mocker):
 
 
 def test_delete_no_sechub(mocker):
+    sechub = boto3.client("securityhub")
     sechub_stub = Stubber(sechub)
     # Note: boto mock appears to be broken for the Sec Hub API
     # It only works if the response containts "ActionTargetArn"
@@ -236,6 +242,7 @@ def test_delete_no_sechub(mocker):
 
 
 def test_delete_other_client_error(mocker):
+    sechub = boto3.client("securityhub")
     sechub_stub = Stubber(sechub)
     # Note: boto mock appears to be broken for the Sec Hub API
     # It only works if the response containts "ActionTargetArn"


### PR DESCRIPTION
- relocate boto calls from module scope to functions so they do not break before stubbed env vars are injected

This should fix the unit test workflow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.