### PR TITLE
Migrate deprecated @aws-cdk/assert to aws-cdk-lib/assertions

### DIFF
--- a/source/jest.config.js
+++ b/source/jest.config.js
@@ -2,12 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 module.exports = {
   roots: [
-  '<rootDir>/test',
-  '<rootDir>/playbooks/CIS120/test',
-  '<rootDir>/playbooks/AFSBP/test',
-  '<rootDir>/playbooks/PCI321/test',
-  '<rootDir>/remediation_runbooks'
-],
+    '<rootDir>/test',
+    '<rootDir>/playbooks/AFSBP/test',
+    '<rootDir>/playbooks/CIS120/test',
+    '<rootDir>/playbooks/CIS140/test',
+    '<rootDir>/playbooks/NEWPLAYBOOK/test',
+    '<rootDir>/playbooks/PCI321/test',
+    '<rootDir>/playbooks/SC/test',
+    '<rootDir>/remediation_runbooks'
+  ],
   testMatch: ['**/*.test.ts'],
   transform: {
     '^.+\\.tsx?$': 'ts-jest'

--- a/source/package-lock.json
+++ b/source/package-lock.json
@@ -12,7 +12,6 @@
                 "solution_deploy": "bin/solution_deploy.js"
             },
             "devDependencies": {
-                "@aws-cdk/assert": "^2.61.1",
                 "@aws-cdk/aws-servicecatalogappregistry-alpha": "^2.61.1-alpha.0",
                 "@cdklabs/cdk-ssm-documents": "^0.0.32",
                 "@types/jest": "^29.4.0",
@@ -50,27 +49,10 @@
                 "node": ">=6.0.0"
             }
         },
-        "node_modules/@aws-cdk/assert": {
-            "version": "2.61.1",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/assert/-/assert-2.61.1.tgz",
-            "integrity": "sha512-6lfRXAUarvy2hywcYb5cgR+ycjhaXSeSJJgTkPAVFgwassQtsPGh0ItFX6T1tuLeUY+yJyi1ema6B4vB5ZQo2g==",
-            "dev": true,
-            "dependencies": {
-                "@aws-cdk/cloudformation-diff": "2.61.1"
-            },
-            "engines": {
-                "node": ">= 14.15.0"
-            },
-            "peerDependencies": {
-                "aws-cdk-lib": "^2.61.1",
-                "constructs": "^10.0.0",
-                "jest": ">=26.6.3"
-            }
-        },
         "node_modules/@aws-cdk/asset-awscli-v1": {
-            "version": "2.2.51",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.51.tgz",
-            "integrity": "sha512-WcFw8LKQt6anPLgcj+NK2UhMdfIk+aLk2LQBNAPYyrynwfSQZjU3auuqsJGZuIwtSZ3Qs885L0GsDK2hunEFtQ==",
+            "version": "2.2.52",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.52.tgz",
+            "integrity": "sha512-9dBPrvByWrUOcs5Rjwv08FWSummo1Uk/EgE3dCFDqvIqlSTudEmu6TGU3zrs00rfcAjqDv6gBuSttzG5f9tfdQ==",
             "dev": true
         },
         "node_modules/@aws-cdk/asset-kubectl-v20": {
@@ -80,9 +62,9 @@
             "dev": true
         },
         "node_modules/@aws-cdk/asset-node-proxy-agent-v5": {
-            "version": "2.0.41",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.41.tgz",
-            "integrity": "sha512-POfpCysF+of+KhMdxNykYkXAKS81gdXXPqukA+j/IubLaCFqIctQLafgAZ5P5ec4c6pHwFjWGl1I6fJOpPSd7g==",
+            "version": "2.0.42",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.42.tgz",
+            "integrity": "sha512-PxvP1UU2xa4k3Ea78DxAYY8ADvwWZ/nPu+xsjQLsT+MP+aB3RZ3pGc/fNlH7Rg56Zyb/j3GSdihAy4Oi5xa+TQ==",
             "dev": true
         },
         "node_modules/@aws-cdk/aws-servicecatalogappregistry-alpha": {
@@ -97,40 +79,6 @@
                 "aws-cdk-lib": "^2.61.1",
                 "constructs": "^10.0.0"
             }
-        },
-        "node_modules/@aws-cdk/cfnspec": {
-            "version": "2.61.1",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/cfnspec/-/cfnspec-2.61.1.tgz",
-            "integrity": "sha512-JGFxJgMcJRSr5zqPlVemZ9T08Q3oq0izdVzU+kDeL2okLXHveNM79+OSPsPg3RVtL49lbR5vvpofk4GDDKvfcg==",
-            "dev": true,
-            "dependencies": {
-                "fs-extra": "^9.1.0",
-                "md5": "^2.3.0"
-            }
-        },
-        "node_modules/@aws-cdk/cloudformation-diff": {
-            "version": "2.61.1",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/cloudformation-diff/-/cloudformation-diff-2.61.1.tgz",
-            "integrity": "sha512-50fdsjMtIpjhrmo0M2J10FIYgnc65hRkHFUdiAH9oC+1iXspFo0RynRI8DJPt//OH7d7w7Mb4nIrEx65PAxb4A==",
-            "dev": true,
-            "dependencies": {
-                "@aws-cdk/cfnspec": "2.61.1",
-                "@types/node": "^14.18.36",
-                "chalk": "^4",
-                "diff": "^5.1.0",
-                "fast-deep-equal": "^3.1.3",
-                "string-width": "^4.2.3",
-                "table": "^6.8.1"
-            },
-            "engines": {
-                "node": ">= 14.15.0"
-            }
-        },
-        "node_modules/@aws-cdk/cloudformation-diff/node_modules/@types/node": {
-            "version": "14.18.36",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.36.tgz",
-            "integrity": "sha512-FXKWbsJ6a1hIrRxv+FoukuHnGTgEzKYGi7kilfMae96AL9UNkPFNWJEEYWzdRI9ooIkbr4AKldyuSTLql06vLQ==",
-            "dev": true
         },
         "node_modules/@babel/code-frame": {
             "version": "7.18.6",
@@ -1335,16 +1283,16 @@
             }
         },
         "node_modules/@jest/console": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.4.0.tgz",
-            "integrity": "sha512-xpXud7e/8zo4syxQlAMDz+EQiFsf8/zXDPslBYm+UaSJ5uGTKQHhbSHfECp7Fw1trQtopjYumeved0n3waijhQ==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.4.1.tgz",
+            "integrity": "sha512-m+XpwKSi3PPM9znm5NGS8bBReeAJJpSkL1OuFCqaMaJL2YX9YXLkkI+MBchMPwu+ZuM2rynL51sgfkQteQ1CKQ==",
             "dev": true,
             "dependencies": {
-                "@jest/types": "^29.4.0",
+                "@jest/types": "^29.4.1",
                 "@types/node": "*",
                 "chalk": "^4.0.0",
-                "jest-message-util": "^29.4.0",
-                "jest-util": "^29.4.0",
+                "jest-message-util": "^29.4.1",
+                "jest-util": "^29.4.1",
                 "slash": "^3.0.0"
             },
             "engines": {
@@ -1352,16 +1300,16 @@
             }
         },
         "node_modules/@jest/core": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.4.0.tgz",
-            "integrity": "sha512-E7oCMcENobBFwQXYjnN2IsuUSpRo5jSv7VYk6O9GyQ5kVAfVSS8819I4W5iCCYvqD6+1TzyzLpeEdZEik81kNw==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.4.1.tgz",
+            "integrity": "sha512-RXFTohpBqpaTebNdg5l3I5yadnKo9zLBajMT0I38D0tDhreVBYv3fA8kywthI00sWxPztWLD3yjiUkewwu/wKA==",
             "dev": true,
             "dependencies": {
-                "@jest/console": "^29.4.0",
-                "@jest/reporters": "^29.4.0",
-                "@jest/test-result": "^29.4.0",
-                "@jest/transform": "^29.4.0",
-                "@jest/types": "^29.4.0",
+                "@jest/console": "^29.4.1",
+                "@jest/reporters": "^29.4.1",
+                "@jest/test-result": "^29.4.1",
+                "@jest/transform": "^29.4.1",
+                "@jest/types": "^29.4.1",
                 "@types/node": "*",
                 "ansi-escapes": "^4.2.1",
                 "chalk": "^4.0.0",
@@ -1369,20 +1317,20 @@
                 "exit": "^0.1.2",
                 "graceful-fs": "^4.2.9",
                 "jest-changed-files": "^29.4.0",
-                "jest-config": "^29.4.0",
-                "jest-haste-map": "^29.4.0",
-                "jest-message-util": "^29.4.0",
+                "jest-config": "^29.4.1",
+                "jest-haste-map": "^29.4.1",
+                "jest-message-util": "^29.4.1",
                 "jest-regex-util": "^29.2.0",
-                "jest-resolve": "^29.4.0",
-                "jest-resolve-dependencies": "^29.4.0",
-                "jest-runner": "^29.4.0",
-                "jest-runtime": "^29.4.0",
-                "jest-snapshot": "^29.4.0",
-                "jest-util": "^29.4.0",
-                "jest-validate": "^29.4.0",
-                "jest-watcher": "^29.4.0",
+                "jest-resolve": "^29.4.1",
+                "jest-resolve-dependencies": "^29.4.1",
+                "jest-runner": "^29.4.1",
+                "jest-runtime": "^29.4.1",
+                "jest-snapshot": "^29.4.1",
+                "jest-util": "^29.4.1",
+                "jest-validate": "^29.4.1",
+                "jest-watcher": "^29.4.1",
                 "micromatch": "^4.0.4",
-                "pretty-format": "^29.4.0",
+                "pretty-format": "^29.4.1",
                 "slash": "^3.0.0",
                 "strip-ansi": "^6.0.0"
             },
@@ -1399,37 +1347,37 @@
             }
         },
         "node_modules/@jest/environment": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.4.0.tgz",
-            "integrity": "sha512-ocl1VGDcZHfHnYLTqkBY7yXme1bF4x0BevJ9wb6y0sLOSyBCpp8L5fEASChB+wU53WMrIK6kBfGt+ZYoM2kcdw==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.4.1.tgz",
+            "integrity": "sha512-pJ14dHGSQke7Q3mkL/UZR9ZtTOxqskZaC91NzamEH4dlKRt42W+maRBXiw/LWkdJe+P0f/zDR37+SPMplMRlPg==",
             "dev": true,
             "dependencies": {
-                "@jest/fake-timers": "^29.4.0",
-                "@jest/types": "^29.4.0",
+                "@jest/fake-timers": "^29.4.1",
+                "@jest/types": "^29.4.1",
                 "@types/node": "*",
-                "jest-mock": "^29.4.0"
+                "jest-mock": "^29.4.1"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/@jest/expect": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.4.0.tgz",
-            "integrity": "sha512-IiDZYQ/Oi94aBT0nKKKRvNsB5JTyHoGb+G3SiGoDxz90JfL7SLx/z5IjB0fzBRzy7aLFQOCbVJlaC2fIgU6Y9Q==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.4.1.tgz",
+            "integrity": "sha512-ZxKJP5DTUNF2XkpJeZIzvnzF1KkfrhEF6Rz0HGG69fHl6Bgx5/GoU3XyaeFYEjuuKSOOsbqD/k72wFvFxc3iTw==",
             "dev": true,
             "dependencies": {
-                "expect": "^29.4.0",
-                "jest-snapshot": "^29.4.0"
+                "expect": "^29.4.1",
+                "jest-snapshot": "^29.4.1"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/@jest/expect-utils": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.4.0.tgz",
-            "integrity": "sha512-w/JzTYIqjmPFIM5OOQHF9CawFx2daw1256Nzj4ZqWX96qRKbCq9WYRVqdySBKHHzuvsXLyTDIF6y61FUyrhmwg==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.4.1.tgz",
+            "integrity": "sha512-w6YJMn5DlzmxjO00i9wu2YSozUYRBhIoJ6nQwpMYcBMtiqMGJm1QBzOf6DDgRao8dbtpDoaqLg6iiQTvv0UHhQ==",
             "dev": true,
             "dependencies": {
                 "jest-get-type": "^29.2.0"
@@ -1439,48 +1387,48 @@
             }
         },
         "node_modules/@jest/fake-timers": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.4.0.tgz",
-            "integrity": "sha512-8sitzN2QrhDwEwH3kKcMMgrv/UIkmm9AUgHixmn4L++GQ0CqVTIztm3YmaIQooLmW3O4GhizNTTCyq3iLbWcMw==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.4.1.tgz",
+            "integrity": "sha512-/1joI6rfHFmmm39JxNfmNAO3Nwm6Y0VoL5fJDy7H1AtWrD1CgRtqJbN9Ld6rhAkGO76qqp4cwhhxJ9o9kYjQMw==",
             "dev": true,
             "dependencies": {
-                "@jest/types": "^29.4.0",
+                "@jest/types": "^29.4.1",
                 "@sinonjs/fake-timers": "^10.0.2",
                 "@types/node": "*",
-                "jest-message-util": "^29.4.0",
-                "jest-mock": "^29.4.0",
-                "jest-util": "^29.4.0"
+                "jest-message-util": "^29.4.1",
+                "jest-mock": "^29.4.1",
+                "jest-util": "^29.4.1"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/@jest/globals": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.4.0.tgz",
-            "integrity": "sha512-Q64ZRgGMVL40RcYTfD2GvyjK7vJLPSIvi8Yp3usGPNPQ3SCW+UCY9KEH6+sVtBo8LzhcjtCXuZEd7avnj/T0mQ==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.4.1.tgz",
+            "integrity": "sha512-znoK2EuFytbHH0ZSf2mQK2K1xtIgmaw4Da21R2C/NE/+NnItm5mPEFQmn8gmF3f0rfOlmZ3Y3bIf7bFj7DHxAA==",
             "dev": true,
             "dependencies": {
-                "@jest/environment": "^29.4.0",
-                "@jest/expect": "^29.4.0",
-                "@jest/types": "^29.4.0",
-                "jest-mock": "^29.4.0"
+                "@jest/environment": "^29.4.1",
+                "@jest/expect": "^29.4.1",
+                "@jest/types": "^29.4.1",
+                "jest-mock": "^29.4.1"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/@jest/reporters": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.4.0.tgz",
-            "integrity": "sha512-FjJwrD1XOQq/AXKrvnOSf0RgAs6ziUuGKx8+/R53Jscc629JIhg7/m241gf1shUm/fKKxoHd7aCexcg7kxvkWQ==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.4.1.tgz",
+            "integrity": "sha512-AISY5xpt2Xpxj9R6y0RF1+O6GRy9JsGa8+vK23Lmzdy1AYcpQn5ItX79wJSsTmfzPKSAcsY1LNt/8Y5Xe5LOSg==",
             "dev": true,
             "dependencies": {
                 "@bcoe/v8-coverage": "^0.2.3",
-                "@jest/console": "^29.4.0",
-                "@jest/test-result": "^29.4.0",
-                "@jest/transform": "^29.4.0",
-                "@jest/types": "^29.4.0",
+                "@jest/console": "^29.4.1",
+                "@jest/test-result": "^29.4.1",
+                "@jest/transform": "^29.4.1",
+                "@jest/types": "^29.4.1",
                 "@jridgewell/trace-mapping": "^0.3.15",
                 "@types/node": "*",
                 "chalk": "^4.0.0",
@@ -1493,9 +1441,9 @@
                 "istanbul-lib-report": "^3.0.0",
                 "istanbul-lib-source-maps": "^4.0.0",
                 "istanbul-reports": "^3.1.3",
-                "jest-message-util": "^29.4.0",
-                "jest-util": "^29.4.0",
-                "jest-worker": "^29.4.0",
+                "jest-message-util": "^29.4.1",
+                "jest-util": "^29.4.1",
+                "jest-worker": "^29.4.1",
                 "slash": "^3.0.0",
                 "string-length": "^4.0.1",
                 "strip-ansi": "^6.0.0",
@@ -1540,13 +1488,13 @@
             }
         },
         "node_modules/@jest/test-result": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.4.0.tgz",
-            "integrity": "sha512-EtRklzjpddZU/aBVxJqqejfzfOcnehmjNXufs6u6qwd05kkhXpAPhZdt8bLlQd7cA2nD+JqZQ5Dx9NX5Jh6mjA==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.4.1.tgz",
+            "integrity": "sha512-WRt29Lwt+hEgfN8QDrXqXGgCTidq1rLyFqmZ4lmJOpVArC8daXrZWkWjiaijQvgd3aOUj2fM8INclKHsQW9YyQ==",
             "dev": true,
             "dependencies": {
-                "@jest/console": "^29.4.0",
-                "@jest/types": "^29.4.0",
+                "@jest/console": "^29.4.1",
+                "@jest/types": "^29.4.1",
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "collect-v8-coverage": "^1.0.0"
             },
@@ -1555,14 +1503,14 @@
             }
         },
         "node_modules/@jest/test-sequencer": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.4.0.tgz",
-            "integrity": "sha512-pEwIgdfvEgF2lBOYX3DVn3SrvsAZ9FXCHw7+C6Qz87HnoDGQwbAselhWLhpgbxDjs6RC9QUJpFnrLmM5uwZV+g==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.4.1.tgz",
+            "integrity": "sha512-v5qLBNSsM0eHzWLXsQ5fiB65xi49A3ILPSFQKPXzGL4Vyux0DPZAIN7NAFJa9b4BiTDP9MBF/Zqc/QA1vuiJ0w==",
             "dev": true,
             "dependencies": {
-                "@jest/test-result": "^29.4.0",
+                "@jest/test-result": "^29.4.1",
                 "graceful-fs": "^4.2.9",
-                "jest-haste-map": "^29.4.0",
+                "jest-haste-map": "^29.4.1",
                 "slash": "^3.0.0"
             },
             "engines": {
@@ -1570,22 +1518,22 @@
             }
         },
         "node_modules/@jest/transform": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.4.0.tgz",
-            "integrity": "sha512-hDjw3jz4GnvbyLMgcFpC9/34QcUhVIzJkBqz7o+3AhgfhGRzGuQppuLf5r/q7lDAAyJ6jzL+SFG7JGsScHOcLQ==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.4.1.tgz",
+            "integrity": "sha512-5w6YJrVAtiAgr0phzKjYd83UPbCXsBRTeYI4BXokv9Er9CcrH9hfXL/crCvP2d2nGOcovPUnlYiLPFLZrkG5Hg==",
             "dev": true,
             "dependencies": {
                 "@babel/core": "^7.11.6",
-                "@jest/types": "^29.4.0",
+                "@jest/types": "^29.4.1",
                 "@jridgewell/trace-mapping": "^0.3.15",
                 "babel-plugin-istanbul": "^6.1.1",
                 "chalk": "^4.0.0",
                 "convert-source-map": "^2.0.0",
                 "fast-json-stable-stringify": "^2.1.0",
                 "graceful-fs": "^4.2.9",
-                "jest-haste-map": "^29.4.0",
+                "jest-haste-map": "^29.4.1",
                 "jest-regex-util": "^29.2.0",
-                "jest-util": "^29.4.0",
+                "jest-util": "^29.4.1",
                 "micromatch": "^4.0.4",
                 "pirates": "^4.0.4",
                 "slash": "^3.0.0",
@@ -1596,9 +1544,9 @@
             }
         },
         "node_modules/@jest/types": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.0.tgz",
-            "integrity": "sha512-1S2Dt5uQp7R0bGY/L2BpuwCSji7v12kY3o8zqwlkbYBmOY956SKk+zOWqmfhHSINegiAVqOXydAYuWpzX6TYsQ==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.1.tgz",
+            "integrity": "sha512-zbrAXDUOnpJ+FMST2rV7QZOgec8rskg2zv8g2ajeqitp4tvZiyqTCYXANrKsM+ryj5o+LI+ZN2EgU9drrkiwSA==",
             "dev": true,
             "dependencies": {
                 "@jest/schemas": "^29.4.0",
@@ -2257,24 +2205,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/astral-regex": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-            "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/at-least-node": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 4.0.0"
-            }
-        },
         "node_modules/available-typed-arrays": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -2288,9 +2218,9 @@
             }
         },
         "node_modules/aws-cdk": {
-            "version": "2.61.1",
-            "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.61.1.tgz",
-            "integrity": "sha512-bufvOB+I2T6YjVjT6D0j6xbi6CnX62j7TfHL905WLd5UQhPecwlL8wLe2whUOKqZj2wmGjaP7jAjIE1FFfh98w==",
+            "version": "2.62.1",
+            "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.62.1.tgz",
+            "integrity": "sha512-r1EnkR8nKfNIlW7BC46b+w7EEb9+Jy/Mgf0s62vdbj1BSNgl1ZdfW2mOe1Ra2FjDC5jhFUX8t+t5+E6eA8vdZA==",
             "dev": true,
             "bin": {
                 "cdk": "bin/cdk"
@@ -2303,9 +2233,9 @@
             }
         },
         "node_modules/aws-cdk-lib": {
-            "version": "2.61.1",
-            "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.61.1.tgz",
-            "integrity": "sha512-+n6rXkIbGtu151XGN54c9+vObUqTKI50skPsZsPo6S0eKgj4ZsYVfS/W6lM4pgv839BwN66hyYAzOvreXAbKeA==",
+            "version": "2.62.1",
+            "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.62.1.tgz",
+            "integrity": "sha512-1ZxdLm3ALIiEAM2DLP6W4DRZV1Ed8HI4lLxkNWmsuTVgbYsj663eawoyOM7/k8QWxBlxwU2T8pl0RtgOzc1Zbg==",
             "bundleDependencies": [
                 "@balena/dockerignore",
                 "case",
@@ -2509,12 +2439,12 @@
             }
         },
         "node_modules/babel-jest": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.4.0.tgz",
-            "integrity": "sha512-M61cGPg4JBashDvIzKoIV/y95mSF6x3ome7CMEaszUTHD4uo6dtC6Nln+fvRTspYNtwy8lDHl5lmoTBSNY/a+g==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.4.1.tgz",
+            "integrity": "sha512-xBZa/pLSsF/1sNpkgsiT3CmY7zV1kAsZ9OxxtrFqYucnOuRftXAfcJqcDVyOPeN4lttWTwhLdu0T9f8uvoPEUg==",
             "dev": true,
             "dependencies": {
-                "@jest/transform": "^29.4.0",
+                "@jest/transform": "^29.4.1",
                 "@types/babel__core": "^7.1.14",
                 "babel-plugin-istanbul": "^6.1.1",
                 "babel-preset-jest": "^29.4.0",
@@ -2730,9 +2660,9 @@
             ]
         },
         "node_modules/cdk-nag": {
-            "version": "2.21.73",
-            "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.21.73.tgz",
-            "integrity": "sha512-LEyVScTHTIQfdMMX9JdLkXmpujgaK29tEpZVmkYmKXv6fiW0hx70t9p4RQ95X8RNXVz2+CLX2H/i9mRnRQNVTg==",
+            "version": "2.21.74",
+            "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.21.74.tgz",
+            "integrity": "sha512-r47FLJqEt5PMoKOifFkw99kL97kpRZnMdVRF/Jt96nE78e7a1DsCSmRbyMFPLA0KE0bEEltTgB//z8npewe6og==",
             "dev": true,
             "peerDependencies": {
                 "aws-cdk-lib": "^2.45.0",
@@ -2762,15 +2692,6 @@
             "dev": true,
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/charenc": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-            "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-            "dev": true,
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/ci-info": {
@@ -2849,9 +2770,9 @@
             "dev": true
         },
         "node_modules/constructs": {
-            "version": "10.1.230",
-            "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.230.tgz",
-            "integrity": "sha512-IthwvFD4pa8CtvNSx4mnfKi0kHEnQJ6tBebo+L6rTSx071H3XpMzV1WZS5PLh5B6czkfzaERV54ZzNKC8jUJxw==",
+            "version": "10.1.231",
+            "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.231.tgz",
+            "integrity": "sha512-y4R6kU5wZCGKmXXxCw8kuq1O9oO98FvhvNiIXXX/xaGdZlrq1+pvLRX5dcSL47PPmzO7rcKNF8a/esEdjRyomA==",
             "dev": true,
             "engines": {
                 "node": ">= 14.17.0"
@@ -2881,15 +2802,6 @@
             },
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/crypt": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-            "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-            "dev": true,
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/debug": {
@@ -2956,9 +2868,9 @@
             }
         },
         "node_modules/diff": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-            "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
             "dev": true,
             "engines": {
                 "node": ">=0.3.1"
@@ -3535,16 +3447,16 @@
             }
         },
         "node_modules/expect": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/expect/-/expect-29.4.0.tgz",
-            "integrity": "sha512-pzaAwjBgLEVxBh6ZHiqb9Wv3JYuv6m8ntgtY7a48nS+2KbX0EJkPS3FQlKiTZNcqzqJHNyQsfjqN60w1hPUBfQ==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/expect/-/expect-29.4.1.tgz",
+            "integrity": "sha512-OKrGESHOaMxK3b6zxIq9SOW8kEXztKff/Dvg88j4xIJxur1hspEbedVkR3GpHe5LO+WB2Qw7OWN0RMTdp6as5A==",
             "dev": true,
             "dependencies": {
-                "@jest/expect-utils": "^29.4.0",
+                "@jest/expect-utils": "^29.4.1",
                 "jest-get-type": "^29.2.0",
-                "jest-matcher-utils": "^29.4.0",
-                "jest-message-util": "^29.4.0",
-                "jest-util": "^29.4.0"
+                "jest-matcher-utils": "^29.4.1",
+                "jest-message-util": "^29.4.1",
+                "jest-util": "^29.4.1"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -3686,21 +3598,6 @@
             "dev": true,
             "dependencies": {
                 "is-callable": "^1.1.3"
-            }
-        },
-        "node_modules/fs-extra": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-            "dev": true,
-            "dependencies": {
-                "at-least-node": "^1.0.0",
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/fs.realpath": {
@@ -4158,12 +4055,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-buffer": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-            "dev": true
-        },
         "node_modules/is-callable": {
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -4470,15 +4361,15 @@
             }
         },
         "node_modules/jest": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest/-/jest-29.4.0.tgz",
-            "integrity": "sha512-Zfd4UzNxPkSoHRBkg225rBjQNa6pVqbh20MGniAzwaOzYLd+pQUcAwH+WPxSXxKFs+QWYfPYIq9hIVSmdVQmPA==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest/-/jest-29.4.1.tgz",
+            "integrity": "sha512-cknimw7gAXPDOmj0QqztlxVtBVCw2lYY9CeIE5N6kD+kET1H4H79HSNISJmijb1HF+qk+G+ploJgiDi5k/fRlg==",
             "dev": true,
             "dependencies": {
-                "@jest/core": "^29.4.0",
-                "@jest/types": "^29.4.0",
+                "@jest/core": "^29.4.1",
+                "@jest/types": "^29.4.1",
                 "import-local": "^3.0.2",
-                "jest-cli": "^29.4.0"
+                "jest-cli": "^29.4.1"
             },
             "bin": {
                 "jest": "bin/jest.js"
@@ -4509,28 +4400,28 @@
             }
         },
         "node_modules/jest-circus": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.4.0.tgz",
-            "integrity": "sha512-/pFBaCeLzCavRWyz14JwFgpZgPpEZdS6nPnREhczbHl2wy2UezvYcVp5akVFfUmBaA4ThAUp0I8cpgkbuNOm3g==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.4.1.tgz",
+            "integrity": "sha512-v02NuL5crMNY4CGPHBEflLzl4v91NFb85a+dH9a1pUNx6Xjggrd8l9pPy4LZ1VYNRXlb+f65+7O/MSIbLir6pA==",
             "dev": true,
             "dependencies": {
-                "@jest/environment": "^29.4.0",
-                "@jest/expect": "^29.4.0",
-                "@jest/test-result": "^29.4.0",
-                "@jest/types": "^29.4.0",
+                "@jest/environment": "^29.4.1",
+                "@jest/expect": "^29.4.1",
+                "@jest/test-result": "^29.4.1",
+                "@jest/types": "^29.4.1",
                 "@types/node": "*",
                 "chalk": "^4.0.0",
                 "co": "^4.6.0",
                 "dedent": "^0.7.0",
                 "is-generator-fn": "^2.0.0",
-                "jest-each": "^29.4.0",
-                "jest-matcher-utils": "^29.4.0",
-                "jest-message-util": "^29.4.0",
-                "jest-runtime": "^29.4.0",
-                "jest-snapshot": "^29.4.0",
-                "jest-util": "^29.4.0",
+                "jest-each": "^29.4.1",
+                "jest-matcher-utils": "^29.4.1",
+                "jest-message-util": "^29.4.1",
+                "jest-runtime": "^29.4.1",
+                "jest-snapshot": "^29.4.1",
+                "jest-util": "^29.4.1",
                 "p-limit": "^3.1.0",
-                "pretty-format": "^29.4.0",
+                "pretty-format": "^29.4.1",
                 "slash": "^3.0.0",
                 "stack-utils": "^2.0.3"
             },
@@ -4539,21 +4430,21 @@
             }
         },
         "node_modules/jest-cli": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.4.0.tgz",
-            "integrity": "sha512-YUkICcxjUd864VOzbfQEi2qd2hIIOd9bRF7LJUNyhWb3Khh3YKrbY0LWwoZZ4WkvukiNdvQu0Z4s6zLsY4hYfg==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.4.1.tgz",
+            "integrity": "sha512-jz7GDIhtxQ37M+9dlbv5K+/FVcIo1O/b1sX3cJgzlQUf/3VG25nvuWzlDC4F1FLLzUThJeWLu8I7JF9eWpuURQ==",
             "dev": true,
             "dependencies": {
-                "@jest/core": "^29.4.0",
-                "@jest/test-result": "^29.4.0",
-                "@jest/types": "^29.4.0",
+                "@jest/core": "^29.4.1",
+                "@jest/test-result": "^29.4.1",
+                "@jest/types": "^29.4.1",
                 "chalk": "^4.0.0",
                 "exit": "^0.1.2",
                 "graceful-fs": "^4.2.9",
                 "import-local": "^3.0.2",
-                "jest-config": "^29.4.0",
-                "jest-util": "^29.4.0",
-                "jest-validate": "^29.4.0",
+                "jest-config": "^29.4.1",
+                "jest-util": "^29.4.1",
+                "jest-validate": "^29.4.1",
                 "prompts": "^2.0.1",
                 "yargs": "^17.3.1"
             },
@@ -4573,31 +4464,31 @@
             }
         },
         "node_modules/jest-config": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.4.0.tgz",
-            "integrity": "sha512-jtgd72nN4Mob4Oego3N/pLRVfR2ui1hv+yO6xR/SUi5G7NtZ/grr95BJ1qRSDYZshuA0Jw57fnttZHZKb04+CA==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.4.1.tgz",
+            "integrity": "sha512-g7p3q4NuXiM4hrS4XFATTkd+2z0Ml2RhFmFPM8c3WyKwVDNszbl4E7cV7WIx1YZeqqCtqbtTtZhGZWJlJqngzg==",
             "dev": true,
             "dependencies": {
                 "@babel/core": "^7.11.6",
-                "@jest/test-sequencer": "^29.4.0",
-                "@jest/types": "^29.4.0",
-                "babel-jest": "^29.4.0",
+                "@jest/test-sequencer": "^29.4.1",
+                "@jest/types": "^29.4.1",
+                "babel-jest": "^29.4.1",
                 "chalk": "^4.0.0",
                 "ci-info": "^3.2.0",
                 "deepmerge": "^4.2.2",
                 "glob": "^7.1.3",
                 "graceful-fs": "^4.2.9",
-                "jest-circus": "^29.4.0",
-                "jest-environment-node": "^29.4.0",
+                "jest-circus": "^29.4.1",
+                "jest-environment-node": "^29.4.1",
                 "jest-get-type": "^29.2.0",
                 "jest-regex-util": "^29.2.0",
-                "jest-resolve": "^29.4.0",
-                "jest-runner": "^29.4.0",
-                "jest-util": "^29.4.0",
-                "jest-validate": "^29.4.0",
+                "jest-resolve": "^29.4.1",
+                "jest-runner": "^29.4.1",
+                "jest-util": "^29.4.1",
+                "jest-validate": "^29.4.1",
                 "micromatch": "^4.0.4",
                 "parse-json": "^5.2.0",
-                "pretty-format": "^29.4.0",
+                "pretty-format": "^29.4.1",
                 "slash": "^3.0.0",
                 "strip-json-comments": "^3.1.1"
             },
@@ -4618,15 +4509,15 @@
             }
         },
         "node_modules/jest-diff": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.4.0.tgz",
-            "integrity": "sha512-s8KNvFx8YgdQ4fn2YLDQ7N6kmVOP68dUDVJrCHNsTc3UM5jcmyyFeYKL8EPWBQbJ0o0VvDGbWp8oYQ1nsnqnWw==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.4.1.tgz",
+            "integrity": "sha512-uazdl2g331iY56CEyfbNA0Ut7Mn2ulAG5vUaEHXycf1L6IPyuImIxSz4F0VYBKi7LYIuxOwTZzK3wh5jHzASMw==",
             "dev": true,
             "dependencies": {
                 "chalk": "^4.0.0",
                 "diff-sequences": "^29.3.1",
                 "jest-get-type": "^29.2.0",
-                "pretty-format": "^29.4.0"
+                "pretty-format": "^29.4.1"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4645,33 +4536,33 @@
             }
         },
         "node_modules/jest-each": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.4.0.tgz",
-            "integrity": "sha512-LTOvB8JDVFjrwXItyQiyLuDYy5PMApGLLzbfIYR79QLpeohS0bcS6j2HjlWuRGSM8QQQyp+ico59Blv+Jx3fMw==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.4.1.tgz",
+            "integrity": "sha512-QlYFiX3llJMWUV0BtWht/esGEz9w+0i7BHwODKCze7YzZzizgExB9MOfiivF/vVT0GSQ8wXLhvHXh3x2fVD4QQ==",
             "dev": true,
             "dependencies": {
-                "@jest/types": "^29.4.0",
+                "@jest/types": "^29.4.1",
                 "chalk": "^4.0.0",
                 "jest-get-type": "^29.2.0",
-                "jest-util": "^29.4.0",
-                "pretty-format": "^29.4.0"
+                "jest-util": "^29.4.1",
+                "pretty-format": "^29.4.1"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/jest-environment-node": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.4.0.tgz",
-            "integrity": "sha512-WVveE3fYSH6FhDtZdvXhFKeLsDRItlQgnij+HQv6ZKxTdT1DB5O0sHXKCEC3K5mHraMs1Kzn4ch9jXC7H4L4wA==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.4.1.tgz",
+            "integrity": "sha512-x/H2kdVgxSkxWAIlIh9MfMuBa0hZySmfsC5lCsWmWr6tZySP44ediRKDUiNggX/eHLH7Cd5ZN10Rw+XF5tXsqg==",
             "dev": true,
             "dependencies": {
-                "@jest/environment": "^29.4.0",
-                "@jest/fake-timers": "^29.4.0",
-                "@jest/types": "^29.4.0",
+                "@jest/environment": "^29.4.1",
+                "@jest/fake-timers": "^29.4.1",
+                "@jest/types": "^29.4.1",
                 "@types/node": "*",
-                "jest-mock": "^29.4.0",
-                "jest-util": "^29.4.0"
+                "jest-mock": "^29.4.1",
+                "jest-util": "^29.4.1"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4687,20 +4578,20 @@
             }
         },
         "node_modules/jest-haste-map": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.4.0.tgz",
-            "integrity": "sha512-m/pIEfoK0HoJz4c9bkgS5F9CXN2AM22eaSmUcmqTpadRlNVBOJE2CwkgaUzbrNn5MuAqTV1IPVYwWwjHNnk8eA==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.4.1.tgz",
+            "integrity": "sha512-imTjcgfVVTvg02khXL11NNLTx9ZaofbAWhilrMg/G8dIkp+HYCswhxf0xxJwBkfhWb3e8dwbjuWburvxmcr58w==",
             "dev": true,
             "dependencies": {
-                "@jest/types": "^29.4.0",
+                "@jest/types": "^29.4.1",
                 "@types/graceful-fs": "^4.1.3",
                 "@types/node": "*",
                 "anymatch": "^3.0.3",
                 "fb-watchman": "^2.0.0",
                 "graceful-fs": "^4.2.9",
                 "jest-regex-util": "^29.2.0",
-                "jest-util": "^29.4.0",
-                "jest-worker": "^29.4.0",
+                "jest-util": "^29.4.1",
+                "jest-worker": "^29.4.1",
                 "micromatch": "^4.0.4",
                 "walker": "^1.0.8"
             },
@@ -4712,46 +4603,46 @@
             }
         },
         "node_modules/jest-leak-detector": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.4.0.tgz",
-            "integrity": "sha512-fEGHS6ijzgSv5exABkCecMHNmyHcV52+l39ZsxuwfxmQMp43KBWJn2/Fwg8/l4jTI9uOY9jv8z1dXGgL0PHFjA==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.4.1.tgz",
+            "integrity": "sha512-akpZv7TPyGMnH2RimOCgy+hPmWZf55EyFUvymQ4LMsQP8xSPlZumCPtXGoDhFNhUE2039RApZkTQDKU79p/FiQ==",
             "dev": true,
             "dependencies": {
                 "jest-get-type": "^29.2.0",
-                "pretty-format": "^29.4.0"
+                "pretty-format": "^29.4.1"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/jest-matcher-utils": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.4.0.tgz",
-            "integrity": "sha512-pU4OjBn96rDdRIaPUImbPiO2ETyRVzkA1EZVu9AxBDv/XPDJ7JWfkb6IiDT5jwgicaPHMrB/fhVa6qjG6potfA==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.4.1.tgz",
+            "integrity": "sha512-k5h0u8V4nAEy6lSACepxL/rw78FLDkBnXhZVgFneVpnJONhb2DhZj/Gv4eNe+1XqQ5IhgUcqj745UwH0HJmMnA==",
             "dev": true,
             "dependencies": {
                 "chalk": "^4.0.0",
-                "jest-diff": "^29.4.0",
+                "jest-diff": "^29.4.1",
                 "jest-get-type": "^29.2.0",
-                "pretty-format": "^29.4.0"
+                "pretty-format": "^29.4.1"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/jest-message-util": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.4.0.tgz",
-            "integrity": "sha512-0FvobqymmhE9pDEifvIcni9GeoKLol8eZspzH5u41g1wxYtLS60a9joT95dzzoCgrKRidNz64eaAXyzaULV8og==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.4.1.tgz",
+            "integrity": "sha512-H4/I0cXUaLeCw6FM+i4AwCnOwHRgitdaUFOdm49022YD5nfyr8C/DrbXOBEyJaj+w/y0gGJ57klssOaUiLLQGQ==",
             "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.12.13",
-                "@jest/types": "^29.4.0",
+                "@jest/types": "^29.4.1",
                 "@types/stack-utils": "^2.0.0",
                 "chalk": "^4.0.0",
                 "graceful-fs": "^4.2.9",
                 "micromatch": "^4.0.4",
-                "pretty-format": "^29.4.0",
+                "pretty-format": "^29.4.1",
                 "slash": "^3.0.0",
                 "stack-utils": "^2.0.3"
             },
@@ -4760,14 +4651,14 @@
             }
         },
         "node_modules/jest-mock": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.4.0.tgz",
-            "integrity": "sha512-+ShT5i+hcu/OFQRV0f/V/YtwpdFcHg64JZ9A8b40JueP+X9HNrZAYGdkupGIzsUK8AucecxCt4wKauMchxubLQ==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.4.1.tgz",
+            "integrity": "sha512-MwA4hQ7zBOcgVCVnsM8TzaFLVUD/pFWTfbkY953Y81L5ret3GFRZtmPmRFAjKQSdCKoJvvqOu6Bvfpqlwwb0dQ==",
             "dev": true,
             "dependencies": {
-                "@jest/types": "^29.4.0",
+                "@jest/types": "^29.4.1",
                 "@types/node": "*",
-                "jest-util": "^29.4.0"
+                "jest-util": "^29.4.1"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4800,17 +4691,17 @@
             }
         },
         "node_modules/jest-resolve": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.4.0.tgz",
-            "integrity": "sha512-g7k7l53T+uC9Dp1mbHyDNkcCt0PMku6Wcfpr1kcMLwOHmM3vucKjSM5+DSa1r4vlDZojh8XH039J3z4FKmtTSw==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.4.1.tgz",
+            "integrity": "sha512-j/ZFNV2lm9IJ2wmlq1uYK0Y/1PiyDq9g4HEGsNTNr3viRbJdV+8Lf1SXIiLZXFvyiisu0qUyIXGBnw+OKWkJwQ==",
             "dev": true,
             "dependencies": {
                 "chalk": "^4.0.0",
                 "graceful-fs": "^4.2.9",
-                "jest-haste-map": "^29.4.0",
+                "jest-haste-map": "^29.4.1",
                 "jest-pnp-resolver": "^1.2.2",
-                "jest-util": "^29.4.0",
-                "jest-validate": "^29.4.0",
+                "jest-util": "^29.4.1",
+                "jest-validate": "^29.4.1",
                 "resolve": "^1.20.0",
                 "resolve.exports": "^2.0.0",
                 "slash": "^3.0.0"
@@ -4820,43 +4711,43 @@
             }
         },
         "node_modules/jest-resolve-dependencies": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.4.0.tgz",
-            "integrity": "sha512-hxfC84trREyULSj1Cm+fMjnudrrI2dVQ04COjZRcjCZ97boJlPtfJ+qrl/pN7YXS2fnu3wTHEc3LO094pngL6A==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.4.1.tgz",
+            "integrity": "sha512-Y3QG3M1ncAMxfjbYgtqNXC5B595zmB6e//p/qpA/58JkQXu/IpLDoLeOa8YoYfsSglBKQQzNUqtfGJJT/qLmJg==",
             "dev": true,
             "dependencies": {
                 "jest-regex-util": "^29.2.0",
-                "jest-snapshot": "^29.4.0"
+                "jest-snapshot": "^29.4.1"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/jest-runner": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.4.0.tgz",
-            "integrity": "sha512-4zpcv0NOiJleqT0NAs8YcVbK8MhVRc58CBBn9b0Exc8VPU9GKI+DbzDUZqJYdkJhJSZFy2862l/F6hAqIow1hg==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.4.1.tgz",
+            "integrity": "sha512-8d6XXXi7GtHmsHrnaqBKWxjKb166Eyj/ksSaUYdcBK09VbjPwIgWov1VwSmtupCIz8q1Xv4Qkzt/BTo3ZqiCeg==",
             "dev": true,
             "dependencies": {
-                "@jest/console": "^29.4.0",
-                "@jest/environment": "^29.4.0",
-                "@jest/test-result": "^29.4.0",
-                "@jest/transform": "^29.4.0",
-                "@jest/types": "^29.4.0",
+                "@jest/console": "^29.4.1",
+                "@jest/environment": "^29.4.1",
+                "@jest/test-result": "^29.4.1",
+                "@jest/transform": "^29.4.1",
+                "@jest/types": "^29.4.1",
                 "@types/node": "*",
                 "chalk": "^4.0.0",
                 "emittery": "^0.13.1",
                 "graceful-fs": "^4.2.9",
                 "jest-docblock": "^29.2.0",
-                "jest-environment-node": "^29.4.0",
-                "jest-haste-map": "^29.4.0",
-                "jest-leak-detector": "^29.4.0",
-                "jest-message-util": "^29.4.0",
-                "jest-resolve": "^29.4.0",
-                "jest-runtime": "^29.4.0",
-                "jest-util": "^29.4.0",
-                "jest-watcher": "^29.4.0",
-                "jest-worker": "^29.4.0",
+                "jest-environment-node": "^29.4.1",
+                "jest-haste-map": "^29.4.1",
+                "jest-leak-detector": "^29.4.1",
+                "jest-message-util": "^29.4.1",
+                "jest-resolve": "^29.4.1",
+                "jest-runtime": "^29.4.1",
+                "jest-util": "^29.4.1",
+                "jest-watcher": "^29.4.1",
+                "jest-worker": "^29.4.1",
                 "p-limit": "^3.1.0",
                 "source-map-support": "0.5.13"
             },
@@ -4875,31 +4766,31 @@
             }
         },
         "node_modules/jest-runtime": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.4.0.tgz",
-            "integrity": "sha512-2zumwaGXsIuSF92Ui5Pn5hZV9r7AHMclfBLikrXSq87/lHea9anQ+mC+Cjz/DYTbf/JMjlK1sjZRh8K3yYNvWg==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.4.1.tgz",
+            "integrity": "sha512-UXTMU9uKu2GjYwTtoAw5rn4STxWw/nadOfW7v1sx6LaJYa3V/iymdCLQM6xy3+7C6mY8GfX22vKpgxY171UIoA==",
             "dev": true,
             "dependencies": {
-                "@jest/environment": "^29.4.0",
-                "@jest/fake-timers": "^29.4.0",
-                "@jest/globals": "^29.4.0",
+                "@jest/environment": "^29.4.1",
+                "@jest/fake-timers": "^29.4.1",
+                "@jest/globals": "^29.4.1",
                 "@jest/source-map": "^29.2.0",
-                "@jest/test-result": "^29.4.0",
-                "@jest/transform": "^29.4.0",
-                "@jest/types": "^29.4.0",
+                "@jest/test-result": "^29.4.1",
+                "@jest/transform": "^29.4.1",
+                "@jest/types": "^29.4.1",
                 "@types/node": "*",
                 "chalk": "^4.0.0",
                 "cjs-module-lexer": "^1.0.0",
                 "collect-v8-coverage": "^1.0.0",
                 "glob": "^7.1.3",
                 "graceful-fs": "^4.2.9",
-                "jest-haste-map": "^29.4.0",
-                "jest-message-util": "^29.4.0",
-                "jest-mock": "^29.4.0",
+                "jest-haste-map": "^29.4.1",
+                "jest-message-util": "^29.4.1",
+                "jest-mock": "^29.4.1",
                 "jest-regex-util": "^29.2.0",
-                "jest-resolve": "^29.4.0",
-                "jest-snapshot": "^29.4.0",
-                "jest-util": "^29.4.0",
+                "jest-resolve": "^29.4.1",
+                "jest-snapshot": "^29.4.1",
+                "jest-util": "^29.4.1",
                 "semver": "^7.3.5",
                 "slash": "^3.0.0",
                 "strip-bom": "^4.0.0"
@@ -4909,9 +4800,9 @@
             }
         },
         "node_modules/jest-snapshot": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.4.0.tgz",
-            "integrity": "sha512-UnK3MhdEWrQ2J6MnlKe51tvN5FjRUBQnO4m1LPlDx61or3w9+cP/U0x9eicutgunu/QzE4WC82jj6CiGIAFYzw==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.4.1.tgz",
+            "integrity": "sha512-l4iV8EjGgQWVz3ee/LR9sULDk2pCkqb71bjvlqn+qp90lFwpnulHj4ZBT8nm1hA1C5wowXLc7MGnw321u0tsYA==",
             "dev": true,
             "dependencies": {
                 "@babel/core": "^7.11.6",
@@ -4920,23 +4811,23 @@
                 "@babel/plugin-syntax-typescript": "^7.7.2",
                 "@babel/traverse": "^7.7.2",
                 "@babel/types": "^7.3.3",
-                "@jest/expect-utils": "^29.4.0",
-                "@jest/transform": "^29.4.0",
-                "@jest/types": "^29.4.0",
+                "@jest/expect-utils": "^29.4.1",
+                "@jest/transform": "^29.4.1",
+                "@jest/types": "^29.4.1",
                 "@types/babel__traverse": "^7.0.6",
                 "@types/prettier": "^2.1.5",
                 "babel-preset-current-node-syntax": "^1.0.0",
                 "chalk": "^4.0.0",
-                "expect": "^29.4.0",
+                "expect": "^29.4.1",
                 "graceful-fs": "^4.2.9",
-                "jest-diff": "^29.4.0",
+                "jest-diff": "^29.4.1",
                 "jest-get-type": "^29.2.0",
-                "jest-haste-map": "^29.4.0",
-                "jest-matcher-utils": "^29.4.0",
-                "jest-message-util": "^29.4.0",
-                "jest-util": "^29.4.0",
+                "jest-haste-map": "^29.4.1",
+                "jest-matcher-utils": "^29.4.1",
+                "jest-message-util": "^29.4.1",
+                "jest-util": "^29.4.1",
                 "natural-compare": "^1.4.0",
-                "pretty-format": "^29.4.0",
+                "pretty-format": "^29.4.1",
                 "semver": "^7.3.5"
             },
             "engines": {
@@ -4944,12 +4835,12 @@
             }
         },
         "node_modules/jest-util": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.4.0.tgz",
-            "integrity": "sha512-lCCwlze7UEV8TpR9ArS8w0cTbcMry5tlBkg7QSc5og5kNyV59dnY2aKHu5fY2k5aDJMQpCUGpvL2w6ZU44lveA==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.4.1.tgz",
+            "integrity": "sha512-bQy9FPGxVutgpN4VRc0hk6w7Hx/m6L53QxpDreTZgJd9gfx/AV2MjyPde9tGyZRINAUrSv57p2inGBu2dRLmkQ==",
             "dev": true,
             "dependencies": {
-                "@jest/types": "^29.4.0",
+                "@jest/types": "^29.4.1",
                 "@types/node": "*",
                 "chalk": "^4.0.0",
                 "ci-info": "^3.2.0",
@@ -4961,17 +4852,17 @@
             }
         },
         "node_modules/jest-validate": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.4.0.tgz",
-            "integrity": "sha512-EXS7u594nX3aAPBnARxBdJ1eZ1cByV6MWrK0Qpt9lt/BcY0p0yYGp/EGJ8GhdLDQh+RFf8qMt2wzbbVzpj5+Vg==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.4.1.tgz",
+            "integrity": "sha512-qNZXcZQdIQx4SfUB/atWnI4/I2HUvhz8ajOSYUu40CSmf9U5emil8EDHgE7M+3j9/pavtk3knlZBDsgFvv/SWw==",
             "dev": true,
             "dependencies": {
-                "@jest/types": "^29.4.0",
+                "@jest/types": "^29.4.1",
                 "camelcase": "^6.2.0",
                 "chalk": "^4.0.0",
                 "jest-get-type": "^29.2.0",
                 "leven": "^3.1.0",
-                "pretty-format": "^29.4.0"
+                "pretty-format": "^29.4.1"
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4990,18 +4881,18 @@
             }
         },
         "node_modules/jest-watcher": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.4.0.tgz",
-            "integrity": "sha512-PnnfLygNKelWOJwpAYlcsQjB+OxRRdckD0qiGmYng4Hkz1ZwK3jvCaJJYiywz2msQn4rBNLdriasJtv7YpWHpA==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.4.1.tgz",
+            "integrity": "sha512-vFOzflGFs27nU6h8dpnVRER3O2rFtL+VMEwnG0H3KLHcllLsU8y9DchSh0AL/Rg5nN1/wSiQ+P4ByMGpuybaVw==",
             "dev": true,
             "dependencies": {
-                "@jest/test-result": "^29.4.0",
-                "@jest/types": "^29.4.0",
+                "@jest/test-result": "^29.4.1",
+                "@jest/types": "^29.4.1",
                 "@types/node": "*",
                 "ansi-escapes": "^4.2.1",
                 "chalk": "^4.0.0",
                 "emittery": "^0.13.1",
-                "jest-util": "^29.4.0",
+                "jest-util": "^29.4.1",
                 "string-length": "^4.0.1"
             },
             "engines": {
@@ -5009,13 +4900,13 @@
             }
         },
         "node_modules/jest-worker": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.4.0.tgz",
-            "integrity": "sha512-dICMQ+Q4W0QVMsaQzWlA1FVQhKNz7QcDCOGtbk1GCAd0Lai+wdkQvfmQwL4MjGumineh1xz+6M5oMj3rfWS02A==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.4.1.tgz",
+            "integrity": "sha512-O9doU/S1EBe+yp/mstQ0VpPwpv0Clgn68TkNwGxL6/usX/KUW9Arnn4ag8C3jc6qHcXznhsT5Na1liYzAsuAbQ==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*",
-                "jest-util": "^29.4.0",
+                "jest-util": "^29.4.1",
                 "merge-stream": "^2.0.0",
                 "supports-color": "^8.0.0"
             },
@@ -5108,18 +4999,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/jsonfile": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-            "dev": true,
-            "dependencies": {
-                "universalify": "^2.0.0"
-            },
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
         "node_modules/kleur": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -5184,12 +5063,6 @@
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true
         },
-        "node_modules/lodash.truncate": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-            "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
-            "dev": true
-        },
         "node_modules/lru-cache": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -5236,17 +5109,6 @@
             "dev": true,
             "dependencies": {
                 "tmpl": "1.0.5"
-            }
-        },
-        "node_modules/md5": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-            "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-            "dev": true,
-            "dependencies": {
-                "charenc": "0.0.2",
-                "crypt": "0.0.2",
-                "is-buffer": "~1.1.6"
             }
         },
         "node_modules/merge-stream": {
@@ -5692,9 +5554,9 @@
             }
         },
         "node_modules/pretty-format": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.4.0.tgz",
-            "integrity": "sha512-J+EVUPXIBHCdWAbvGBwXs0mk3ljGppoh/076g1S8qYS8nVG4u/yrhMvyTFHYYYKWnDdgRLExx0vA7pzxVGdlNw==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.4.1.tgz",
+            "integrity": "sha512-dt/Z761JUVsrIKaY215o1xQJBGlSmTx/h4cSqXqjHLnU1+Kt+mavVE7UgqJJO5ukx5HjSswHfmXz4LjS2oIJfg==",
             "dev": true,
             "dependencies": {
                 "@jest/schemas": "^29.4.0",
@@ -5798,15 +5660,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/require-from-string": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -6019,23 +5872,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/slice-ansi": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-            "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "astral-regex": "^2.0.0",
-                "is-fullwidth-code-point": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-            }
-        },
         "node_modules/source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -6203,44 +6039,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/table": {
-            "version": "6.8.1",
-            "resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
-            "integrity": "sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==",
-            "dev": true,
-            "dependencies": {
-                "ajv": "^8.0.1",
-                "lodash.truncate": "^4.4.2",
-                "slice-ansi": "^4.0.0",
-                "string-width": "^4.2.3",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
-        "node_modules/table/node_modules/ajv": {
-            "version": "8.12.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-            "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-            "dev": true,
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/table/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true
-        },
         "node_modules/test-exclude": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -6374,15 +6172,6 @@
                 }
             }
         },
-        "node_modules/ts-node/node_modules/diff": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.3.1"
-            }
-        },
         "node_modules/tsconfig-paths": {
             "version": "3.14.1",
             "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -6510,15 +6299,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/universalify": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-            "dev": true,
-            "engines": {
-                "node": ">= 10.0.0"
             }
         },
         "node_modules/update-browserslist-db": {
@@ -6762,19 +6542,10 @@
                 "@jridgewell/trace-mapping": "^0.3.9"
             }
         },
-        "@aws-cdk/assert": {
-            "version": "2.61.1",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/assert/-/assert-2.61.1.tgz",
-            "integrity": "sha512-6lfRXAUarvy2hywcYb5cgR+ycjhaXSeSJJgTkPAVFgwassQtsPGh0ItFX6T1tuLeUY+yJyi1ema6B4vB5ZQo2g==",
-            "dev": true,
-            "requires": {
-                "@aws-cdk/cloudformation-diff": "2.61.1"
-            }
-        },
         "@aws-cdk/asset-awscli-v1": {
-            "version": "2.2.51",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.51.tgz",
-            "integrity": "sha512-WcFw8LKQt6anPLgcj+NK2UhMdfIk+aLk2LQBNAPYyrynwfSQZjU3auuqsJGZuIwtSZ3Qs885L0GsDK2hunEFtQ==",
+            "version": "2.2.52",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.52.tgz",
+            "integrity": "sha512-9dBPrvByWrUOcs5Rjwv08FWSummo1Uk/EgE3dCFDqvIqlSTudEmu6TGU3zrs00rfcAjqDv6gBuSttzG5f9tfdQ==",
             "dev": true
         },
         "@aws-cdk/asset-kubectl-v20": {
@@ -6784,9 +6555,9 @@
             "dev": true
         },
         "@aws-cdk/asset-node-proxy-agent-v5": {
-            "version": "2.0.41",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.41.tgz",
-            "integrity": "sha512-POfpCysF+of+KhMdxNykYkXAKS81gdXXPqukA+j/IubLaCFqIctQLafgAZ5P5ec4c6pHwFjWGl1I6fJOpPSd7g==",
+            "version": "2.0.42",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.42.tgz",
+            "integrity": "sha512-PxvP1UU2xa4k3Ea78DxAYY8ADvwWZ/nPu+xsjQLsT+MP+aB3RZ3pGc/fNlH7Rg56Zyb/j3GSdihAy4Oi5xa+TQ==",
             "dev": true
         },
         "@aws-cdk/aws-servicecatalogappregistry-alpha": {
@@ -6795,39 +6566,6 @@
             "integrity": "sha512-aTI5BiHGGRI1JvabvtmpxXHkpclfb2i68gNw8RykHXyuB55ySNDcuB1lhpWWG+6IF9iMgC2Dw00l6kT3NDArVA==",
             "dev": true,
             "requires": {}
-        },
-        "@aws-cdk/cfnspec": {
-            "version": "2.61.1",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/cfnspec/-/cfnspec-2.61.1.tgz",
-            "integrity": "sha512-JGFxJgMcJRSr5zqPlVemZ9T08Q3oq0izdVzU+kDeL2okLXHveNM79+OSPsPg3RVtL49lbR5vvpofk4GDDKvfcg==",
-            "dev": true,
-            "requires": {
-                "fs-extra": "^9.1.0",
-                "md5": "^2.3.0"
-            }
-        },
-        "@aws-cdk/cloudformation-diff": {
-            "version": "2.61.1",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/cloudformation-diff/-/cloudformation-diff-2.61.1.tgz",
-            "integrity": "sha512-50fdsjMtIpjhrmo0M2J10FIYgnc65hRkHFUdiAH9oC+1iXspFo0RynRI8DJPt//OH7d7w7Mb4nIrEx65PAxb4A==",
-            "dev": true,
-            "requires": {
-                "@aws-cdk/cfnspec": "2.61.1",
-                "@types/node": "^14.18.36",
-                "chalk": "^4",
-                "diff": "^5.1.0",
-                "fast-deep-equal": "^3.1.3",
-                "string-width": "^4.2.3",
-                "table": "^6.8.1"
-            },
-            "dependencies": {
-                "@types/node": {
-                    "version": "14.18.36",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.36.tgz",
-                    "integrity": "sha512-FXKWbsJ6a1hIrRxv+FoukuHnGTgEzKYGi7kilfMae96AL9UNkPFNWJEEYWzdRI9ooIkbr4AKldyuSTLql06vLQ==",
-                    "dev": true
-                }
-            }
         },
         "@babel/code-frame": {
             "version": "7.18.6",
@@ -7720,30 +7458,30 @@
             "dev": true
         },
         "@jest/console": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.4.0.tgz",
-            "integrity": "sha512-xpXud7e/8zo4syxQlAMDz+EQiFsf8/zXDPslBYm+UaSJ5uGTKQHhbSHfECp7Fw1trQtopjYumeved0n3waijhQ==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.4.1.tgz",
+            "integrity": "sha512-m+XpwKSi3PPM9znm5NGS8bBReeAJJpSkL1OuFCqaMaJL2YX9YXLkkI+MBchMPwu+ZuM2rynL51sgfkQteQ1CKQ==",
             "dev": true,
             "requires": {
-                "@jest/types": "^29.4.0",
+                "@jest/types": "^29.4.1",
                 "@types/node": "*",
                 "chalk": "^4.0.0",
-                "jest-message-util": "^29.4.0",
-                "jest-util": "^29.4.0",
+                "jest-message-util": "^29.4.1",
+                "jest-util": "^29.4.1",
                 "slash": "^3.0.0"
             }
         },
         "@jest/core": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.4.0.tgz",
-            "integrity": "sha512-E7oCMcENobBFwQXYjnN2IsuUSpRo5jSv7VYk6O9GyQ5kVAfVSS8819I4W5iCCYvqD6+1TzyzLpeEdZEik81kNw==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.4.1.tgz",
+            "integrity": "sha512-RXFTohpBqpaTebNdg5l3I5yadnKo9zLBajMT0I38D0tDhreVBYv3fA8kywthI00sWxPztWLD3yjiUkewwu/wKA==",
             "dev": true,
             "requires": {
-                "@jest/console": "^29.4.0",
-                "@jest/reporters": "^29.4.0",
-                "@jest/test-result": "^29.4.0",
-                "@jest/transform": "^29.4.0",
-                "@jest/types": "^29.4.0",
+                "@jest/console": "^29.4.1",
+                "@jest/reporters": "^29.4.1",
+                "@jest/test-result": "^29.4.1",
+                "@jest/transform": "^29.4.1",
+                "@jest/types": "^29.4.1",
                 "@types/node": "*",
                 "ansi-escapes": "^4.2.1",
                 "chalk": "^4.0.0",
@@ -7751,92 +7489,92 @@
                 "exit": "^0.1.2",
                 "graceful-fs": "^4.2.9",
                 "jest-changed-files": "^29.4.0",
-                "jest-config": "^29.4.0",
-                "jest-haste-map": "^29.4.0",
-                "jest-message-util": "^29.4.0",
+                "jest-config": "^29.4.1",
+                "jest-haste-map": "^29.4.1",
+                "jest-message-util": "^29.4.1",
                 "jest-regex-util": "^29.2.0",
-                "jest-resolve": "^29.4.0",
-                "jest-resolve-dependencies": "^29.4.0",
-                "jest-runner": "^29.4.0",
-                "jest-runtime": "^29.4.0",
-                "jest-snapshot": "^29.4.0",
-                "jest-util": "^29.4.0",
-                "jest-validate": "^29.4.0",
-                "jest-watcher": "^29.4.0",
+                "jest-resolve": "^29.4.1",
+                "jest-resolve-dependencies": "^29.4.1",
+                "jest-runner": "^29.4.1",
+                "jest-runtime": "^29.4.1",
+                "jest-snapshot": "^29.4.1",
+                "jest-util": "^29.4.1",
+                "jest-validate": "^29.4.1",
+                "jest-watcher": "^29.4.1",
                 "micromatch": "^4.0.4",
-                "pretty-format": "^29.4.0",
+                "pretty-format": "^29.4.1",
                 "slash": "^3.0.0",
                 "strip-ansi": "^6.0.0"
             }
         },
         "@jest/environment": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.4.0.tgz",
-            "integrity": "sha512-ocl1VGDcZHfHnYLTqkBY7yXme1bF4x0BevJ9wb6y0sLOSyBCpp8L5fEASChB+wU53WMrIK6kBfGt+ZYoM2kcdw==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.4.1.tgz",
+            "integrity": "sha512-pJ14dHGSQke7Q3mkL/UZR9ZtTOxqskZaC91NzamEH4dlKRt42W+maRBXiw/LWkdJe+P0f/zDR37+SPMplMRlPg==",
             "dev": true,
             "requires": {
-                "@jest/fake-timers": "^29.4.0",
-                "@jest/types": "^29.4.0",
+                "@jest/fake-timers": "^29.4.1",
+                "@jest/types": "^29.4.1",
                 "@types/node": "*",
-                "jest-mock": "^29.4.0"
+                "jest-mock": "^29.4.1"
             }
         },
         "@jest/expect": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.4.0.tgz",
-            "integrity": "sha512-IiDZYQ/Oi94aBT0nKKKRvNsB5JTyHoGb+G3SiGoDxz90JfL7SLx/z5IjB0fzBRzy7aLFQOCbVJlaC2fIgU6Y9Q==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.4.1.tgz",
+            "integrity": "sha512-ZxKJP5DTUNF2XkpJeZIzvnzF1KkfrhEF6Rz0HGG69fHl6Bgx5/GoU3XyaeFYEjuuKSOOsbqD/k72wFvFxc3iTw==",
             "dev": true,
             "requires": {
-                "expect": "^29.4.0",
-                "jest-snapshot": "^29.4.0"
+                "expect": "^29.4.1",
+                "jest-snapshot": "^29.4.1"
             }
         },
         "@jest/expect-utils": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.4.0.tgz",
-            "integrity": "sha512-w/JzTYIqjmPFIM5OOQHF9CawFx2daw1256Nzj4ZqWX96qRKbCq9WYRVqdySBKHHzuvsXLyTDIF6y61FUyrhmwg==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.4.1.tgz",
+            "integrity": "sha512-w6YJMn5DlzmxjO00i9wu2YSozUYRBhIoJ6nQwpMYcBMtiqMGJm1QBzOf6DDgRao8dbtpDoaqLg6iiQTvv0UHhQ==",
             "dev": true,
             "requires": {
                 "jest-get-type": "^29.2.0"
             }
         },
         "@jest/fake-timers": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.4.0.tgz",
-            "integrity": "sha512-8sitzN2QrhDwEwH3kKcMMgrv/UIkmm9AUgHixmn4L++GQ0CqVTIztm3YmaIQooLmW3O4GhizNTTCyq3iLbWcMw==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.4.1.tgz",
+            "integrity": "sha512-/1joI6rfHFmmm39JxNfmNAO3Nwm6Y0VoL5fJDy7H1AtWrD1CgRtqJbN9Ld6rhAkGO76qqp4cwhhxJ9o9kYjQMw==",
             "dev": true,
             "requires": {
-                "@jest/types": "^29.4.0",
+                "@jest/types": "^29.4.1",
                 "@sinonjs/fake-timers": "^10.0.2",
                 "@types/node": "*",
-                "jest-message-util": "^29.4.0",
-                "jest-mock": "^29.4.0",
-                "jest-util": "^29.4.0"
+                "jest-message-util": "^29.4.1",
+                "jest-mock": "^29.4.1",
+                "jest-util": "^29.4.1"
             }
         },
         "@jest/globals": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.4.0.tgz",
-            "integrity": "sha512-Q64ZRgGMVL40RcYTfD2GvyjK7vJLPSIvi8Yp3usGPNPQ3SCW+UCY9KEH6+sVtBo8LzhcjtCXuZEd7avnj/T0mQ==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.4.1.tgz",
+            "integrity": "sha512-znoK2EuFytbHH0ZSf2mQK2K1xtIgmaw4Da21R2C/NE/+NnItm5mPEFQmn8gmF3f0rfOlmZ3Y3bIf7bFj7DHxAA==",
             "dev": true,
             "requires": {
-                "@jest/environment": "^29.4.0",
-                "@jest/expect": "^29.4.0",
-                "@jest/types": "^29.4.0",
-                "jest-mock": "^29.4.0"
+                "@jest/environment": "^29.4.1",
+                "@jest/expect": "^29.4.1",
+                "@jest/types": "^29.4.1",
+                "jest-mock": "^29.4.1"
             }
         },
         "@jest/reporters": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.4.0.tgz",
-            "integrity": "sha512-FjJwrD1XOQq/AXKrvnOSf0RgAs6ziUuGKx8+/R53Jscc629JIhg7/m241gf1shUm/fKKxoHd7aCexcg7kxvkWQ==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.4.1.tgz",
+            "integrity": "sha512-AISY5xpt2Xpxj9R6y0RF1+O6GRy9JsGa8+vK23Lmzdy1AYcpQn5ItX79wJSsTmfzPKSAcsY1LNt/8Y5Xe5LOSg==",
             "dev": true,
             "requires": {
                 "@bcoe/v8-coverage": "^0.2.3",
-                "@jest/console": "^29.4.0",
-                "@jest/test-result": "^29.4.0",
-                "@jest/transform": "^29.4.0",
-                "@jest/types": "^29.4.0",
+                "@jest/console": "^29.4.1",
+                "@jest/test-result": "^29.4.1",
+                "@jest/transform": "^29.4.1",
+                "@jest/types": "^29.4.1",
                 "@jridgewell/trace-mapping": "^0.3.15",
                 "@types/node": "*",
                 "chalk": "^4.0.0",
@@ -7849,9 +7587,9 @@
                 "istanbul-lib-report": "^3.0.0",
                 "istanbul-lib-source-maps": "^4.0.0",
                 "istanbul-reports": "^3.1.3",
-                "jest-message-util": "^29.4.0",
-                "jest-util": "^29.4.0",
-                "jest-worker": "^29.4.0",
+                "jest-message-util": "^29.4.1",
+                "jest-util": "^29.4.1",
+                "jest-worker": "^29.4.1",
                 "slash": "^3.0.0",
                 "string-length": "^4.0.1",
                 "strip-ansi": "^6.0.0",
@@ -7879,46 +7617,46 @@
             }
         },
         "@jest/test-result": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.4.0.tgz",
-            "integrity": "sha512-EtRklzjpddZU/aBVxJqqejfzfOcnehmjNXufs6u6qwd05kkhXpAPhZdt8bLlQd7cA2nD+JqZQ5Dx9NX5Jh6mjA==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.4.1.tgz",
+            "integrity": "sha512-WRt29Lwt+hEgfN8QDrXqXGgCTidq1rLyFqmZ4lmJOpVArC8daXrZWkWjiaijQvgd3aOUj2fM8INclKHsQW9YyQ==",
             "dev": true,
             "requires": {
-                "@jest/console": "^29.4.0",
-                "@jest/types": "^29.4.0",
+                "@jest/console": "^29.4.1",
+                "@jest/types": "^29.4.1",
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "collect-v8-coverage": "^1.0.0"
             }
         },
         "@jest/test-sequencer": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.4.0.tgz",
-            "integrity": "sha512-pEwIgdfvEgF2lBOYX3DVn3SrvsAZ9FXCHw7+C6Qz87HnoDGQwbAselhWLhpgbxDjs6RC9QUJpFnrLmM5uwZV+g==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.4.1.tgz",
+            "integrity": "sha512-v5qLBNSsM0eHzWLXsQ5fiB65xi49A3ILPSFQKPXzGL4Vyux0DPZAIN7NAFJa9b4BiTDP9MBF/Zqc/QA1vuiJ0w==",
             "dev": true,
             "requires": {
-                "@jest/test-result": "^29.4.0",
+                "@jest/test-result": "^29.4.1",
                 "graceful-fs": "^4.2.9",
-                "jest-haste-map": "^29.4.0",
+                "jest-haste-map": "^29.4.1",
                 "slash": "^3.0.0"
             }
         },
         "@jest/transform": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.4.0.tgz",
-            "integrity": "sha512-hDjw3jz4GnvbyLMgcFpC9/34QcUhVIzJkBqz7o+3AhgfhGRzGuQppuLf5r/q7lDAAyJ6jzL+SFG7JGsScHOcLQ==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.4.1.tgz",
+            "integrity": "sha512-5w6YJrVAtiAgr0phzKjYd83UPbCXsBRTeYI4BXokv9Er9CcrH9hfXL/crCvP2d2nGOcovPUnlYiLPFLZrkG5Hg==",
             "dev": true,
             "requires": {
                 "@babel/core": "^7.11.6",
-                "@jest/types": "^29.4.0",
+                "@jest/types": "^29.4.1",
                 "@jridgewell/trace-mapping": "^0.3.15",
                 "babel-plugin-istanbul": "^6.1.1",
                 "chalk": "^4.0.0",
                 "convert-source-map": "^2.0.0",
                 "fast-json-stable-stringify": "^2.1.0",
                 "graceful-fs": "^4.2.9",
-                "jest-haste-map": "^29.4.0",
+                "jest-haste-map": "^29.4.1",
                 "jest-regex-util": "^29.2.0",
-                "jest-util": "^29.4.0",
+                "jest-util": "^29.4.1",
                 "micromatch": "^4.0.4",
                 "pirates": "^4.0.4",
                 "slash": "^3.0.0",
@@ -7926,9 +7664,9 @@
             }
         },
         "@jest/types": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.0.tgz",
-            "integrity": "sha512-1S2Dt5uQp7R0bGY/L2BpuwCSji7v12kY3o8zqwlkbYBmOY956SKk+zOWqmfhHSINegiAVqOXydAYuWpzX6TYsQ==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.1.tgz",
+            "integrity": "sha512-zbrAXDUOnpJ+FMST2rV7QZOgec8rskg2zv8g2ajeqitp4tvZiyqTCYXANrKsM+ryj5o+LI+ZN2EgU9drrkiwSA==",
             "dev": true,
             "requires": {
                 "@jest/schemas": "^29.4.0",
@@ -8419,18 +8157,6 @@
                 "es-shim-unscopables": "^1.0.0"
             }
         },
-        "astral-regex": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-            "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-            "dev": true
-        },
-        "at-least-node": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-            "dev": true
-        },
         "available-typed-arrays": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -8438,18 +8164,18 @@
             "dev": true
         },
         "aws-cdk": {
-            "version": "2.61.1",
-            "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.61.1.tgz",
-            "integrity": "sha512-bufvOB+I2T6YjVjT6D0j6xbi6CnX62j7TfHL905WLd5UQhPecwlL8wLe2whUOKqZj2wmGjaP7jAjIE1FFfh98w==",
+            "version": "2.62.1",
+            "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.62.1.tgz",
+            "integrity": "sha512-r1EnkR8nKfNIlW7BC46b+w7EEb9+Jy/Mgf0s62vdbj1BSNgl1ZdfW2mOe1Ra2FjDC5jhFUX8t+t5+E6eA8vdZA==",
             "dev": true,
             "requires": {
                 "fsevents": "2.3.2"
             }
         },
         "aws-cdk-lib": {
-            "version": "2.61.1",
-            "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.61.1.tgz",
-            "integrity": "sha512-+n6rXkIbGtu151XGN54c9+vObUqTKI50skPsZsPo6S0eKgj4ZsYVfS/W6lM4pgv839BwN66hyYAzOvreXAbKeA==",
+            "version": "2.62.1",
+            "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.62.1.tgz",
+            "integrity": "sha512-1ZxdLm3ALIiEAM2DLP6W4DRZV1Ed8HI4lLxkNWmsuTVgbYsj663eawoyOM7/k8QWxBlxwU2T8pl0RtgOzc1Zbg==",
             "dev": true,
             "requires": {
                 "@aws-cdk/asset-awscli-v1": "^2.2.49",
@@ -8582,12 +8308,12 @@
             }
         },
         "babel-jest": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.4.0.tgz",
-            "integrity": "sha512-M61cGPg4JBashDvIzKoIV/y95mSF6x3ome7CMEaszUTHD4uo6dtC6Nln+fvRTspYNtwy8lDHl5lmoTBSNY/a+g==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.4.1.tgz",
+            "integrity": "sha512-xBZa/pLSsF/1sNpkgsiT3CmY7zV1kAsZ9OxxtrFqYucnOuRftXAfcJqcDVyOPeN4lttWTwhLdu0T9f8uvoPEUg==",
             "dev": true,
             "requires": {
-                "@jest/transform": "^29.4.0",
+                "@jest/transform": "^29.4.1",
                 "@types/babel__core": "^7.1.14",
                 "babel-plugin-istanbul": "^6.1.1",
                 "babel-preset-jest": "^29.4.0",
@@ -8741,9 +8467,9 @@
             "dev": true
         },
         "cdk-nag": {
-            "version": "2.21.73",
-            "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.21.73.tgz",
-            "integrity": "sha512-LEyVScTHTIQfdMMX9JdLkXmpujgaK29tEpZVmkYmKXv6fiW0hx70t9p4RQ95X8RNXVz2+CLX2H/i9mRnRQNVTg==",
+            "version": "2.21.74",
+            "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.21.74.tgz",
+            "integrity": "sha512-r47FLJqEt5PMoKOifFkw99kL97kpRZnMdVRF/Jt96nE78e7a1DsCSmRbyMFPLA0KE0bEEltTgB//z8npewe6og==",
             "dev": true,
             "requires": {}
         },
@@ -8761,12 +8487,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
             "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
-            "dev": true
-        },
-        "charenc": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-            "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
             "dev": true
         },
         "ci-info": {
@@ -8826,9 +8546,9 @@
             "dev": true
         },
         "constructs": {
-            "version": "10.1.230",
-            "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.230.tgz",
-            "integrity": "sha512-IthwvFD4pa8CtvNSx4mnfKi0kHEnQJ6tBebo+L6rTSx071H3XpMzV1WZS5PLh5B6czkfzaERV54ZzNKC8jUJxw==",
+            "version": "10.1.231",
+            "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.231.tgz",
+            "integrity": "sha512-y4R6kU5wZCGKmXXxCw8kuq1O9oO98FvhvNiIXXX/xaGdZlrq1+pvLRX5dcSL47PPmzO7rcKNF8a/esEdjRyomA==",
             "dev": true
         },
         "convert-source-map": {
@@ -8853,12 +8573,6 @@
                 "shebang-command": "^2.0.0",
                 "which": "^2.0.1"
             }
-        },
-        "crypt": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-            "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-            "dev": true
         },
         "debug": {
             "version": "4.3.4",
@@ -8904,9 +8618,9 @@
             "dev": true
         },
         "diff": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-            "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
             "dev": true
         },
         "diff-sequences": {
@@ -9343,16 +9057,16 @@
             "dev": true
         },
         "expect": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/expect/-/expect-29.4.0.tgz",
-            "integrity": "sha512-pzaAwjBgLEVxBh6ZHiqb9Wv3JYuv6m8ntgtY7a48nS+2KbX0EJkPS3FQlKiTZNcqzqJHNyQsfjqN60w1hPUBfQ==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/expect/-/expect-29.4.1.tgz",
+            "integrity": "sha512-OKrGESHOaMxK3b6zxIq9SOW8kEXztKff/Dvg88j4xIJxur1hspEbedVkR3GpHe5LO+WB2Qw7OWN0RMTdp6as5A==",
             "dev": true,
             "requires": {
-                "@jest/expect-utils": "^29.4.0",
+                "@jest/expect-utils": "^29.4.1",
                 "jest-get-type": "^29.2.0",
-                "jest-matcher-utils": "^29.4.0",
-                "jest-message-util": "^29.4.0",
-                "jest-util": "^29.4.0"
+                "jest-matcher-utils": "^29.4.1",
+                "jest-message-util": "^29.4.1",
+                "jest-util": "^29.4.1"
             }
         },
         "fast-deep-equal": {
@@ -9472,18 +9186,6 @@
             "dev": true,
             "requires": {
                 "is-callable": "^1.1.3"
-            }
-        },
-        "fs-extra": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-            "dev": true,
-            "requires": {
-                "at-least-node": "^1.0.0",
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
             }
         },
         "fs.realpath": {
@@ -9802,12 +9504,6 @@
                 "has-tostringtag": "^1.0.0"
             }
         },
-        "is-buffer": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-            "dev": true
-        },
         "is-callable": {
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -10017,15 +9713,15 @@
             }
         },
         "jest": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest/-/jest-29.4.0.tgz",
-            "integrity": "sha512-Zfd4UzNxPkSoHRBkg225rBjQNa6pVqbh20MGniAzwaOzYLd+pQUcAwH+WPxSXxKFs+QWYfPYIq9hIVSmdVQmPA==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest/-/jest-29.4.1.tgz",
+            "integrity": "sha512-cknimw7gAXPDOmj0QqztlxVtBVCw2lYY9CeIE5N6kD+kET1H4H79HSNISJmijb1HF+qk+G+ploJgiDi5k/fRlg==",
             "dev": true,
             "requires": {
-                "@jest/core": "^29.4.0",
-                "@jest/types": "^29.4.0",
+                "@jest/core": "^29.4.1",
+                "@jest/types": "^29.4.1",
                 "import-local": "^3.0.2",
-                "jest-cli": "^29.4.0"
+                "jest-cli": "^29.4.1"
             }
         },
         "jest-changed-files": {
@@ -10039,92 +9735,92 @@
             }
         },
         "jest-circus": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.4.0.tgz",
-            "integrity": "sha512-/pFBaCeLzCavRWyz14JwFgpZgPpEZdS6nPnREhczbHl2wy2UezvYcVp5akVFfUmBaA4ThAUp0I8cpgkbuNOm3g==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.4.1.tgz",
+            "integrity": "sha512-v02NuL5crMNY4CGPHBEflLzl4v91NFb85a+dH9a1pUNx6Xjggrd8l9pPy4LZ1VYNRXlb+f65+7O/MSIbLir6pA==",
             "dev": true,
             "requires": {
-                "@jest/environment": "^29.4.0",
-                "@jest/expect": "^29.4.0",
-                "@jest/test-result": "^29.4.0",
-                "@jest/types": "^29.4.0",
+                "@jest/environment": "^29.4.1",
+                "@jest/expect": "^29.4.1",
+                "@jest/test-result": "^29.4.1",
+                "@jest/types": "^29.4.1",
                 "@types/node": "*",
                 "chalk": "^4.0.0",
                 "co": "^4.6.0",
                 "dedent": "^0.7.0",
                 "is-generator-fn": "^2.0.0",
-                "jest-each": "^29.4.0",
-                "jest-matcher-utils": "^29.4.0",
-                "jest-message-util": "^29.4.0",
-                "jest-runtime": "^29.4.0",
-                "jest-snapshot": "^29.4.0",
-                "jest-util": "^29.4.0",
+                "jest-each": "^29.4.1",
+                "jest-matcher-utils": "^29.4.1",
+                "jest-message-util": "^29.4.1",
+                "jest-runtime": "^29.4.1",
+                "jest-snapshot": "^29.4.1",
+                "jest-util": "^29.4.1",
                 "p-limit": "^3.1.0",
-                "pretty-format": "^29.4.0",
+                "pretty-format": "^29.4.1",
                 "slash": "^3.0.0",
                 "stack-utils": "^2.0.3"
             }
         },
         "jest-cli": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.4.0.tgz",
-            "integrity": "sha512-YUkICcxjUd864VOzbfQEi2qd2hIIOd9bRF7LJUNyhWb3Khh3YKrbY0LWwoZZ4WkvukiNdvQu0Z4s6zLsY4hYfg==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.4.1.tgz",
+            "integrity": "sha512-jz7GDIhtxQ37M+9dlbv5K+/FVcIo1O/b1sX3cJgzlQUf/3VG25nvuWzlDC4F1FLLzUThJeWLu8I7JF9eWpuURQ==",
             "dev": true,
             "requires": {
-                "@jest/core": "^29.4.0",
-                "@jest/test-result": "^29.4.0",
-                "@jest/types": "^29.4.0",
+                "@jest/core": "^29.4.1",
+                "@jest/test-result": "^29.4.1",
+                "@jest/types": "^29.4.1",
                 "chalk": "^4.0.0",
                 "exit": "^0.1.2",
                 "graceful-fs": "^4.2.9",
                 "import-local": "^3.0.2",
-                "jest-config": "^29.4.0",
-                "jest-util": "^29.4.0",
-                "jest-validate": "^29.4.0",
+                "jest-config": "^29.4.1",
+                "jest-util": "^29.4.1",
+                "jest-validate": "^29.4.1",
                 "prompts": "^2.0.1",
                 "yargs": "^17.3.1"
             }
         },
         "jest-config": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.4.0.tgz",
-            "integrity": "sha512-jtgd72nN4Mob4Oego3N/pLRVfR2ui1hv+yO6xR/SUi5G7NtZ/grr95BJ1qRSDYZshuA0Jw57fnttZHZKb04+CA==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.4.1.tgz",
+            "integrity": "sha512-g7p3q4NuXiM4hrS4XFATTkd+2z0Ml2RhFmFPM8c3WyKwVDNszbl4E7cV7WIx1YZeqqCtqbtTtZhGZWJlJqngzg==",
             "dev": true,
             "requires": {
                 "@babel/core": "^7.11.6",
-                "@jest/test-sequencer": "^29.4.0",
-                "@jest/types": "^29.4.0",
-                "babel-jest": "^29.4.0",
+                "@jest/test-sequencer": "^29.4.1",
+                "@jest/types": "^29.4.1",
+                "babel-jest": "^29.4.1",
                 "chalk": "^4.0.0",
                 "ci-info": "^3.2.0",
                 "deepmerge": "^4.2.2",
                 "glob": "^7.1.3",
                 "graceful-fs": "^4.2.9",
-                "jest-circus": "^29.4.0",
-                "jest-environment-node": "^29.4.0",
+                "jest-circus": "^29.4.1",
+                "jest-environment-node": "^29.4.1",
                 "jest-get-type": "^29.2.0",
                 "jest-regex-util": "^29.2.0",
-                "jest-resolve": "^29.4.0",
-                "jest-runner": "^29.4.0",
-                "jest-util": "^29.4.0",
-                "jest-validate": "^29.4.0",
+                "jest-resolve": "^29.4.1",
+                "jest-runner": "^29.4.1",
+                "jest-util": "^29.4.1",
+                "jest-validate": "^29.4.1",
                 "micromatch": "^4.0.4",
                 "parse-json": "^5.2.0",
-                "pretty-format": "^29.4.0",
+                "pretty-format": "^29.4.1",
                 "slash": "^3.0.0",
                 "strip-json-comments": "^3.1.1"
             }
         },
         "jest-diff": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.4.0.tgz",
-            "integrity": "sha512-s8KNvFx8YgdQ4fn2YLDQ7N6kmVOP68dUDVJrCHNsTc3UM5jcmyyFeYKL8EPWBQbJ0o0VvDGbWp8oYQ1nsnqnWw==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.4.1.tgz",
+            "integrity": "sha512-uazdl2g331iY56CEyfbNA0Ut7Mn2ulAG5vUaEHXycf1L6IPyuImIxSz4F0VYBKi7LYIuxOwTZzK3wh5jHzASMw==",
             "dev": true,
             "requires": {
                 "chalk": "^4.0.0",
                 "diff-sequences": "^29.3.1",
                 "jest-get-type": "^29.2.0",
-                "pretty-format": "^29.4.0"
+                "pretty-format": "^29.4.1"
             }
         },
         "jest-docblock": {
@@ -10137,30 +9833,30 @@
             }
         },
         "jest-each": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.4.0.tgz",
-            "integrity": "sha512-LTOvB8JDVFjrwXItyQiyLuDYy5PMApGLLzbfIYR79QLpeohS0bcS6j2HjlWuRGSM8QQQyp+ico59Blv+Jx3fMw==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.4.1.tgz",
+            "integrity": "sha512-QlYFiX3llJMWUV0BtWht/esGEz9w+0i7BHwODKCze7YzZzizgExB9MOfiivF/vVT0GSQ8wXLhvHXh3x2fVD4QQ==",
             "dev": true,
             "requires": {
-                "@jest/types": "^29.4.0",
+                "@jest/types": "^29.4.1",
                 "chalk": "^4.0.0",
                 "jest-get-type": "^29.2.0",
-                "jest-util": "^29.4.0",
-                "pretty-format": "^29.4.0"
+                "jest-util": "^29.4.1",
+                "pretty-format": "^29.4.1"
             }
         },
         "jest-environment-node": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.4.0.tgz",
-            "integrity": "sha512-WVveE3fYSH6FhDtZdvXhFKeLsDRItlQgnij+HQv6ZKxTdT1DB5O0sHXKCEC3K5mHraMs1Kzn4ch9jXC7H4L4wA==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.4.1.tgz",
+            "integrity": "sha512-x/H2kdVgxSkxWAIlIh9MfMuBa0hZySmfsC5lCsWmWr6tZySP44ediRKDUiNggX/eHLH7Cd5ZN10Rw+XF5tXsqg==",
             "dev": true,
             "requires": {
-                "@jest/environment": "^29.4.0",
-                "@jest/fake-timers": "^29.4.0",
-                "@jest/types": "^29.4.0",
+                "@jest/environment": "^29.4.1",
+                "@jest/fake-timers": "^29.4.1",
+                "@jest/types": "^29.4.1",
                 "@types/node": "*",
-                "jest-mock": "^29.4.0",
-                "jest-util": "^29.4.0"
+                "jest-mock": "^29.4.1",
+                "jest-util": "^29.4.1"
             }
         },
         "jest-get-type": {
@@ -10170,12 +9866,12 @@
             "dev": true
         },
         "jest-haste-map": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.4.0.tgz",
-            "integrity": "sha512-m/pIEfoK0HoJz4c9bkgS5F9CXN2AM22eaSmUcmqTpadRlNVBOJE2CwkgaUzbrNn5MuAqTV1IPVYwWwjHNnk8eA==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.4.1.tgz",
+            "integrity": "sha512-imTjcgfVVTvg02khXL11NNLTx9ZaofbAWhilrMg/G8dIkp+HYCswhxf0xxJwBkfhWb3e8dwbjuWburvxmcr58w==",
             "dev": true,
             "requires": {
-                "@jest/types": "^29.4.0",
+                "@jest/types": "^29.4.1",
                 "@types/graceful-fs": "^4.1.3",
                 "@types/node": "*",
                 "anymatch": "^3.0.3",
@@ -10183,60 +9879,60 @@
                 "fsevents": "^2.3.2",
                 "graceful-fs": "^4.2.9",
                 "jest-regex-util": "^29.2.0",
-                "jest-util": "^29.4.0",
-                "jest-worker": "^29.4.0",
+                "jest-util": "^29.4.1",
+                "jest-worker": "^29.4.1",
                 "micromatch": "^4.0.4",
                 "walker": "^1.0.8"
             }
         },
         "jest-leak-detector": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.4.0.tgz",
-            "integrity": "sha512-fEGHS6ijzgSv5exABkCecMHNmyHcV52+l39ZsxuwfxmQMp43KBWJn2/Fwg8/l4jTI9uOY9jv8z1dXGgL0PHFjA==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.4.1.tgz",
+            "integrity": "sha512-akpZv7TPyGMnH2RimOCgy+hPmWZf55EyFUvymQ4LMsQP8xSPlZumCPtXGoDhFNhUE2039RApZkTQDKU79p/FiQ==",
             "dev": true,
             "requires": {
                 "jest-get-type": "^29.2.0",
-                "pretty-format": "^29.4.0"
+                "pretty-format": "^29.4.1"
             }
         },
         "jest-matcher-utils": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.4.0.tgz",
-            "integrity": "sha512-pU4OjBn96rDdRIaPUImbPiO2ETyRVzkA1EZVu9AxBDv/XPDJ7JWfkb6IiDT5jwgicaPHMrB/fhVa6qjG6potfA==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.4.1.tgz",
+            "integrity": "sha512-k5h0u8V4nAEy6lSACepxL/rw78FLDkBnXhZVgFneVpnJONhb2DhZj/Gv4eNe+1XqQ5IhgUcqj745UwH0HJmMnA==",
             "dev": true,
             "requires": {
                 "chalk": "^4.0.0",
-                "jest-diff": "^29.4.0",
+                "jest-diff": "^29.4.1",
                 "jest-get-type": "^29.2.0",
-                "pretty-format": "^29.4.0"
+                "pretty-format": "^29.4.1"
             }
         },
         "jest-message-util": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.4.0.tgz",
-            "integrity": "sha512-0FvobqymmhE9pDEifvIcni9GeoKLol8eZspzH5u41g1wxYtLS60a9joT95dzzoCgrKRidNz64eaAXyzaULV8og==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.4.1.tgz",
+            "integrity": "sha512-H4/I0cXUaLeCw6FM+i4AwCnOwHRgitdaUFOdm49022YD5nfyr8C/DrbXOBEyJaj+w/y0gGJ57klssOaUiLLQGQ==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.12.13",
-                "@jest/types": "^29.4.0",
+                "@jest/types": "^29.4.1",
                 "@types/stack-utils": "^2.0.0",
                 "chalk": "^4.0.0",
                 "graceful-fs": "^4.2.9",
                 "micromatch": "^4.0.4",
-                "pretty-format": "^29.4.0",
+                "pretty-format": "^29.4.1",
                 "slash": "^3.0.0",
                 "stack-utils": "^2.0.3"
             }
         },
         "jest-mock": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.4.0.tgz",
-            "integrity": "sha512-+ShT5i+hcu/OFQRV0f/V/YtwpdFcHg64JZ9A8b40JueP+X9HNrZAYGdkupGIzsUK8AucecxCt4wKauMchxubLQ==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.4.1.tgz",
+            "integrity": "sha512-MwA4hQ7zBOcgVCVnsM8TzaFLVUD/pFWTfbkY953Y81L5ret3GFRZtmPmRFAjKQSdCKoJvvqOu6Bvfpqlwwb0dQ==",
             "dev": true,
             "requires": {
-                "@jest/types": "^29.4.0",
+                "@jest/types": "^29.4.1",
                 "@types/node": "*",
-                "jest-util": "^29.4.0"
+                "jest-util": "^29.4.1"
             }
         },
         "jest-pnp-resolver": {
@@ -10253,57 +9949,57 @@
             "dev": true
         },
         "jest-resolve": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.4.0.tgz",
-            "integrity": "sha512-g7k7l53T+uC9Dp1mbHyDNkcCt0PMku6Wcfpr1kcMLwOHmM3vucKjSM5+DSa1r4vlDZojh8XH039J3z4FKmtTSw==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.4.1.tgz",
+            "integrity": "sha512-j/ZFNV2lm9IJ2wmlq1uYK0Y/1PiyDq9g4HEGsNTNr3viRbJdV+8Lf1SXIiLZXFvyiisu0qUyIXGBnw+OKWkJwQ==",
             "dev": true,
             "requires": {
                 "chalk": "^4.0.0",
                 "graceful-fs": "^4.2.9",
-                "jest-haste-map": "^29.4.0",
+                "jest-haste-map": "^29.4.1",
                 "jest-pnp-resolver": "^1.2.2",
-                "jest-util": "^29.4.0",
-                "jest-validate": "^29.4.0",
+                "jest-util": "^29.4.1",
+                "jest-validate": "^29.4.1",
                 "resolve": "^1.20.0",
                 "resolve.exports": "^2.0.0",
                 "slash": "^3.0.0"
             }
         },
         "jest-resolve-dependencies": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.4.0.tgz",
-            "integrity": "sha512-hxfC84trREyULSj1Cm+fMjnudrrI2dVQ04COjZRcjCZ97boJlPtfJ+qrl/pN7YXS2fnu3wTHEc3LO094pngL6A==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.4.1.tgz",
+            "integrity": "sha512-Y3QG3M1ncAMxfjbYgtqNXC5B595zmB6e//p/qpA/58JkQXu/IpLDoLeOa8YoYfsSglBKQQzNUqtfGJJT/qLmJg==",
             "dev": true,
             "requires": {
                 "jest-regex-util": "^29.2.0",
-                "jest-snapshot": "^29.4.0"
+                "jest-snapshot": "^29.4.1"
             }
         },
         "jest-runner": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.4.0.tgz",
-            "integrity": "sha512-4zpcv0NOiJleqT0NAs8YcVbK8MhVRc58CBBn9b0Exc8VPU9GKI+DbzDUZqJYdkJhJSZFy2862l/F6hAqIow1hg==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.4.1.tgz",
+            "integrity": "sha512-8d6XXXi7GtHmsHrnaqBKWxjKb166Eyj/ksSaUYdcBK09VbjPwIgWov1VwSmtupCIz8q1Xv4Qkzt/BTo3ZqiCeg==",
             "dev": true,
             "requires": {
-                "@jest/console": "^29.4.0",
-                "@jest/environment": "^29.4.0",
-                "@jest/test-result": "^29.4.0",
-                "@jest/transform": "^29.4.0",
-                "@jest/types": "^29.4.0",
+                "@jest/console": "^29.4.1",
+                "@jest/environment": "^29.4.1",
+                "@jest/test-result": "^29.4.1",
+                "@jest/transform": "^29.4.1",
+                "@jest/types": "^29.4.1",
                 "@types/node": "*",
                 "chalk": "^4.0.0",
                 "emittery": "^0.13.1",
                 "graceful-fs": "^4.2.9",
                 "jest-docblock": "^29.2.0",
-                "jest-environment-node": "^29.4.0",
-                "jest-haste-map": "^29.4.0",
-                "jest-leak-detector": "^29.4.0",
-                "jest-message-util": "^29.4.0",
-                "jest-resolve": "^29.4.0",
-                "jest-runtime": "^29.4.0",
-                "jest-util": "^29.4.0",
-                "jest-watcher": "^29.4.0",
-                "jest-worker": "^29.4.0",
+                "jest-environment-node": "^29.4.1",
+                "jest-haste-map": "^29.4.1",
+                "jest-leak-detector": "^29.4.1",
+                "jest-message-util": "^29.4.1",
+                "jest-resolve": "^29.4.1",
+                "jest-runtime": "^29.4.1",
+                "jest-util": "^29.4.1",
+                "jest-watcher": "^29.4.1",
+                "jest-worker": "^29.4.1",
                 "p-limit": "^3.1.0",
                 "source-map-support": "0.5.13"
             },
@@ -10321,40 +10017,40 @@
             }
         },
         "jest-runtime": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.4.0.tgz",
-            "integrity": "sha512-2zumwaGXsIuSF92Ui5Pn5hZV9r7AHMclfBLikrXSq87/lHea9anQ+mC+Cjz/DYTbf/JMjlK1sjZRh8K3yYNvWg==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.4.1.tgz",
+            "integrity": "sha512-UXTMU9uKu2GjYwTtoAw5rn4STxWw/nadOfW7v1sx6LaJYa3V/iymdCLQM6xy3+7C6mY8GfX22vKpgxY171UIoA==",
             "dev": true,
             "requires": {
-                "@jest/environment": "^29.4.0",
-                "@jest/fake-timers": "^29.4.0",
-                "@jest/globals": "^29.4.0",
+                "@jest/environment": "^29.4.1",
+                "@jest/fake-timers": "^29.4.1",
+                "@jest/globals": "^29.4.1",
                 "@jest/source-map": "^29.2.0",
-                "@jest/test-result": "^29.4.0",
-                "@jest/transform": "^29.4.0",
-                "@jest/types": "^29.4.0",
+                "@jest/test-result": "^29.4.1",
+                "@jest/transform": "^29.4.1",
+                "@jest/types": "^29.4.1",
                 "@types/node": "*",
                 "chalk": "^4.0.0",
                 "cjs-module-lexer": "^1.0.0",
                 "collect-v8-coverage": "^1.0.0",
                 "glob": "^7.1.3",
                 "graceful-fs": "^4.2.9",
-                "jest-haste-map": "^29.4.0",
-                "jest-message-util": "^29.4.0",
-                "jest-mock": "^29.4.0",
+                "jest-haste-map": "^29.4.1",
+                "jest-message-util": "^29.4.1",
+                "jest-mock": "^29.4.1",
                 "jest-regex-util": "^29.2.0",
-                "jest-resolve": "^29.4.0",
-                "jest-snapshot": "^29.4.0",
-                "jest-util": "^29.4.0",
+                "jest-resolve": "^29.4.1",
+                "jest-snapshot": "^29.4.1",
+                "jest-util": "^29.4.1",
                 "semver": "^7.3.5",
                 "slash": "^3.0.0",
                 "strip-bom": "^4.0.0"
             }
         },
         "jest-snapshot": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.4.0.tgz",
-            "integrity": "sha512-UnK3MhdEWrQ2J6MnlKe51tvN5FjRUBQnO4m1LPlDx61or3w9+cP/U0x9eicutgunu/QzE4WC82jj6CiGIAFYzw==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.4.1.tgz",
+            "integrity": "sha512-l4iV8EjGgQWVz3ee/LR9sULDk2pCkqb71bjvlqn+qp90lFwpnulHj4ZBT8nm1hA1C5wowXLc7MGnw321u0tsYA==",
             "dev": true,
             "requires": {
                 "@babel/core": "^7.11.6",
@@ -10363,33 +10059,33 @@
                 "@babel/plugin-syntax-typescript": "^7.7.2",
                 "@babel/traverse": "^7.7.2",
                 "@babel/types": "^7.3.3",
-                "@jest/expect-utils": "^29.4.0",
-                "@jest/transform": "^29.4.0",
-                "@jest/types": "^29.4.0",
+                "@jest/expect-utils": "^29.4.1",
+                "@jest/transform": "^29.4.1",
+                "@jest/types": "^29.4.1",
                 "@types/babel__traverse": "^7.0.6",
                 "@types/prettier": "^2.1.5",
                 "babel-preset-current-node-syntax": "^1.0.0",
                 "chalk": "^4.0.0",
-                "expect": "^29.4.0",
+                "expect": "^29.4.1",
                 "graceful-fs": "^4.2.9",
-                "jest-diff": "^29.4.0",
+                "jest-diff": "^29.4.1",
                 "jest-get-type": "^29.2.0",
-                "jest-haste-map": "^29.4.0",
-                "jest-matcher-utils": "^29.4.0",
-                "jest-message-util": "^29.4.0",
-                "jest-util": "^29.4.0",
+                "jest-haste-map": "^29.4.1",
+                "jest-matcher-utils": "^29.4.1",
+                "jest-message-util": "^29.4.1",
+                "jest-util": "^29.4.1",
                 "natural-compare": "^1.4.0",
-                "pretty-format": "^29.4.0",
+                "pretty-format": "^29.4.1",
                 "semver": "^7.3.5"
             }
         },
         "jest-util": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.4.0.tgz",
-            "integrity": "sha512-lCCwlze7UEV8TpR9ArS8w0cTbcMry5tlBkg7QSc5og5kNyV59dnY2aKHu5fY2k5aDJMQpCUGpvL2w6ZU44lveA==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.4.1.tgz",
+            "integrity": "sha512-bQy9FPGxVutgpN4VRc0hk6w7Hx/m6L53QxpDreTZgJd9gfx/AV2MjyPde9tGyZRINAUrSv57p2inGBu2dRLmkQ==",
             "dev": true,
             "requires": {
-                "@jest/types": "^29.4.0",
+                "@jest/types": "^29.4.1",
                 "@types/node": "*",
                 "chalk": "^4.0.0",
                 "ci-info": "^3.2.0",
@@ -10398,17 +10094,17 @@
             }
         },
         "jest-validate": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.4.0.tgz",
-            "integrity": "sha512-EXS7u594nX3aAPBnARxBdJ1eZ1cByV6MWrK0Qpt9lt/BcY0p0yYGp/EGJ8GhdLDQh+RFf8qMt2wzbbVzpj5+Vg==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.4.1.tgz",
+            "integrity": "sha512-qNZXcZQdIQx4SfUB/atWnI4/I2HUvhz8ajOSYUu40CSmf9U5emil8EDHgE7M+3j9/pavtk3knlZBDsgFvv/SWw==",
             "dev": true,
             "requires": {
-                "@jest/types": "^29.4.0",
+                "@jest/types": "^29.4.1",
                 "camelcase": "^6.2.0",
                 "chalk": "^4.0.0",
                 "jest-get-type": "^29.2.0",
                 "leven": "^3.1.0",
-                "pretty-format": "^29.4.0"
+                "pretty-format": "^29.4.1"
             },
             "dependencies": {
                 "camelcase": {
@@ -10420,29 +10116,29 @@
             }
         },
         "jest-watcher": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.4.0.tgz",
-            "integrity": "sha512-PnnfLygNKelWOJwpAYlcsQjB+OxRRdckD0qiGmYng4Hkz1ZwK3jvCaJJYiywz2msQn4rBNLdriasJtv7YpWHpA==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.4.1.tgz",
+            "integrity": "sha512-vFOzflGFs27nU6h8dpnVRER3O2rFtL+VMEwnG0H3KLHcllLsU8y9DchSh0AL/Rg5nN1/wSiQ+P4ByMGpuybaVw==",
             "dev": true,
             "requires": {
-                "@jest/test-result": "^29.4.0",
-                "@jest/types": "^29.4.0",
+                "@jest/test-result": "^29.4.1",
+                "@jest/types": "^29.4.1",
                 "@types/node": "*",
                 "ansi-escapes": "^4.2.1",
                 "chalk": "^4.0.0",
                 "emittery": "^0.13.1",
-                "jest-util": "^29.4.0",
+                "jest-util": "^29.4.1",
                 "string-length": "^4.0.1"
             }
         },
         "jest-worker": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.4.0.tgz",
-            "integrity": "sha512-dICMQ+Q4W0QVMsaQzWlA1FVQhKNz7QcDCOGtbk1GCAd0Lai+wdkQvfmQwL4MjGumineh1xz+6M5oMj3rfWS02A==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.4.1.tgz",
+            "integrity": "sha512-O9doU/S1EBe+yp/mstQ0VpPwpv0Clgn68TkNwGxL6/usX/KUW9Arnn4ag8C3jc6qHcXznhsT5Na1liYzAsuAbQ==",
             "dev": true,
             "requires": {
                 "@types/node": "*",
-                "jest-util": "^29.4.0",
+                "jest-util": "^29.4.1",
                 "merge-stream": "^2.0.0",
                 "supports-color": "^8.0.0"
             },
@@ -10509,16 +10205,6 @@
             "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
             "dev": true
         },
-        "jsonfile": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "^4.1.6",
-                "universalify": "^2.0.0"
-            }
-        },
         "kleur": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -10568,12 +10254,6 @@
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true
         },
-        "lodash.truncate": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-            "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
-            "dev": true
-        },
         "lru-cache": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -10613,17 +10293,6 @@
             "dev": true,
             "requires": {
                 "tmpl": "1.0.5"
-            }
-        },
-        "md5": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-            "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-            "dev": true,
-            "requires": {
-                "charenc": "0.0.2",
-                "crypt": "0.0.2",
-                "is-buffer": "~1.1.6"
             }
         },
         "merge-stream": {
@@ -10945,9 +10614,9 @@
             }
         },
         "pretty-format": {
-            "version": "29.4.0",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.4.0.tgz",
-            "integrity": "sha512-J+EVUPXIBHCdWAbvGBwXs0mk3ljGppoh/076g1S8qYS8nVG4u/yrhMvyTFHYYYKWnDdgRLExx0vA7pzxVGdlNw==",
+            "version": "29.4.1",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.4.1.tgz",
+            "integrity": "sha512-dt/Z761JUVsrIKaY215o1xQJBGlSmTx/h4cSqXqjHLnU1+Kt+mavVE7UgqJJO5ukx5HjSswHfmXz4LjS2oIJfg==",
             "dev": true,
             "requires": {
                 "@jest/schemas": "^29.4.0",
@@ -11012,12 +10681,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-            "dev": true
-        },
-        "require-from-string": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
             "dev": true
         },
         "resolve": {
@@ -11165,17 +10828,6 @@
             "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
             "dev": true
         },
-        "slice-ansi": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-            "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-            "dev": true,
-            "requires": {
-                "ansi-styles": "^4.0.0",
-                "astral-regex": "^2.0.0",
-                "is-fullwidth-code-point": "^3.0.0"
-            }
-        },
         "source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -11300,39 +10952,6 @@
             "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
             "dev": true
         },
-        "table": {
-            "version": "6.8.1",
-            "resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
-            "integrity": "sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==",
-            "dev": true,
-            "requires": {
-                "ajv": "^8.0.1",
-                "lodash.truncate": "^4.4.2",
-                "slice-ansi": "^4.0.0",
-                "string-width": "^4.2.3",
-                "strip-ansi": "^6.0.1"
-            },
-            "dependencies": {
-                "ajv": {
-                    "version": "8.12.0",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-                    "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-                    "dev": true,
-                    "requires": {
-                        "fast-deep-equal": "^3.1.1",
-                        "json-schema-traverse": "^1.0.0",
-                        "require-from-string": "^2.0.2",
-                        "uri-js": "^4.2.2"
-                    }
-                },
-                "json-schema-traverse": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-                    "dev": true
-                }
-            }
-        },
         "test-exclude": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -11406,14 +11025,6 @@
                 "make-error": "^1.1.1",
                 "v8-compile-cache-lib": "^3.0.1",
                 "yn": "3.1.1"
-            },
-            "dependencies": {
-                "diff": {
-                    "version": "4.0.2",
-                    "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-                    "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-                    "dev": true
-                }
             }
         },
         "tsconfig-paths": {
@@ -11509,12 +11120,6 @@
                 "has-symbols": "^1.0.3",
                 "which-boxed-primitive": "^1.0.2"
             }
-        },
-        "universalify": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-            "dev": true
         },
         "update-browserslist-db": {
             "version": "1.0.10",

--- a/source/package.json
+++ b/source/package.json
@@ -18,7 +18,6 @@
         "cdk": "cdk"
     },
     "devDependencies": {
-        "@aws-cdk/assert": "^2.61.1",
         "@aws-cdk/aws-servicecatalogappregistry-alpha": "^2.61.1-alpha.0",
         "@cdklabs/cdk-ssm-documents": "^0.0.32",
         "@types/jest": "^29.4.0",

--- a/source/playbooks/AFSBP/test/afsbp_stack.test.ts
+++ b/source/playbooks/AFSBP/test/afsbp_stack.test.ts
@@ -1,12 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { SynthUtils } from '@aws-cdk/assert';
-import * as cdk from 'aws-cdk-lib';
+import { App, DefaultStackSynthesizer, Stack } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
 import { PlaybookPrimaryStack, PlaybookMemberStack } from '../../../lib/sharrplaybook-construct';
 
-function getPrimaryStack(): cdk.Stack {
-  const app = new cdk.App();
+function getPrimaryStack(): Stack {
+  const app = new App();
   const stack = new PlaybookPrimaryStack(app, 'primaryStack', {
+    synthesizer: new DefaultStackSynthesizer({ generateBootstrapVersionRule: false }),
     description: 'test;',
     solutionId: 'SO0111',
     solutionVersion: 'v1.1.1',
@@ -21,12 +22,13 @@ function getPrimaryStack(): cdk.Stack {
 }
 
 test('Primary Stack - AFSBP', () => {
-  expect(SynthUtils.toCloudFormation(getPrimaryStack())).toMatchSnapshot();
+  expect(Template.fromStack(getPrimaryStack())).toMatchSnapshot();
 });
 
-function getMemberStack(): cdk.Stack {
-  const app = new cdk.App();
+function getMemberStack(): Stack {
+  const app = new App();
   const stack = new PlaybookMemberStack(app, 'memberStack', {
+    synthesizer: new DefaultStackSynthesizer({ generateBootstrapVersionRule: false }),
     description: 'test;',
     solutionId: 'SO0111',
     solutionVersion: 'v1.1.1',
@@ -42,5 +44,5 @@ function getMemberStack(): cdk.Stack {
 }
 
 test('Member Stack - AFSBP', () => {
-  expect(SynthUtils.toCloudFormation(getMemberStack())).toMatchSnapshot();
+  expect(Template.fromStack(getMemberStack())).toMatchSnapshot();
 });

--- a/source/playbooks/CIS120/test/cis_stack.test.ts
+++ b/source/playbooks/CIS120/test/cis_stack.test.ts
@@ -1,15 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { SynthUtils } from '@aws-cdk/assert';
-import * as cdk from 'aws-cdk-lib';
+import { Stack, App, DefaultStackSynthesizer } from 'aws-cdk-lib';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
+import { Template } from 'aws-cdk-lib/assertions';
 import { PlaybookPrimaryStack, PlaybookMemberStack } from '../../../lib/sharrplaybook-construct';
 
 const RESOURCE_PREFIX = 'SO0111';
 
-function getPrimaryStack(): cdk.Stack {
-  const app = new cdk.App();
+function getPrimaryStack(): Stack {
+  const app = new App();
   const stack = new PlaybookPrimaryStack(app, 'primaryStack', {
+    synthesizer: new DefaultStackSynthesizer({ generateBootstrapVersionRule: false }),
     description: 'test;',
     solutionId: 'SO0111',
     solutionVersion: 'v1.1.1',
@@ -24,12 +25,13 @@ function getPrimaryStack(): cdk.Stack {
 }
 
 test('default stack', () => {
-  expect(SynthUtils.toCloudFormation(getPrimaryStack())).toMatchSnapshot();
+  expect(Template.fromStack(getPrimaryStack())).toMatchSnapshot();
 });
 
-function getMemberStack(): cdk.Stack {
-  const app = new cdk.App();
+function getMemberStack(): Stack {
+  const app = new App();
   const stack = new PlaybookMemberStack(app, 'memberStack', {
+    synthesizer: new DefaultStackSynthesizer({ generateBootstrapVersionRule: false }),
     description: 'test;',
     solutionId: 'SO0111',
     solutionVersion: 'v1.1.1',
@@ -51,5 +53,5 @@ function getMemberStack(): cdk.Stack {
 }
 
 test('default stack', () => {
-  expect(SynthUtils.toCloudFormation(getMemberStack())).toMatchSnapshot();
+  expect(Template.fromStack(getMemberStack())).toMatchSnapshot();
 });

--- a/source/playbooks/CIS140/test/__snapshots__/cis_stack.test.ts.snap
+++ b/source/playbooks/CIS140/test/__snapshots__/cis_stack.test.ts.snap
@@ -1,0 +1,1421 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`default stack 1`] = `
+{
+  "Description": "test;",
+  "Mappings": {
+    "SourceCode": {
+      "General": {
+        "KeyPrefix": "aws-security-hub-automated-response-and-remediation/v1.1.1",
+        "S3Bucket": "sharrbukkit",
+      },
+    },
+  },
+  "Parameters": {
+    "CIS14011AutoTrigger": {
+      "AllowedValues": [
+        "ENABLED",
+        "DISABLED",
+      ],
+      "Default": "DISABLED",
+      "Description": "This will fully enable automated remediation for CIS 1.4.0 1.1",
+      "Type": "String",
+    },
+    "CIS14012AutoTrigger": {
+      "AllowedValues": [
+        "ENABLED",
+        "DISABLED",
+      ],
+      "Default": "DISABLED",
+      "Description": "This will fully enable automated remediation for CIS 1.4.0 1.2",
+      "Type": "String",
+    },
+    "CIS14013AutoTrigger": {
+      "AllowedValues": [
+        "ENABLED",
+        "DISABLED",
+      ],
+      "Default": "DISABLED",
+      "Description": "This will fully enable automated remediation for CIS 1.4.0 1.3",
+      "Type": "String",
+    },
+    "SsmParameterValueSolutionsSO0111OrchestratorArnC96584B6F00A464EAD1953AFF4B05118Parameter": {
+      "Default": "/Solutions/SO0111/OrchestratorArn",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "CIS11AutoEventRule5178D649": {
+      "Properties": {
+        "Description": "Remediate CIS 1.4.0 1.1 automatic remediation trigger event rule.",
+        "EventPattern": {
+          "detail": {
+            "findings": {
+              "Compliance": {
+                "Status": [
+                  "FAILED",
+                  "WARNING",
+                ],
+              },
+              "GeneratorId": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.4.0/rule/1.1",
+                    ],
+                  ],
+                },
+              ],
+              "RecordState": [
+                "ACTIVE",
+              ],
+              "Workflow": {
+                "Status": [
+                  "NEW",
+                ],
+              },
+            },
+          },
+          "detail-type": [
+            "Security Hub Findings - Imported",
+          ],
+          "source": [
+            "aws.securityhub",
+          ],
+        },
+        "Name": "CIS_1.4.0_1.1_AutoTrigger",
+        "State": {
+          "Ref": "CIS14011AutoTrigger",
+        },
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "SsmParameterValueSolutionsSO0111OrchestratorArnC96584B6F00A464EAD1953AFF4B05118Parameter",
+            },
+            "Id": "Target0",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "CIS11EventsRuleRoleB8D228E0",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "CIS11EventsRuleRoleB8D228E0": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CIS11EventsRuleRoleDefaultPolicy66E09676": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "states:StartExecution",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "SsmParameterValueSolutionsSO0111OrchestratorArnC96584B6F00A464EAD1953AFF4B05118Parameter",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CIS11EventsRuleRoleDefaultPolicy66E09676",
+        "Roles": [
+          {
+            "Ref": "CIS11EventsRuleRoleB8D228E0",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CIS12AutoEventRuleD40B64BC": {
+      "Properties": {
+        "Description": "Remediate CIS 1.4.0 1.2 automatic remediation trigger event rule.",
+        "EventPattern": {
+          "detail": {
+            "findings": {
+              "Compliance": {
+                "Status": [
+                  "FAILED",
+                  "WARNING",
+                ],
+              },
+              "GeneratorId": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.4.0/rule/1.2",
+                    ],
+                  ],
+                },
+              ],
+              "RecordState": [
+                "ACTIVE",
+              ],
+              "Workflow": {
+                "Status": [
+                  "NEW",
+                ],
+              },
+            },
+          },
+          "detail-type": [
+            "Security Hub Findings - Imported",
+          ],
+          "source": [
+            "aws.securityhub",
+          ],
+        },
+        "Name": "CIS_1.4.0_1.2_AutoTrigger",
+        "State": {
+          "Ref": "CIS14012AutoTrigger",
+        },
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "SsmParameterValueSolutionsSO0111OrchestratorArnC96584B6F00A464EAD1953AFF4B05118Parameter",
+            },
+            "Id": "Target0",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "CIS12EventsRuleRoleA8389A61",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "CIS12EventsRuleRoleA8389A61": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CIS12EventsRuleRoleDefaultPolicyA48EF9DD": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "states:StartExecution",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "SsmParameterValueSolutionsSO0111OrchestratorArnC96584B6F00A464EAD1953AFF4B05118Parameter",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CIS12EventsRuleRoleDefaultPolicyA48EF9DD",
+        "Roles": [
+          {
+            "Ref": "CIS12EventsRuleRoleA8389A61",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CIS13AutoEventRuleC6C84C81": {
+      "Properties": {
+        "Description": "Remediate CIS 1.4.0 1.3 automatic remediation trigger event rule.",
+        "EventPattern": {
+          "detail": {
+            "findings": {
+              "Compliance": {
+                "Status": [
+                  "FAILED",
+                  "WARNING",
+                ],
+              },
+              "GeneratorId": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.4.0/rule/1.3",
+                    ],
+                  ],
+                },
+              ],
+              "RecordState": [
+                "ACTIVE",
+              ],
+              "Workflow": {
+                "Status": [
+                  "NEW",
+                ],
+              },
+            },
+          },
+          "detail-type": [
+            "Security Hub Findings - Imported",
+          ],
+          "source": [
+            "aws.securityhub",
+          ],
+        },
+        "Name": "CIS_1.4.0_1.3_AutoTrigger",
+        "State": {
+          "Ref": "CIS14013AutoTrigger",
+        },
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "SsmParameterValueSolutionsSO0111OrchestratorArnC96584B6F00A464EAD1953AFF4B05118Parameter",
+            },
+            "Id": "Target0",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "CIS13EventsRuleRoleFEBE574F",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "CIS13EventsRuleRoleDefaultPolicy2E3E119B": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "states:StartExecution",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "SsmParameterValueSolutionsSO0111OrchestratorArnC96584B6F00A464EAD1953AFF4B05118Parameter",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CIS13EventsRuleRoleDefaultPolicy2E3E119B",
+        "Roles": [
+          {
+            "Ref": "CIS13EventsRuleRoleFEBE574F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CIS13EventsRuleRoleFEBE574F": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "StandardVersionCB2C6951": {
+      "Properties": {
+        "Description": "This parameter controls whether the SHARR step function will process findings for this version of the standard.",
+        "Name": "/Solutions/SO0111/cis-aws-foundations-benchmark/1.4.0/status",
+        "Type": "String",
+        "Value": "enabled",
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+  },
+}
+`;
+
+exports[`default stack 2`] = `
+{
+  "Conditions": {
+    "Enable13Condition": {
+      "Fn::Equals": [
+        {
+          "Ref": "Enable13",
+        },
+        "Available",
+      ],
+    },
+    "Enable15Condition": {
+      "Fn::Equals": [
+        {
+          "Ref": "Enable15",
+        },
+        "Available",
+      ],
+    },
+    "Enable21Condition": {
+      "Fn::Equals": [
+        {
+          "Ref": "Enable21",
+        },
+        "Available",
+      ],
+    },
+  },
+  "Description": "test;",
+  "Parameters": {
+    "Enable13": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for CIS version 1.4.0 Control 1.3 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "Enable15": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for CIS version 1.4.0 Control 1.5 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "Enable21": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for CIS version 1.4.0 Control 2.1 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "SecHubAdminAccount": {
+      "AllowedPattern": "\\d{12}",
+      "Description": "Admin account number",
+      "Type": "String",
+    },
+  },
+  "Resources": {
+    "ControlCIS13": {
+      "Condition": "Enable13Condition",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-CIS_1.2.0_1.3
+
+## What does this document do?
+This document ensures that credentials unused for 90 days or greater are disabled.
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Output Parameters
+* Remediation.Output - Output of DescribeAutoScalingGroups API.
+
+## Documentation Links
+* [CIS v1.2.0 1.3](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-1.3)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{Finding}}",
+                  "expected_control_id": [
+                    "1.3",
+                  ],
+                  "parse_id_pattern": "^arn:(?:aws|aws-cn|aws-us-gov):iam::\\d{12}:user(?:(?:\\u002F)|(?:\\u002F[\\u0021-\\u007F]{1,510}\\u002F))([\\w+=,.@-]{1,64})$",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }",
+              },
+              "isEnd": false,
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "IAMUser",
+                  "Selector": "$.Payload.resource_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "IAMResourceId",
+                  "Selector": "$.Payload.details.AwsIamUser.UserId",
+                  "Type": "String",
+                },
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-RevokeUnusedIAMUserCredentials",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{global:AWS_PARTITION}}:iam::{{global:ACCOUNT_ID}}:role/SO0111-RevokeUnusedIAMUserCredentials",
+                  "IAMResourceId": "{{ ParseInput.IAMResourceId }}",
+                },
+              },
+              "isEnd": false,
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "description": "Update finding",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ParseInput.FindingId}}",
+                    "ProductArn": "{{ParseInput.ProductArn}}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Deactivated unused keys and expired logins for {{ ParseInput.IAMUser }}.",
+                  "UpdatedBy": "ASR-CIS_1.2.0_1.3",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "ParseInput.AffectedObject",
+            "Remediation.Output",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the 1.3 finding",
+              "type": "StringMap",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-CIS_1.4.0_1.3",
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlCIS15": {
+      "Condition": "Enable15Condition",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-CIS_1.2.0_1.5
+
+## What does this document do?
+This document establishes a default password policy.
+
+## Security Standards and Controls
+* CIS 1.5 - 1.11
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+## Output Parameters
+* Remediation.Output
+
+## Documentation Links
+* [CIS v1.2.0 1.5](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-1.5)
+* [CIS v1.2.0 1.6](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-1.6)
+* [CIS v1.2.0 1.7](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-1.7)
+* [CIS v1.2.0 1.8](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-1.8)
+* [CIS v1.2.0 1.9](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-1.9)
+* [CIS v1.2.0 1.10](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-1.10)
+* [CIS v1.2.0 1.11](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-1.11)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{Finding}}",
+                  "expected_control_id": [
+                    "1.5",
+                    "1.6",
+                    "1.7",
+                    "1.8",
+                    "1.9",
+                    "1.10",
+                    "1.11",
+                  ],
+                  "parse_id_pattern": "",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }",
+              },
+              "isEnd": false,
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-SetIAMPasswordPolicy",
+                "RuntimeParameters": {
+                  "AllowUsersToChangePassword": true,
+                  "AutomationAssumeRole": "arn:{{global:AWS_PARTITION}}:iam::{{global:ACCOUNT_ID}}:role/SO0111-SetIAMPasswordPolicy",
+                  "HardExpiry": true,
+                  "MaxPasswordAge": 90,
+                  "MinimumPasswordLength": 14,
+                  "PasswordReusePrevention": 24,
+                  "RequireLowercaseCharacters": true,
+                  "RequireNumbers": true,
+                  "RequireSymbols": true,
+                  "RequireUppercaseCharacters": true,
+                },
+              },
+              "isEnd": false,
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "description": "Update finding",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ParseInput.FindingId}}",
+                    "ProductArn": "{{ParseInput.ProductArn}}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Established a baseline password policy using the AWSConfigRemediation-SetIAMPasswordPolicy runbook.",
+                  "UpdatedBy": "ASR-CIS_1.2.0_1.5",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "ParseInput.AffectedObject",
+            "Remediation.Output",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the 1.5 finding",
+              "type": "StringMap",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-CIS_1.4.0_1.5",
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlCIS21": {
+      "Condition": "Enable21Condition",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-CIS_1.2.0_2.1
+
+## What does this document do?
+Creates a multi-region trail with KMS encryption and enables CloudTrail
+Note: this remediation will create a NEW trail.
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Documentation Links
+* [CIS v1.2.0 2.1](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-2.1)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{Finding}}",
+                  "expected_control_id": [
+                    "2.1",
+                  ],
+                  "parse_id_pattern": "",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }",
+              },
+              "isEnd": false,
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "ResourceId",
+                  "Selector": "$.Payload.resource_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "AWSPartition",
+                  "Selector": "$.Payload.partition",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-CreateCloudTrailMultiRegionTrail",
+                "RuntimeParameters": {
+                  "AWSPartition": "{{global:AWS_PARTITION}}",
+                  "AutomationAssumeRole": "arn:{{global:AWS_PARTITION}}:iam::{{global:ACCOUNT_ID}}:role/SO0111-CreateCloudTrailMultiRegionTrail",
+                },
+              },
+              "isEnd": false,
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "description": "Update finding",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ParseInput.FindingId}}",
+                    "ProductArn": "{{ParseInput.ProductArn}}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Multi-region, encrypted AWS CloudTrail successfully created",
+                  "UpdatedBy": "ASR-CIS_1.2.0_2.11",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the 2.1 finding",
+              "type": "StringMap",
+            },
+            "KMSKeyArn": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):kms:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:(?:(?:alias/[A-Za-z0-9/-_])|(?:key/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})))$",
+              "default": "{{ssm:/Solutions/SO0111/CMK_REMEDIATION_ARN}}",
+              "description": "The ARN of the KMS key created by ASR for this remediation",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-CIS_1.4.0_2.1",
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "RemapCIS4245EB49A0": {
+      "Properties": {
+        "Description": "Remap the CIS 4.2 finding to CIS 4.1 remediation",
+        "Name": "/Solutions/SO0111/cis-aws-foundations-benchmark/1.4.0-4.2",
+        "Type": "String",
+        "Value": "4.1",
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+  },
+}
+`;

--- a/source/playbooks/CIS140/test/cis_stack.test.ts
+++ b/source/playbooks/CIS140/test/cis_stack.test.ts
@@ -1,15 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { SynthUtils } from '@aws-cdk/assert';
-import * as cdk from 'aws-cdk-lib';
+import { App, DefaultStackSynthesizer, Stack } from 'aws-cdk-lib';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
+import { Template } from 'aws-cdk-lib/assertions';
 import { PlaybookPrimaryStack, PlaybookMemberStack } from '../../../lib/sharrplaybook-construct';
 
 const RESOURCE_PREFIX = 'SO0111';
 
-function getPrimaryStack(): cdk.Stack {
-  const app = new cdk.App();
+function getPrimaryStack(): Stack {
+  const app = new App();
   const stack = new PlaybookPrimaryStack(app, 'primaryStack', {
+    synthesizer: new DefaultStackSynthesizer({ generateBootstrapVersionRule: false }),
     description: 'test;',
     solutionId: 'SO0111',
     solutionVersion: 'v1.1.1',
@@ -24,12 +25,13 @@ function getPrimaryStack(): cdk.Stack {
 }
 
 test('default stack', () => {
-  expect(SynthUtils.toCloudFormation(getPrimaryStack())).toMatchSnapshot();
+  expect(Template.fromStack(getPrimaryStack())).toMatchSnapshot();
 });
 
-function getMemberStack(): cdk.Stack {
-  const app = new cdk.App();
+function getMemberStack(): Stack {
+  const app = new App();
   const stack = new PlaybookMemberStack(app, 'memberStack', {
+    synthesizer: new DefaultStackSynthesizer({ generateBootstrapVersionRule: false }),
     description: 'test;',
     solutionId: 'SO0111',
     solutionVersion: 'v1.1.1',
@@ -51,5 +53,5 @@ function getMemberStack(): cdk.Stack {
 }
 
 test('default stack', () => {
-  expect(SynthUtils.toCloudFormation(getMemberStack())).toMatchSnapshot();
+  expect(Template.fromStack(getMemberStack())).toMatchSnapshot();
 });

--- a/source/playbooks/NEWPLAYBOOK/test/__snapshots__/newplaybook_stack.test.ts.snap
+++ b/source/playbooks/NEWPLAYBOOK/test/__snapshots__/newplaybook_stack.test.ts.snap
@@ -1,0 +1,730 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`admin stack 1`] = `
+{
+  "Description": "test;",
+  "Mappings": {
+    "SourceCode": {
+      "General": {
+        "KeyPrefix": "aws-security-hub-automated-response-and-remediation/v1.1.1",
+        "S3Bucket": "sharrbukkit",
+      },
+    },
+  },
+  "Parameters": {
+    "PCI321Example1AutoTrigger": {
+      "AllowedValues": [
+        "ENABLED",
+        "DISABLED",
+      ],
+      "Default": "DISABLED",
+      "Description": "This will fully enable automated remediation for PCI 3.2.1 Example.1",
+      "Type": "String",
+    },
+    "PCI321Example3AutoTrigger": {
+      "AllowedValues": [
+        "ENABLED",
+        "DISABLED",
+      ],
+      "Default": "DISABLED",
+      "Description": "This will fully enable automated remediation for PCI 3.2.1 Example.3",
+      "Type": "String",
+    },
+    "PCI321Example5AutoTrigger": {
+      "AllowedValues": [
+        "ENABLED",
+        "DISABLED",
+      ],
+      "Default": "DISABLED",
+      "Description": "This will fully enable automated remediation for PCI 3.2.1 Example.5",
+      "Type": "String",
+    },
+    "SsmParameterValueSolutionsSO0111OrchestratorArnC96584B6F00A464EAD1953AFF4B05118Parameter": {
+      "Default": "/Solutions/SO0111/OrchestratorArn",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "PCIExample1AutoEventRule6C982301": {
+      "Properties": {
+        "Description": "Remediate PCI 3.2.1 Example.1 automatic remediation trigger event rule.",
+        "EventPattern": {
+          "detail": {
+            "findings": {
+              "Compliance": {
+                "Status": [
+                  "FAILED",
+                  "WARNING",
+                ],
+              },
+              "GeneratorId": [
+                "pci-dss/v/3.2.1/Example.1",
+              ],
+              "RecordState": [
+                "ACTIVE",
+              ],
+              "Workflow": {
+                "Status": [
+                  "NEW",
+                ],
+              },
+            },
+          },
+          "detail-type": [
+            "Security Hub Findings - Imported",
+          ],
+          "source": [
+            "aws.securityhub",
+          ],
+        },
+        "Name": "PCI_3.2.1_Example.1_AutoTrigger",
+        "State": {
+          "Ref": "PCI321Example1AutoTrigger",
+        },
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "SsmParameterValueSolutionsSO0111OrchestratorArnC96584B6F00A464EAD1953AFF4B05118Parameter",
+            },
+            "Id": "Target0",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "PCIExample1EventsRuleRoleD486082E",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "PCIExample1EventsRuleRoleD486082E": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "PCIExample1EventsRuleRoleDefaultPolicyE4F7D24C": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "states:StartExecution",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "SsmParameterValueSolutionsSO0111OrchestratorArnC96584B6F00A464EAD1953AFF4B05118Parameter",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "PCIExample1EventsRuleRoleDefaultPolicyE4F7D24C",
+        "Roles": [
+          {
+            "Ref": "PCIExample1EventsRuleRoleD486082E",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "PCIExample3AutoEventRule3C7AABD6": {
+      "Properties": {
+        "Description": "Remediate PCI 3.2.1 Example.3 automatic remediation trigger event rule.",
+        "EventPattern": {
+          "detail": {
+            "findings": {
+              "Compliance": {
+                "Status": [
+                  "FAILED",
+                  "WARNING",
+                ],
+              },
+              "GeneratorId": [
+                "pci-dss/v/3.2.1/Example.3",
+              ],
+              "RecordState": [
+                "ACTIVE",
+              ],
+              "Workflow": {
+                "Status": [
+                  "NEW",
+                ],
+              },
+            },
+          },
+          "detail-type": [
+            "Security Hub Findings - Imported",
+          ],
+          "source": [
+            "aws.securityhub",
+          ],
+        },
+        "Name": "PCI_3.2.1_Example.3_AutoTrigger",
+        "State": {
+          "Ref": "PCI321Example3AutoTrigger",
+        },
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "SsmParameterValueSolutionsSO0111OrchestratorArnC96584B6F00A464EAD1953AFF4B05118Parameter",
+            },
+            "Id": "Target0",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "PCIExample3EventsRuleRoleA99F7A6B",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "PCIExample3EventsRuleRoleA99F7A6B": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "PCIExample3EventsRuleRoleDefaultPolicyA3E0C4E3": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "states:StartExecution",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "SsmParameterValueSolutionsSO0111OrchestratorArnC96584B6F00A464EAD1953AFF4B05118Parameter",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "PCIExample3EventsRuleRoleDefaultPolicyA3E0C4E3",
+        "Roles": [
+          {
+            "Ref": "PCIExample3EventsRuleRoleA99F7A6B",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "PCIExample5AutoEventRuleDA18E2FE": {
+      "Properties": {
+        "Description": "Remediate PCI 3.2.1 Example.5 automatic remediation trigger event rule.",
+        "EventPattern": {
+          "detail": {
+            "findings": {
+              "Compliance": {
+                "Status": [
+                  "FAILED",
+                  "WARNING",
+                ],
+              },
+              "GeneratorId": [
+                "pci-dss/v/3.2.1/Example.5",
+              ],
+              "RecordState": [
+                "ACTIVE",
+              ],
+              "Workflow": {
+                "Status": [
+                  "NEW",
+                ],
+              },
+            },
+          },
+          "detail-type": [
+            "Security Hub Findings - Imported",
+          ],
+          "source": [
+            "aws.securityhub",
+          ],
+        },
+        "Name": "PCI_3.2.1_Example.5_AutoTrigger",
+        "State": {
+          "Ref": "PCI321Example5AutoTrigger",
+        },
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "SsmParameterValueSolutionsSO0111OrchestratorArnC96584B6F00A464EAD1953AFF4B05118Parameter",
+            },
+            "Id": "Target0",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "PCIExample5EventsRuleRole5B9B7CC6",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "PCIExample5EventsRuleRole5B9B7CC6": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "PCIExample5EventsRuleRoleDefaultPolicy1043BED1": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "states:StartExecution",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "SsmParameterValueSolutionsSO0111OrchestratorArnC96584B6F00A464EAD1953AFF4B05118Parameter",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "PCIExample5EventsRuleRoleDefaultPolicy1043BED1",
+        "Roles": [
+          {
+            "Ref": "PCIExample5EventsRuleRole5B9B7CC6",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "StandardVersionCB2C6951": {
+      "Properties": {
+        "Description": "This parameter controls whether the SHARR step function will process findings for this version of the standard.",
+        "Name": "/Solutions/SO0111/pci-dss/3.2.1/status",
+        "Type": "String",
+        "Value": "enabled",
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+  },
+}
+`;
+
+exports[`member stack 1`] = `
+{
+  "Conditions": {
+    "EnableRDS6Condition": {
+      "Fn::Equals": [
+        {
+          "Ref": "EnableRDS6",
+        },
+        "Available",
+      ],
+    },
+  },
+  "Description": "test;",
+  "Parameters": {
+    "EnableRDS6": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for NPB version 3.2.1 Control RDS.6 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "SecHubAdminAccount": {
+      "AllowedPattern": "\\d{12}",
+      "Description": "Admin account number",
+      "Type": "String",
+    },
+  },
+  "Resources": {
+    "ControlNPBRDS6": {
+      "Condition": "EnableRDS6Condition",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASRRemediation-AFSBP_RDS.6
+
+## What does this document do?
+This document enables \`Enhanced Monitoring\` on a given Amazon RDS instance by calling another SSM document.
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Output Parameters
+* VerifyRemediation.Output - The standard HTTP response from the ModifyDBInstance API.
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{Finding}}",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }",
+              },
+              "isEnd": false,
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "ResourceId",
+                  "Selector": "$.Payload.resource_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "description": "## GetRole API to get EnhancedMonitoring IAM role ARN
+",
+              "inputs": {
+                "Api": "GetRole",
+                "RoleName": "SO0111-ASR-RDSEnhancedMonitoring",
+                "Service": "iam",
+              },
+              "isEnd": false,
+              "name": "GetMonitoringRoleArn",
+              "outputs": [
+                {
+                  "Name": "Arn",
+                  "Selector": "$.Role.Arn",
+                  "Type": "String",
+                },
+              ],
+              "timeoutSeconds": 600,
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "AWSConfigRemediation-EnableEnhancedMonitoringOnRDSInstance",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "{{ AutomationAssumeRole }}",
+                  "MonitoringRoleArn": "{{GetMonitoringRoleArn.Arn}}",
+                  "ResourceId": "{{ ParseInput.ResourceId }}",
+                },
+              },
+              "isEnd": false,
+              "name": "ExecRemediation",
+            },
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "verify_remediation",
+                "InputPayload": {
+                  "remediation_output": "{{ExecRemediation.Output}}",
+                },
+                "Runtime": "python3.8",
+                "Script": "import json
+
+def verify_remediation(event, context):
+  remediation_output = json.loads(event['remediation_output'][0])
+
+  if remediation_output.get('DBInstance').get('MonitoringInterval', 0) > 0:
+    return {
+      "response": {
+        "message": "Enhanced Monitoring enabled on database " + remediation_output['DBInstance']['DBInstanceIdentifier'],
+        "status": "Success"
+      }
+    }",
+              },
+              "name": "VerifyRemediation",
+              "outputs": [
+                {
+                  "Name": "Output",
+                  "Selector": "$.Payload.response",
+                  "Type": "StringMap",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "description": "Update finding",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ParseInput.FindingId}}",
+                    "ProductArn": "{{ParseInput.ProductArn}}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Deletion protection enabled on RDS DB cluster",
+                  "UpdatedBy": "ASRRemediation-AFSBP_RDS.7",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "VerifyRemediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from Step function for RDS7 finding",
+              "type": "StringMap",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-NPB_3.2.1_RDS.6",
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+  },
+}
+`;

--- a/source/playbooks/NEWPLAYBOOK/test/newplaybook_stack.test.ts
+++ b/source/playbooks/NEWPLAYBOOK/test/newplaybook_stack.test.ts
@@ -1,12 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { SynthUtils } from '@aws-cdk/assert';
-import * as cdk from 'aws-cdk-lib';
+import { App, DefaultStackSynthesizer, Stack } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
 import { PlaybookPrimaryStack, PlaybookMemberStack } from '../../../lib/sharrplaybook-construct';
 
-function getTestStack(): cdk.Stack {
-  const app = new cdk.App();
+function getTestStack(): Stack {
+  const app = new App();
   const stack = new PlaybookPrimaryStack(app, 'stack', {
+    synthesizer: new DefaultStackSynthesizer({ generateBootstrapVersionRule: false }),
     description: 'test;',
     solutionId: 'SO0111',
     solutionVersion: 'v1.1.1',
@@ -20,26 +21,28 @@ function getTestStack(): cdk.Stack {
   return stack;
 }
 
-test('default stack', () => {
-  expect(SynthUtils.toCloudFormation(getTestStack())).toMatchSnapshot();
+test('admin stack', () => {
+  expect(Template.fromStack(getTestStack())).toMatchSnapshot();
 });
 
-function getMemberStack(): cdk.Stack {
-  const app = new cdk.App();
+function getMemberStack(): Stack {
+  const app = new App();
   const stack = new PlaybookMemberStack(app, 'memberStack', {
+    synthesizer: new DefaultStackSynthesizer({ generateBootstrapVersionRule: false }),
     description: 'test;',
     solutionId: 'SO0111',
     solutionVersion: 'v1.1.1',
     solutionDistBucket: 'sharrbukkit',
     ssmdocs: 'playbooks/NEWPLAYBOOK/ssmdocs',
-    remediations: [{ control: 'Example.3' }, { control: 'Example.5' }, { control: 'Example.1' }],
-    securityStandard: 'PCI',
-    securityStandardLongName: 'pci-dss',
+    remediations: [{ control: 'RDS.6' }],
+    securityStandard: 'NPB',
+    securityStandardLongName: 'newplaybook',
     securityStandardVersion: '3.2.1',
+    commonScripts: 'playbooks/common',
   });
   return stack;
 }
 
-test('default stack', () => {
-  expect(SynthUtils.toCloudFormation(getMemberStack())).toMatchSnapshot();
+test('member stack', () => {
+  expect(Template.fromStack(getMemberStack())).toMatchSnapshot();
 });

--- a/source/playbooks/PCI321/test/pci321_stack.test.ts
+++ b/source/playbooks/PCI321/test/pci321_stack.test.ts
@@ -1,12 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { SynthUtils } from '@aws-cdk/assert';
-import * as cdk from 'aws-cdk-lib';
+import { App, DefaultStackSynthesizer, Stack } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
 import { PlaybookPrimaryStack, PlaybookMemberStack } from '../../../lib/sharrplaybook-construct';
 
-function getTestStack(): cdk.Stack {
-  const app = new cdk.App();
+function getTestStack(): Stack {
+  const app = new App();
   const stack = new PlaybookPrimaryStack(app, 'stack', {
+    synthesizer: new DefaultStackSynthesizer({ generateBootstrapVersionRule: false }),
     description: 'test;',
     solutionId: 'SO0111',
     solutionVersion: 'v1.1.1',
@@ -21,12 +22,13 @@ function getTestStack(): cdk.Stack {
 }
 
 test('default stack', () => {
-  expect(SynthUtils.toCloudFormation(getTestStack())).toMatchSnapshot();
+  expect(Template.fromStack(getTestStack())).toMatchSnapshot();
 });
 
-function getMemberStack(): cdk.Stack {
-  const app = new cdk.App();
+function getMemberStack(): Stack {
+  const app = new App();
   const stack = new PlaybookMemberStack(app, 'memberStack', {
+    synthesizer: new DefaultStackSynthesizer({ generateBootstrapVersionRule: false }),
     description: 'test;',
     solutionId: 'SO0111',
     solutionVersion: 'v1.1.1',
@@ -42,5 +44,5 @@ function getMemberStack(): cdk.Stack {
 }
 
 test('default stack', () => {
-  expect(SynthUtils.toCloudFormation(getMemberStack())).toMatchSnapshot();
+  expect(Template.fromStack(getMemberStack())).toMatchSnapshot();
 });

--- a/source/playbooks/SC/test/__snapshots__/security_controls_stack.test.ts.snap
+++ b/source/playbooks/SC/test/__snapshots__/security_controls_stack.test.ts.snap
@@ -1,0 +1,16111 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`admin stack 1`] = `
+{
+  "Description": "test;",
+  "Parameters": {
+    "SC200Example1AutoTrigger": {
+      "AllowedValues": [
+        "ENABLED",
+        "DISABLED",
+      ],
+      "Default": "DISABLED",
+      "Description": "This will fully enable automated remediation for SC 2.0.0 Example.1",
+      "Type": "String",
+    },
+    "SC200Example3AutoTrigger": {
+      "AllowedValues": [
+        "ENABLED",
+        "DISABLED",
+      ],
+      "Default": "DISABLED",
+      "Description": "This will fully enable automated remediation for SC 2.0.0 Example.3",
+      "Type": "String",
+    },
+    "SC200Example5AutoTrigger": {
+      "AllowedValues": [
+        "ENABLED",
+        "DISABLED",
+      ],
+      "Default": "DISABLED",
+      "Description": "This will fully enable automated remediation for SC 2.0.0 Example.5",
+      "Type": "String",
+    },
+    "SsmParameterValueSolutionsSO0111OrchestratorArnC96584B6F00A464EAD1953AFF4B05118Parameter": {
+      "Default": "/Solutions/SO0111/OrchestratorArn",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "SCExample1AutoEventRule34C9623C": {
+      "Properties": {
+        "Description": "Remediate SC 2.0.0 Example.1 automatic remediation trigger event rule.",
+        "EventPattern": {
+          "detail": {
+            "findings": {
+              "Compliance": {
+                "Status": [
+                  "FAILED",
+                  "WARNING",
+                ],
+              },
+              "GeneratorId": [
+                "control/Example.1",
+              ],
+              "RecordState": [
+                "ACTIVE",
+              ],
+              "Workflow": {
+                "Status": [
+                  "NEW",
+                ],
+              },
+            },
+          },
+          "detail-type": [
+            "Security Hub Findings - Imported",
+          ],
+          "source": [
+            "aws.securityhub",
+          ],
+        },
+        "Name": "SC_2.0.0_Example.1_AutoTrigger",
+        "State": {
+          "Ref": "SC200Example1AutoTrigger",
+        },
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "SsmParameterValueSolutionsSO0111OrchestratorArnC96584B6F00A464EAD1953AFF4B05118Parameter",
+            },
+            "Id": "Target0",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "SCExample1EventsRuleRole4E88085F",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "SCExample1EventsRuleRole4E88085F": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "SCExample1EventsRuleRoleDefaultPolicyCA403208": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "states:StartExecution",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "SsmParameterValueSolutionsSO0111OrchestratorArnC96584B6F00A464EAD1953AFF4B05118Parameter",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "SCExample1EventsRuleRoleDefaultPolicyCA403208",
+        "Roles": [
+          {
+            "Ref": "SCExample1EventsRuleRole4E88085F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "SCExample3AutoEventRule21EE1ACB": {
+      "Properties": {
+        "Description": "Remediate SC 2.0.0 Example.3 automatic remediation trigger event rule.",
+        "EventPattern": {
+          "detail": {
+            "findings": {
+              "Compliance": {
+                "Status": [
+                  "FAILED",
+                  "WARNING",
+                ],
+              },
+              "GeneratorId": [
+                "control/Example.3",
+              ],
+              "RecordState": [
+                "ACTIVE",
+              ],
+              "Workflow": {
+                "Status": [
+                  "NEW",
+                ],
+              },
+            },
+          },
+          "detail-type": [
+            "Security Hub Findings - Imported",
+          ],
+          "source": [
+            "aws.securityhub",
+          ],
+        },
+        "Name": "SC_2.0.0_Example.3_AutoTrigger",
+        "State": {
+          "Ref": "SC200Example3AutoTrigger",
+        },
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "SsmParameterValueSolutionsSO0111OrchestratorArnC96584B6F00A464EAD1953AFF4B05118Parameter",
+            },
+            "Id": "Target0",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "SCExample3EventsRuleRole1761FED0",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "SCExample3EventsRuleRole1761FED0": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "SCExample3EventsRuleRoleDefaultPolicy6D141B89": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "states:StartExecution",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "SsmParameterValueSolutionsSO0111OrchestratorArnC96584B6F00A464EAD1953AFF4B05118Parameter",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "SCExample3EventsRuleRoleDefaultPolicy6D141B89",
+        "Roles": [
+          {
+            "Ref": "SCExample3EventsRuleRole1761FED0",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "SCExample5AutoEventRule174B7EFF": {
+      "Properties": {
+        "Description": "Remediate SC 2.0.0 Example.5 automatic remediation trigger event rule.",
+        "EventPattern": {
+          "detail": {
+            "findings": {
+              "Compliance": {
+                "Status": [
+                  "FAILED",
+                  "WARNING",
+                ],
+              },
+              "GeneratorId": [
+                "control/Example.5",
+              ],
+              "RecordState": [
+                "ACTIVE",
+              ],
+              "Workflow": {
+                "Status": [
+                  "NEW",
+                ],
+              },
+            },
+          },
+          "detail-type": [
+            "Security Hub Findings - Imported",
+          ],
+          "source": [
+            "aws.securityhub",
+          ],
+        },
+        "Name": "SC_2.0.0_Example.5_AutoTrigger",
+        "State": {
+          "Ref": "SC200Example5AutoTrigger",
+        },
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "SsmParameterValueSolutionsSO0111OrchestratorArnC96584B6F00A464EAD1953AFF4B05118Parameter",
+            },
+            "Id": "Target0",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "SCExample5EventsRuleRole568252F1",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "SCExample5EventsRuleRole568252F1": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "SCExample5EventsRuleRoleDefaultPolicy179ECE2B": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "states:StartExecution",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "SsmParameterValueSolutionsSO0111OrchestratorArnC96584B6F00A464EAD1953AFF4B05118Parameter",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "SCExample5EventsRuleRoleDefaultPolicy179ECE2B",
+        "Roles": [
+          {
+            "Ref": "SCExample5EventsRuleRole568252F1",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "StandardVersionCB2C6951": {
+      "Properties": {
+        "Description": "This parameter controls whether the SHARR step function will process findings for this version of the standard.",
+        "Name": "/Solutions/SO0111/security-control/2.0.0/status",
+        "Type": "String",
+        "Value": "enabled",
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+  },
+}
+`;
+
+exports[`member stack 1`] = `
+{
+  "Conditions": {
+    "ControlRunbooksEnableAutoScaling1ConditionD5DF4981": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableAutoScaling1851AF8B0",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableCloudFormation1ConditionD8D32097": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableCloudFormation1B75725BB",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableCloudTrail1ConditionB7EBAA86": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableCloudTrail1F0F927F7",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableCloudTrail2ConditionC182A10F": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableCloudTrail28CC248AB",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableCloudTrail4Condition587734A2": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableCloudTrail4040C6EAB",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableCloudTrail5Condition17B6B536": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableCloudTrail52CBFD019",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableCloudTrail6Condition486CC2C3": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableCloudTrail63394AC2B",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableCloudTrail7ConditionA4FF88B2": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableCloudTrail7FFC8DAB9",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableCloudWatch1ConditionAB0DF2E5": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableCloudWatch19BE65F2B",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableCodeBuild2ConditionB01F473D": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableCodeBuild26FB6E539",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableConfig1Condition8CEB8627": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableConfig19F6E6FE3",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableEC213Condition567EA275": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableEC21349FA0A79",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableEC215Condition52A7DE4B": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableEC215DA64A549",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableEC21ConditionD4F1277B": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableEC21395C7891",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableEC22ConditionB9E0D42E": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableEC22F9B66A60",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableEC26ConditionF1F880B0": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableEC265685AB83",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableEC27ConditionC77CF056": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableEC27108F6303",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableIAM3Condition3AA0E892": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableIAM35D05519D",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableIAM7ConditionDF8E776B": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableIAM766CB4E0A",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableIAM8Condition9CA5CB4B": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableIAM834577BE3",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableKMS4Condition710C0C5C": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableKMS415F4485B",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableLambda1Condition077CECAF": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableLambda11AAE99FF",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableRDS13Condition0E8A44B3": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableRDS13F10477DD",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableRDS16ConditionCB5C3E8F": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableRDS16F428962C",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableRDS1ConditionFAE5B7EA": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableRDS18380A289",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableRDS2Condition4FD00FE6": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableRDS2004A67EB",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableRDS4Condition2E89346E": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableRDS4E2A98B6D",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableRDS5ConditionEC2574C3": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableRDS59E051E8F",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableRDS6Condition4A60A39B": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableRDS6C46B2207",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableRDS7ConditionE53509B0": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableRDS7CEA605AE",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableRDS8Condition8F460AB5": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableRDS8FBE41D2B",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableRedshift1Condition3449D560": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableRedshift1E5BFAC24",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableRedshift3ConditionC65BAEF6": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableRedshift39346F065",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableRedshift4Condition2377F6B5": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableRedshift40FBDF0D8",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableRedshift6Condition5A51FC97": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableRedshift648AC3FBB",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableS31Condition25C33B3F": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableS3116A23B93",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableS32ConditionD6F8CCE9": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableS325CF1F81C",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableS34ConditionC23F6623": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableS348078AE21",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableS35ConditionD5E024B6": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableS35B965D7F6",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableS36ConditionD22273E2": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableS36B92F84BB",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableSNS1Condition7720D1CC": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableSNS1B5923950",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableSNS2Condition69621468": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableSNS232380485",
+        },
+        "Available",
+      ],
+    },
+    "ControlRunbooksEnableSQS1Condition3065B4F2": {
+      "Fn::Equals": [
+        {
+          "Ref": "ControlRunbooksEnableSQS1A400C913",
+        },
+        "Available",
+      ],
+    },
+  },
+  "Description": "test;",
+  "Parameters": {
+    "ControlRunbooksEnableAutoScaling1851AF8B0": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control AutoScaling.1 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableCloudFormation1B75725BB": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control CloudFormation.1 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableCloudTrail1F0F927F7": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control CloudTrail.1 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableCloudTrail28CC248AB": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control CloudTrail.2 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableCloudTrail4040C6EAB": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control CloudTrail.4 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableCloudTrail52CBFD019": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control CloudTrail.5 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableCloudTrail63394AC2B": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control CloudTrail.6 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableCloudTrail7FFC8DAB9": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control CloudTrail.7 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableCloudWatch19BE65F2B": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control CloudWatch.1 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableCodeBuild26FB6E539": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control CodeBuild.2 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableConfig19F6E6FE3": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control Config.1 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableEC21349FA0A79": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control EC2.13 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableEC21395C7891": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control EC2.1 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableEC215DA64A549": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control EC2.15 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableEC22F9B66A60": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control EC2.2 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableEC265685AB83": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control EC2.6 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableEC27108F6303": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control EC2.7 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableIAM35D05519D": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control IAM.3 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableIAM766CB4E0A": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control IAM.7 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableIAM834577BE3": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control IAM.8 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableKMS415F4485B": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control KMS.4 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableLambda11AAE99FF": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control Lambda.1 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableRDS13F10477DD": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control RDS.13 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableRDS16F428962C": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control RDS.16 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableRDS18380A289": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control RDS.1 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableRDS2004A67EB": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control RDS.2 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableRDS4E2A98B6D": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control RDS.4 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableRDS59E051E8F": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control RDS.5 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableRDS6C46B2207": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control RDS.6 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableRDS7CEA605AE": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control RDS.7 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableRDS8FBE41D2B": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control RDS.8 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableRedshift1E5BFAC24": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control Redshift.1 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableRedshift39346F065": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control Redshift.3 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableRedshift40FBDF0D8": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control Redshift.4 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableRedshift648AC3FBB": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control Redshift.6 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableS3116A23B93": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control S3.1 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableS325CF1F81C": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control S3.2 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableS348078AE21": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control S3.4 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableS35B965D7F6": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control S3.5 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableS36B92F84BB": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control S3.6 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableSNS1B5923950": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control SNS.1 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableSNS232380485": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control SNS.2 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "ControlRunbooksEnableSQS1A400C913": {
+      "AllowedValues": [
+        "Available",
+        "NOT Available",
+      ],
+      "Default": "Available",
+      "Description": "Enable/disable availability of remediation for pci-dss version 3.2.1 Control SQS.1 in Security Hub Console Custom Actions. If NOT Available the remediation cannot be triggered from the Security Hub console in the Security Hub Admin account.",
+      "Type": "String",
+    },
+    "SecHubAdminAccount": {
+      "AllowedPattern": "\\d{12}",
+      "Description": "Admin account number",
+      "Type": "String",
+    },
+  },
+  "Resources": {
+    "ControlRunbooksAutoScaling1BA109277": {
+      "Condition": "ControlRunbooksEnableAutoScaling1ConditionD5DF4981",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_AutoScaling.1
+
+## What does this document do?
+This document enables ELB healthcheck on a given AutoScaling Group using the [UpdateAutoScalingGroup] API.
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* HealthCheckGracePeriod: (Optional) Health check grace period when ELB health check is Enabled
+Default: 30 seconds
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Output Parameters
+* Remediation.Output
+
+## Documentation Links
+* [AFSBP AutoScaling.1](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-autoscaling-1)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "AutoScaling.1",
+                  ],
+                  "parse_id_pattern": "^arn:(?:aws|aws-cn|aws-us-gov):autoscaling:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:autoScalingGroup:(?:[0-9a-fA-F]{11}-(?:[0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}):autoScalingGroupName\\/(.*)$",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "AutoScalingGroupName",
+                  "Selector": "$.Payload.resource_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationAccount",
+                  "Selector": "$.Payload.account_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationRegion",
+                  "Selector": "$.Payload.resource_region",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-EnableAutoScalingGroupELBHealthCheck",
+                "RuntimeParameters": {
+                  "AutoScalingGroupName": "{{ ParseInput.AutoScalingGroupName }}",
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                },
+                "TargetLocations": [
+                  {
+                    "Accounts": [
+                      "{{ ParseInput.RemediationAccount }}",
+                    ],
+                    "ExecutionRoleName": "{{ RemediationRoleName }}",
+                    "Regions": [
+                      "{{ ParseInput.RemediationRegion }}",
+                    ],
+                  },
+                ],
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "ASG health check type updated to ELB",
+                  "UpdatedBy": "ASR-PCI_3.2.1_AutoScaling.1",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the AutoScaling.1 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-EnableAutoScalingGroupELBHealthCheck",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_AutoScaling.1",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksCloudFormation12CB945DB": {
+      "Condition": "ControlRunbooksEnableCloudFormation1ConditionD8D32097",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_CloudFormation.1
+
+## What does this document do?
+This document configures an SNS topic for notifications from a CloudFormation stack by calling another document.
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Output Parameters
+* Remediation.Output
+
+## Documentation Links
+* [AFSBP v1.0.0 CloudFormation.1](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-cloudformation-1)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "CloudFormation.1",
+                  ],
+                  "parse_id_pattern": "^(arn:(?:aws|aws-us-gov|aws-cn):cloudformation:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:stack/[a-zA-Z][a-zA-Z0-9-]{0,127}/[a-fA-F0-9]{8}-(?:[a-fA-F0-9]{4}-){3}[a-fA-F0-9]{12})$",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "StackArn",
+                  "Selector": "$.Payload.resource_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationAccount",
+                  "Selector": "$.Payload.account_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationRegion",
+                  "Selector": "$.Payload.resource_region",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-ConfigureSNSTopicForStack",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "StackArn": "{{ ParseInput.StackArn }}",
+                },
+                "TargetLocations": [
+                  {
+                    "Accounts": [
+                      "{{ ParseInput.RemediationAccount }}",
+                    ],
+                    "ExecutionRoleName": "{{ RemediationRoleName }}",
+                    "Regions": [
+                      "{{ ParseInput.RemediationRegion }}",
+                    ],
+                  },
+                ],
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Configured SNS topic for notifications",
+                  "UpdatedBy": "ASR-PCI_3.2.1_CloudFormation.1",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the CloudFormation.1 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-ConfigureSNSTopicForStack",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_CloudFormation.1",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksCloudTrail1B15F1A13": {
+      "Condition": "ControlRunbooksEnableCloudTrail1ConditionB7EBAA86",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_CloudTrail.1
+## What does this document do?
+Creates a multi-region trail with KMS encryption and enables CloudTrail
+Note: this remediation will create a NEW trail.
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Documentation Links
+* [AFSBP CloudTrail.1](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-cloudtrail-1)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "CloudTrail.1",
+                  ],
+                  "parse_id_pattern": "",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-CreateCloudTrailMultiRegionTrail",
+                "RuntimeParameters": {
+                  "AWSPartition": "{{ global:AWS_PARTITION }}",
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                },
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Multi-region, encrypted AWS CloudTrail successfully created",
+                  "UpdatedBy": "ASR-PCI_3.2.1_CloudTrail.1",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the CloudTrail.1 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-CreateCloudTrailMultiRegionTrail",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_CloudTrail.1",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksCloudTrail2979D0B5D": {
+      "Condition": "ControlRunbooksEnableCloudTrail2ConditionC182A10F",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_CloudTrail.2
+## What does this document do?
+This document enables SSE KMS encryption for log files using the ASR remediation KMS CMK
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+## Output Parameters
+* Remediation.Output - Output from the remediation
+
+## Documentation Links
+* [AFSBP CloudTrail.2](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-cloudtrail-2)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "CloudTrail.2",
+                  ],
+                  "parse_id_pattern": "",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "TrailArn",
+                  "Selector": "$.Payload.resource_id",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-EnableCloudTrailEncryption",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "KMSKeyArn": "{{ KMSKeyArn }}",
+                  "TrailArn": "{{ ParseInput.TrailArn }}",
+                  "TrailRegion": "{{ ParseInput.RemediationRegion }}",
+                },
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Encryption enabled on CloudTrail",
+                  "UpdatedBy": "ASR-PCI_3.2.1_CloudTrail.2",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the CloudTrail.2 finding",
+              "type": "StringMap",
+            },
+            "KMSKeyArn": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):kms:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:(?:(?:alias\\/[A-Za-z0-9/_-])|(?:key\\/(?:[0-9a-fA-F]{8}-(?:[0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12})))$",
+              "default": "{{ssm:/Solutions/SO0111/CMK_REMEDIATION_ARN}}",
+              "type": "String",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-EnableCloudTrailEncryption",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_CloudTrail.2",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksCloudTrail4057F669F": {
+      "Condition": "ControlRunbooksEnableCloudTrail4Condition587734A2",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_CloudTrail.4
+
+## What does this document do?
+This document enables CloudTrail log file validation.
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Output Parameters
+* Remediation.Output
+
+## Documentation Links
+* [AFSBP v1.0.0 CloudTrail.4](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-cloudtrail-4)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "CloudTrail.4",
+                  ],
+                  "parse_id_pattern": "^arn:(?:aws|aws-cn|aws-us-gov):cloudtrail:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:trail\\/([A-Za-z0-9._-]{3,128})$",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "TrailName",
+                  "Selector": "$.Payload.resource_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationAccount",
+                  "Selector": "$.Payload.account_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationRegion",
+                  "Selector": "$.Payload.resource_region",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-EnableCloudTrailLogFileValidation",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "TrailName": "{{ ParseInput.TrailName }}",
+                },
+                "TargetLocations": [
+                  {
+                    "Accounts": [
+                      "{{ ParseInput.RemediationAccount }}",
+                    ],
+                    "ExecutionRoleName": "{{ RemediationRoleName }}",
+                    "Regions": [
+                      "{{ ParseInput.RemediationRegion }}",
+                    ],
+                  },
+                ],
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Enabled CloudTrail log file validation.",
+                  "UpdatedBy": "ASR-PCI_3.2.1_CloudTrail.4",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the CloudTrail.4 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-EnableCloudTrailLogFileValidation",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_CloudTrail.4",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksCloudTrail54F5ED8E4": {
+      "Condition": "ControlRunbooksEnableCloudTrail5Condition17B6B536",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_CloudTrail.5
+
+## What does this document do?
+This document configures CloudTrail to log to CloudWatch Logs.
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Output Parameters
+* Remediation.Output - Remediation results
+
+## Documentation Links
+* [AFSBP v1.0.0 CloudTrail.5](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-cloudtrail-5)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "CloudTrail.5",
+                  ],
+                  "parse_id_pattern": "^arn:(?:aws|aws-cn|aws-us-gov):cloudtrail:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:trail\\/([A-Za-z0-9._-]{3,128})$",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "TrailName",
+                  "Selector": "$.Payload.resource_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationAccount",
+                  "Selector": "$.Payload.account_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationRegion",
+                  "Selector": "$.Payload.resource_region",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-EnableCloudTrailToCloudWatchLogging",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "CloudWatchLogsRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/SO0111-CloudTrailToCloudWatchLogs",
+                  "LogGroupName": "CloudTrail/{{ ParseInput.TrailName }}",
+                  "TrailName": "{{ ParseInput.TrailName }}",
+                },
+                "TargetLocations": [
+                  {
+                    "Accounts": [
+                      "{{ ParseInput.RemediationAccount }}",
+                    ],
+                    "ExecutionRoleName": "{{ RemediationRoleName }}",
+                    "Regions": [
+                      "{{ ParseInput.RemediationRegion }}",
+                    ],
+                  },
+                ],
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Configured CloudTrail logging to CloudWatch Logs Group CloudTrail/{{ ParseInput.TrailName }}",
+                  "UpdatedBy": "ASR-PCI_3.2.1_CloudTrail.5",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the CloudTrail.5 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-EnableCloudTrailToCloudWatchLogging",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_CloudTrail.5",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksCloudTrail6526C5643": {
+      "Condition": "ControlRunbooksEnableCloudTrail6Condition486CC2C3",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-CIS_1.2.0_2.3
+
+## What does this document do?
+This document blocks public access to the CloudTrail S3 bucket.
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Output Parameters
+* Remediation.Output
+
+## Documentation Links
+* [CIS v1.2.0 2.3](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-2.3)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "CloudTrail.6",
+                  ],
+                  "parse_id_pattern": "^arn:(?:aws|aws-cn|aws-us-gov):s3:::([A-Za-z0-9.-]{3,63})$",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "BucketName",
+                  "Selector": "$.Payload.resource_id",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-ConfigureS3BucketPublicAccessBlock",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "BlockPublicAcls": true,
+                  "BlockPublicPolicy": true,
+                  "BucketName": "{{ ParseInput.BucketName }}",
+                  "IgnorePublicAcls": true,
+                  "RestrictPublicBuckets": true,
+                },
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Disabled public access to CloudTrail logs bucket.",
+                  "UpdatedBy": "ASR-PCI_3.2.1_CloudTrail.6",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the CloudTrail.6 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-ConfigureS3BucketPublicAccessBlock",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_CloudTrail.6",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksCloudTrail7C6D85038": {
+      "Condition": "ControlRunbooksEnableCloudTrail7ConditionA4FF88B2",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-CIS_1.2.0_2.6
+
+## What does this document do?
+Configures access logging for a CloudTrail S3 bucket.
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Output Parameters
+* Remediation.Output - Remediation results
+
+## Documentation Links
+* [CIS v1.2.0 2.6](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-2.6)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "CloudTrail.7",
+                  ],
+                  "parse_id_pattern": "^arn:(?:aws|aws-cn|aws-us-gov):s3:::([A-Za-z0-9.-]{3,63})$",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "BucketName",
+                  "Selector": "$.Payload.resource_id",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-CreateAccessLoggingBucket",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/SO0111-CreateAccessLoggingBucket",
+                  "BucketName": "so0111-cloudtrailaccesslogs-{{ global:ACCOUNT_ID }}-{{ global:REGION }}",
+                },
+              },
+              "name": "CreateAccessLoggingBucket",
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "AWS-ConfigureS3BucketLogging",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "BucketName": "{{ ParseInput.BucketName }}",
+                  "GrantedPermission": [
+                    "READ",
+                  ],
+                  "GranteeType": [
+                    "Group",
+                  ],
+                  "GranteeUri": [
+                    "http://acs.amazonaws.com/groups/s3/LogDelivery",
+                  ],
+                  "TargetBucket": [
+                    "so0111-cloudtrailaccesslogs-{{ global:ACCOUNT_ID }}-{{ global:REGION }}",
+                  ],
+                  "TargetPrefix": [
+                    "{{ ParseInput.BucketName }}",
+                  ],
+                },
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Created S3 bucket so0111-cloudtrailaccesslogs-{{ global:ACCOUNT_ID }}-{{ global:REGION }} for logging access to {{ ParseInput.BucketName }}",
+                  "UpdatedBy": "ASR-PCI_3.2.1_CloudTrail.7",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the CloudTrail.7 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-ConfigureS3BucketLogging",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_CloudTrail.7",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksCloudWatch1A05F543A": {
+      "Condition": "ControlRunbooksEnableCloudWatch1ConditionAB0DF2E5",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-CIS_1.2.0_3.x
+
+## What does this document do?
+Remediates the following CIS findings:
+
+3.1 - Creates a log metric filter and alarm for unauthorized API calls
+3.2 - Creates a log metric filter and alarm for AWS Management Console sign-in without MFA
+3.3 - Creates a log metric filter and alarm for usage of "root" account
+3.4 - Creates a log metric filter and alarm for for IAM policy changes
+3.5 - Creates a log metric filter and alarm for CloudTrail configuration changes
+3.6 - Creates a log metric filter and alarm for AWS Management Console authentication failures
+3.7 - Creates a log metric filter and alarm for disabling or scheduled deletion of customer created CMKs
+3.8 - Creates a log metric filter and alarm for S3 bucket policy changes
+3.9 - Creates a log metric filter and alarm for AWS Config configuration changes
+3.10 - Creates a log metric filter and alarm for security group changes
+3.11 - Creates a log metric filter and alarm for changes to Network Access Control Lists (NACL)
+3.12 - Creates a log metric filter and alarm for changes to network gateways
+3.13 - Creates a log metric filter and alarm for route table changes
+3.14 - Creates a log metric filter and alarm for VPC changes
+
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Output Parameters
+* Remediation.Output - Output of remediation runbook.
+
+## Documentation Links
+[CIS v1.2.0 3.1](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-3.1)
+[CIS v1.2.0 3.2](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-3.2)
+[CIS v1.2.0 3.3](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-3.3)
+[CIS v1.2.0 3.4](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-3.4)
+[CIS v1.2.0 3.5](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-3.5)
+[CIS v1.2.0 3.6](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-3.6)
+[CIS v1.2.0 3.7](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-3.7)
+[CIS v1.2.0 3.8](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-3.8)
+[CIS v1.2.0 3.9](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-3.9)
+[CIS v1.2.0 3.10](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-3.10)
+[CIS v1.2.0 3.11](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-3.11)
+[CIS v1.2.0 3.12](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-3.12)
+[CIS v1.2.0 3.13](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-3.13)
+[CIS v1.2.0 3.14](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-3.14)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "CloudWatch.1",
+                    "CloudWatch.2",
+                    "CloudWatch.3",
+                    "CloudWatch.4",
+                    "CloudWatch.5",
+                    "CloudWatch.6",
+                    "CloudWatch.7",
+                    "CloudWatch.8",
+                    "CloudWatch.9",
+                    "CloudWatch.10",
+                    "CloudWatch.11",
+                    "CloudWatch.12",
+                    "CloudWatch.13",
+                    "CloudWatch.14",
+                  ],
+                  "parse_id_pattern": "",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "ControlId",
+                  "Selector": "$.Payload.control_id",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "verify",
+                "InputPayload": {
+                  "ControlId": "{{ ParseInput.ControlId }}",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+CIS_mappings = {
+    "3.1": {
+        "filter_name": "UnauthorizedAPICalls",
+        "filter_pattern": '{($.errorCode="*UnauthorizedOperation") || ($.errorCode="AccessDenied*")}',
+        "metric_name": "UnauthorizedAPICalls",
+        "metric_value": 1,
+        "alarm_name": "UnauthorizedAPICalls",
+        "alarm_desc": "Alarm for UnauthorizedAPICalls > 0",
+        "alarm_threshold": 1
+    },
+    "3.2": {
+        "filter_name": "ConsoleSigninWithoutMFA",
+        "filter_pattern": '{($.eventName="ConsoleLogin") && ($.additionalEventData.MFAUsed !="Yes")}',
+        "metric_name": "ConsoleSigninWithoutMFA",
+        "metric_value": 1,
+        "alarm_name": "ConsoleSigninWithoutMFA",
+        "alarm_desc": "Alarm for ConsoleSigninWithoutMFA > 0",
+        "alarm_threshold": 1
+    },
+    "3.3": {
+        "filter_name": "RootAccountUsage",
+        "filter_pattern": '{$.userIdentity.type="Root" && $.userIdentity.invokedBy NOT EXISTS && $.eventType !="AwsServiceEvent"}',
+        "metric_name": "RootAccountUsage",
+        "metric_value": 1,
+        "alarm_name": "RootAccountUsage",
+        "alarm_desc": "Alarm for RootAccountUsage > 0",
+        "alarm_threshold": 1
+    },
+    "3.4": {
+        "filter_name": "IAMPolicyChanges",
+        "filter_pattern": '{($.eventName=DeleteGroupPolicy) || ($.eventName=DeleteRolePolicy) || ($.eventName=DeleteUserPolicy) || ($.eventName=PutGroupPolicy) || ($.eventName=PutRolePolicy) || ($.eventName=PutUserPolicy) || ($.eventName=CreatePolicy) || ($.eventName=DeletePolicy) || ($.eventName=CreatePolicyVersion) || ($.eventName=DeletePolicyVersion) || ($.eventName=AttachRolePolicy) || ($.eventName=DetachRolePolicy) || ($.eventName=AttachUserPolicy) || ($.eventName=DetachUserPolicy) || ($.eventName=AttachGroupPolicy) || ($.eventName=DetachGroupPolicy)}',
+        "metric_name": "IAMPolicyChanges",
+        "metric_value": 1,
+        "alarm_name": "IAMPolicyChanges",
+        "alarm_desc": "Alarm for IAMPolicyChanges > 0",
+        "alarm_threshold": 1
+    },
+    "3.5": {
+        "filter_name": "CloudTrailChanges",
+        "filter_pattern": '{($.eventName=CreateTrail) || ($.eventName=UpdateTrail) || ($.eventName=DeleteTrail) || ($.eventName=StartLogging) || ($.eventName=StopLogging)}',
+        "metric_name": "CloudTrailChanges",
+        "metric_value": 1,
+        "alarm_name": "CloudTrailChanges",
+        "alarm_desc": "Alarm for CloudTrailChanges > 0",
+        "alarm_threshold": 1
+    },
+    "3.6": {
+        "filter_name": "ConsoleAuthenticationFailure",
+        "filter_pattern": '{($.eventName=ConsoleLogin) && ($.errorMessage="Failed authentication")}',
+        "metric_name": "ConsoleAuthenticationFailure",
+        "metric_value": 1,
+        "alarm_name": "ConsoleAuthenticationFailure",
+        "alarm_desc": "Alarm for ConsoleAuthenticationFailure > 0",
+        "alarm_threshold": 1
+    },
+    "3.7": {
+        "filter_name": "DisableOrDeleteCMK",
+        "filter_pattern": '{($.eventSource=kms.amazonaws.com) && (($.eventName=DisableKey) || ($.eventName=ScheduleKeyDeletion))}',
+        "metric_name": "DisableOrDeleteCMK",
+        "metric_value": 1,
+        "alarm_name": "DisableOrDeleteCMK",
+        "alarm_desc": "Alarm for DisableOrDeleteCMK > 0",
+        "alarm_threshold": 1
+    },
+    "3.8": {
+        "filter_name": "S3BucketPolicyChanges",
+        "filter_pattern": '{($.eventSource=s3.amazonaws.com) && (($.eventName=PutBucketAcl) || ($.eventName=PutBucketPolicy) || ($.eventName=PutBucketCors) || ($.eventName=PutBucketLifecycle) || ($.eventName=PutBucketReplication) || ($.eventName=DeleteBucketPolicy) || ($.eventName=DeleteBucketCors) || ($.eventName=DeleteBucketLifecycle) || ($.eventName=DeleteBucketReplication))}',
+        "metric_name": "S3BucketPolicyChanges",
+        "metric_value": 1,
+        "alarm_name": "S3BucketPolicyChanges",
+        "alarm_desc": "Alarm for S3BucketPolicyChanges > 0",
+        "alarm_threshold": 1
+    },
+    "3.9": {
+        "filter_name": "AWSConfigChanges",
+        "filter_pattern": '{($.eventSource=config.amazonaws.com) && (($.eventName=StopConfigurationRecorder) || ($.eventName=DeleteDeliveryChannel) || ($.eventName=PutDeliveryChannel) || ($.eventName=PutConfigurationRecorder))}',
+        "metric_name": "AWSConfigChanges",
+        "metric_value": 1,
+        "alarm_name": "AWSConfigChanges",
+        "alarm_desc": "Alarm for AWSConfigChanges > 0",
+        "alarm_threshold": 1
+    },
+    "3.10": {
+        "filter_name": "SecurityGroupChanges",
+        "filter_pattern": '{($.eventName=AuthorizeSecurityGroupIngress) || ($.eventName=AuthorizeSecurityGroupEgress) || ($.eventName=RevokeSecurityGroupIngress) || ($.eventName=RevokeSecurityGroupEgress) || ($.eventName=CreateSecurityGroup) || ($.eventName=DeleteSecurityGroup)}',
+        "metric_name": "SecurityGroupChanges",
+        "metric_value": 1,
+        "alarm_name": "SecurityGroupChanges",
+        "alarm_desc": "Alarm for SecurityGroupChanges > 0",
+        "alarm_threshold": 1
+    },
+    "3.11": {
+        "filter_name": "NetworkACLChanges",
+        "filter_pattern": '{($.eventName=CreateNetworkAcl) || ($.eventName=CreateNetworkAclEntry) || ($.eventName=DeleteNetworkAcl) || ($.eventName=DeleteNetworkAclEntry) || ($.eventName=ReplaceNetworkAclEntry) || ($.eventName=ReplaceNetworkAclAssociation)}',
+        "metric_name": "NetworkACLChanges",
+        "metric_value": 1,
+        "alarm_name": "NetworkACLChanges",
+        "alarm_desc": "Alarm for NetworkACLChanges > 0",
+        "alarm_threshold": 1
+    },
+    "3.12": {
+        "filter_name": "NetworkGatewayChanges",
+        "filter_pattern": '{($.eventName=CreateCustomerGateway) || ($.eventName=DeleteCustomerGateway) || ($.eventName=AttachInternetGateway) || ($.eventName=CreateInternetGateway) || ($.eventName=DeleteInternetGateway) || ($.eventName=DetachInternetGateway)}',
+        "metric_name": "NetworkGatewayChanges",
+        "metric_value": 1,
+        "alarm_name": "NetworkGatewayChanges",
+        "alarm_desc": "Alarm for NetworkGatewayChanges > 0",
+        "alarm_threshold": 1
+    },
+    "3.13": {
+        "filter_name": "RouteTableChanges",
+        "filter_pattern": '{($.eventName=CreateRoute) || ($.eventName=CreateRouteTable) || ($.eventName=ReplaceRoute) || ($.eventName=ReplaceRouteTableAssociation) || ($.eventName=DeleteRouteTable) || ($.eventName=DeleteRoute) || ($.eventName=DisassociateRouteTable)}',
+        "metric_name": "RouteTableChanges",
+        "metric_value": 1,
+        "alarm_name": "RouteTableChanges",
+        "alarm_desc": "Alarm for RouteTableChanges > 0",
+        "alarm_threshold": 1
+    },
+    "3.14": {
+        "filter_name": "VPCChanges",
+        "filter_pattern": '{($.eventName=CreateVpc) || ($.eventName=DeleteVpc) || ($.eventName=ModifyVpcAttribute) || ($.eventName=AcceptVpcPeeringConnection) || ($.eventName=CreateVpcPeeringConnection) || ($.eventName=DeleteVpcPeeringConnection) || ($.eventName=RejectVpcPeeringConnection) || ($.eventName=AttachClassicLinkVpc) || ($.eventName=DetachClassicLinkVpc) || ($.eventName=DisableVpcClassicLink) || ($.eventName=EnableVpcClassicLink)}',
+        "metric_name": "VPCChanges",
+        "metric_value": 1,
+        "alarm_name": "VPCChanges",
+        "alarm_desc": "Alarm for VPCChanges > 0",
+        "alarm_threshold": 1
+    }
+}
+
+
+def verify(event, context):
+
+    return CIS_mappings.get(event['ControlId'], None)
+",
+              },
+              "name": "GetMetricFilterAndAlarmInputValue",
+              "outputs": [
+                {
+                  "Name": "FilterName",
+                  "Selector": "$.Payload.filter_name",
+                  "Type": "String",
+                },
+                {
+                  "Name": "FilterPattern",
+                  "Selector": "$.Payload.filter_pattern",
+                  "Type": "String",
+                },
+                {
+                  "Name": "MetricName",
+                  "Selector": "$.Payload.metric_name",
+                  "Type": "String",
+                },
+                {
+                  "Name": "MetricValue",
+                  "Selector": "$.Payload.metric_value",
+                  "Type": "Integer",
+                },
+                {
+                  "Name": "AlarmName",
+                  "Selector": "$.Payload.alarm_name",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AlarmDesc",
+                  "Selector": "$.Payload.alarm_desc",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AlarmThreshold",
+                  "Selector": "$.Payload.alarm_threshold",
+                  "Type": "Integer",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-CreateLogMetricFilterAndAlarm",
+                "RuntimeParameters": {
+                  "AlarmDesc": "{{ GetMetricFilterAndAlarmInputValue.AlarmDesc }}",
+                  "AlarmName": "{{ GetMetricFilterAndAlarmInputValue.AlarmName }}",
+                  "AlarmThreshold": "{{ GetMetricFilterAndAlarmInputValue.AlarmThreshold }}",
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "FilterName": "{{ GetMetricFilterAndAlarmInputValue.FilterName }}",
+                  "FilterPattern": "{{ GetMetricFilterAndAlarmInputValue.FilterPattern }}",
+                  "KMSKeyArn": "{{ KMSKeyArn }}",
+                  "LogGroupName": "{{ LogGroupName }}",
+                  "MetricName": "{{ GetMetricFilterAndAlarmInputValue.MetricName }}",
+                  "MetricNamespace": "{{ MetricNamespace }}",
+                  "MetricValue": "{{ GetMetricFilterAndAlarmInputValue.MetricValue }}",
+                  "SNSTopicName": "SO0111-ASR-LocalAlarmNotification",
+                },
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Added metric filter to the log group and notifications to SNS topic SO0111-ASR-LocalAlarmNotification.",
+                  "UpdatedBy": "ASR-PCI_3.2.1_CloudWatch.1",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the CloudWatch.1 finding",
+              "type": "StringMap",
+            },
+            "KMSKeyArn": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):kms:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:(?:(?:alias\\/[A-Za-z0-9/-_])|(?:key\\/(?:[0-9a-fA-F]{8}-(?:[0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12})))$",
+              "default": "{{ssm:/Solutions/SO0111/CMK_REMEDIATION_ARN}}",
+              "description": "The ARN of the KMS key created by ASR for remediations",
+              "type": "String",
+            },
+            "LogGroupName": {
+              "allowedPattern": ".*",
+              "default": "{{ssm:/Solutions/SO0111/Metrics_LogGroupName}}",
+              "description": "The name of the Log group to be used to create filters and metric alarms",
+              "type": "String",
+            },
+            "MetricNamespace": {
+              "allowedPattern": ".*",
+              "default": "LogMetrics",
+              "description": "The name of the metric namespace where the metrics will be logged",
+              "type": "String",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-CreateLogMetricFilterAndAlarm",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_CloudWatch.1",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksCodeBuild2A2751671": {
+      "Condition": "ControlRunbooksEnableCodeBuild2ConditionB01F473D",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_CodeBuild.2
+
+## What does this document do?
+This document removes CodeBuild project environment variables containing clear text credentials and replaces them with Amazon EC2 Systems Manager Parameters.
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Output Parameters
+* Remediation.Output
+
+## Documentation Links
+* [AFSBP v1.0.0 CodeBuild.2](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-codebuild-2)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "CodeBuild.2",
+                  ],
+                  "parse_id_pattern": "^arn:(?:aws|aws-cn|aws-us-gov):codebuild:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:project\\/([A-Za-z0-9][A-Za-z0-9\\-_]{1,254})$",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "ProjectName",
+                  "Selector": "$.Payload.resource_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationAccount",
+                  "Selector": "$.Payload.account_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationRegion",
+                  "Selector": "$.Payload.resource_region",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-ReplaceCodeBuildClearTextCredentials",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "ProjectName": "{{ ParseInput.ProjectName }}",
+                },
+                "TargetLocations": [
+                  {
+                    "Accounts": [
+                      "{{ ParseInput.RemediationAccount }}",
+                    ],
+                    "ExecutionRoleName": "{{ RemediationRoleName }}",
+                    "Regions": [
+                      "{{ ParseInput.RemediationRegion }}",
+                    ],
+                  },
+                ],
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Replaced clear text credentials with SSM parameters.",
+                  "UpdatedBy": "ASR-PCI_3.2.1_CodeBuild.2",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the CodeBuild.2 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-ReplaceCodeBuildClearTextCredentials",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_CodeBuild.2",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksConfig1512B566F": {
+      "Condition": "ControlRunbooksEnableConfig1Condition8CEB8627",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_Config.1
+## What does this document do?
+Enables AWS Config:
+* Turns on recording for all resources.
+* Creates an encrypted bucket for Config logging.
+* Creates a logging bucket for access logs for the config bucket
+* Creates an SNS topic for Config notifications
+* Creates a service-linked role
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Documentation Links
+* [AFSBP Config.1](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-config-1)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "Config.1",
+                  ],
+                  "parse_id_pattern": "",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-EnableAWSConfig",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "KMSKeyArn": "{{ KMSKeyArn }}",
+                  "SNSTopicName": "SO0111-ASR-AWSConfigNotification",
+                },
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "AWS Config enabled",
+                  "UpdatedBy": "ASR-PCI_3.2.1_Config.1",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the Config.1 finding",
+              "type": "StringMap",
+            },
+            "KMSKeyArn": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):kms:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:(?:(?:alias\\/[A-Za-z0-9/-_])|(?:key\\/(?:[0-9a-fA-F]{8}-(?:[0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12})))$",
+              "default": "{{ssm:/Solutions/SO0111/CMK_REMEDIATION_ARN}}",
+              "description": "The ARN of the KMS key created by ASR for remediations",
+              "type": "String",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-EnableAWSConfig",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_Config.1",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksEC213D7C9C1EB": {
+      "Condition": "ControlRunbooksEnableEC213Condition567EA275",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-PCI_3.2.1_EC2.5
+
+## What does this document do?
+Removes public access to remove server administrative ports from an EC2 Security Group
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Output Parameters
+* Remediation.Output - Output of AWS-DisablePublicAccessForSecurityGroup runbook.
+
+## Documentation Links
+* [PCI v3.2.1 EC2.5](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-pci-controls.html#pcidss-ec2-5)
+* [CIS v1.2.0 4.1](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-4.1)
+* [CIS v1.2.0 4.2](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-4.2)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "EC2.13",
+                    "EC2.14",
+                  ],
+                  "parse_id_pattern": "^arn:(?:aws|aws-cn|aws-us-gov):ec2:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:security-group\\/(sg-[a-f\\d]{8,17})$",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "GroupId",
+                  "Selector": "$.Payload.resource_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationAccount",
+                  "Selector": "$.Payload.account_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationRegion",
+                  "Selector": "$.Payload.resource_region",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "AWS-DisablePublicAccessForSecurityGroup",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "GroupId": "{{ ParseInput.GroupId }}",
+                },
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Disabled public access to administrative ports in the security group {{ ParseInput.GroupId }}.",
+                  "UpdatedBy": "ASR-PCI_3.2.1_EC2.13",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the EC2.13 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-DisablePublicAccessForSecurityGroup",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_EC2.13",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksEC214D3BB404": {
+      "Condition": "ControlRunbooksEnableEC21ConditionD4F1277B",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_EC2.1
+## What does this document do?
+This document changes all public EC2 snapshots to private
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Documentation Links
+* [AFSBP EC2.1](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-ec2-1)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "EC2.1",
+                  ],
+                  "parse_id_pattern": "",
+                  "resource_index": 2,
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "TestMode",
+                  "Selector": "$.Payload.testmode",
+                  "Type": "Boolean",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-MakeEBSSnapshotsPrivate",
+                "RuntimeParameters": {
+                  "AccountId": "{{ ParseInput.RemediationAccount }}",
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "TestMode": "{{ ParseInput.TestMode }}",
+                },
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "EBS Snapshot modified to private",
+                  "UpdatedBy": "ASR-PCI_3.2.1_EC2.1",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the EC2.1 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-MakeEBSSnapshotsPrivate",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_EC2.1",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksEC2153B43E7A8": {
+      "Condition": "ControlRunbooksEnableEC215Condition52A7DE4B",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_EC2.15
+ 
+## What does this document do?
+This document disables auto assignment of public IP addresses on a subnet.
+ 
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+ 
+## Output Parameters
+* Remediation.Output
+ 
+## Documentation Links
+* [AFSBP v1.0.0 EC2.15](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-ec2-15)",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "EC2.15",
+                  ],
+                  "parse_id_pattern": "",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "SubnetARN",
+                  "Selector": "$.Payload.resource_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationAccount",
+                  "Selector": "$.Payload.account_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationRegion",
+                  "Selector": "$.Payload.resource_region",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-DisablePublicIPAutoAssign",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "SubnetARN": "{{ ParseInput.SubnetARN }}",
+                },
+                "TargetLocations": [
+                  {
+                    "Accounts": [
+                      "{{ ParseInput.RemediationAccount }}",
+                    ],
+                    "ExecutionRoleName": "{{ RemediationRoleName }}",
+                    "Regions": [
+                      "{{ ParseInput.RemediationRegion }}",
+                    ],
+                  },
+                ],
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Disabled public IP auto assignment for subnet.",
+                  "UpdatedBy": "ASR-PCI_3.2.1_EC2.15",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the EC2.15 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-DisablePublicIPAutoAssign",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_EC2.15",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksEC22ED852ADF": {
+      "Condition": "ControlRunbooksEnableEC22ConditionB9E0D42E",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_EC2.2
+
+## What does this document do?
+This document deletes ingress and egress rules from default security
+group using the AWS SSM Runbook AWSConfigRemediation-RemoveVPCDefaultSecurityGroupRules
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Output Parameters
+* Remediation.Output - Output from AWSConfigRemediation-RemoveVPCDefaultSecurityGroupRules SSM doc
+
+## Documentation Links
+* [AFSBP EC2.2](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-ec2-2)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "EC2.2",
+                  ],
+                  "parse_id_pattern": "^arn:(?:aws|aws-cn|aws-us-gov):ec2:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:security-group\\/(sg-[0-9a-f]*)$",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "GroupId",
+                  "Selector": "$.Payload.resource_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationAccount",
+                  "Selector": "$.Payload.account_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationRegion",
+                  "Selector": "$.Payload.resource_region",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-RemoveVPCDefaultSecurityGroupRules",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "GroupId": "{{ ParseInput.GroupId }}",
+                },
+                "TargetLocations": [
+                  {
+                    "Accounts": [
+                      "{{ ParseInput.RemediationAccount }}",
+                    ],
+                    "ExecutionRoleName": "{{ RemediationRoleName }}",
+                    "Regions": [
+                      "{{ ParseInput.RemediationRegion }}",
+                    ],
+                  },
+                ],
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Removed rules on default security group",
+                  "UpdatedBy": "ASR-PCI_3.2.1_EC2.2",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the EC2.2 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-RemoveVPCDefaultSecurityGroupRules",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_EC2.2",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksEC267E3087AE": {
+      "Condition": "ControlRunbooksEnableEC26ConditionF1F880B0",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_EC2.6
+
+## What does this document do?
+Enables VPC Flow Logs for a VPC
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Output Parameters
+* Remediation.Output - Remediation results
+
+## Documentation Links
+* [AFSBP EC2.6](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-ec2-6)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "EC2.6",
+                  ],
+                  "parse_id_pattern": "^arn:(?:aws|aws-cn|aws-us-gov):ec2:.*:\\d{12}:vpc\\/(vpc-[0-9a-f]{8,17})$",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "VPC",
+                  "Selector": "$.Payload.resource_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationAccount",
+                  "Selector": "$.Payload.account_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationRegion",
+                  "Selector": "$.Payload.resource_region",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-EnableVPCFlowLogs",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "RemediationRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/SO0111-EnableVPCFlowLogs-remediationRole",
+                  "VPC": "{{ ParseInput.VPC }}",
+                },
+                "TargetLocations": [
+                  {
+                    "Accounts": [
+                      "{{ ParseInput.RemediationAccount }}",
+                    ],
+                    "ExecutionRoleName": "{{ RemediationRoleName }}",
+                    "Regions": [
+                      "{{ ParseInput.RemediationRegion }}",
+                    ],
+                  },
+                ],
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Removed rules on default security group",
+                  "UpdatedBy": "ASR-PCI_3.2.1_EC2.6",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the EC2.6 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-EnableVPCFlowLogs",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_EC2.6",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksEC277719A4CD": {
+      "Condition": "ControlRunbooksEnableEC27ConditionC77CF056",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_EC2.7
+## What does this document do?
+This document enables \`EBS Encryption by default\` for an AWS account in the current region by calling another SSM document
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+## Output Parameters
+* Remediation.Output
+
+## Documentation Links
+* [AFSBP EC2.7](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-ec2-7)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "EC2.7",
+                  ],
+                  "parse_id_pattern": "",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-EnableEbsEncryptionByDefault",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                },
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Enabled EBS encryption by default",
+                  "UpdatedBy": "ASR-PCI_3.2.1_EC2.7",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the EC2.7 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-EnableEbsEncryptionByDefault",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_EC2.7",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksIAM3DC25477E": {
+      "Condition": "ControlRunbooksEnableIAM3Condition3AA0E892",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_IAM.3
+
+## What does this document do?
+This document disables active keys that have not been rotated for more than 90 days. Note that this remediation is **DISRUPTIVE**.
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Output Parameters
+* Remediation.Output
+
+## Documentation Links
+* [AFSBP v1.0.0 IAM.3](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-iam-3)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "IAM.3",
+                  ],
+                  "parse_id_pattern": "^arn:(?:aws|aws-cn|aws-us-gov):iam::\\d{12}:user(?:(?:\\u002F)|(?:\\u002F[\\u0021-\\u007F]{1,510}\\u002F))([\\w+=,.@-]{1,64})$",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "IAMUser",
+                  "Selector": "$.Payload.resource_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "IAMResourceId",
+                  "Selector": "$.Payload.details.AwsIamUser.UserId",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-RevokeUnrotatedKeys",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "IAMResourceId": "{{ ParseInput.IAMResourceId }}",
+                  "MaxCredentialUsageAge": "{{ MaxCredentialUsageAge }}",
+                },
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Deactivated unrotated keys for {{ ParseInput.IAMUser }}.",
+                  "UpdatedBy": "ASR-PCI_3.2.1_IAM.3",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the IAM.3 finding",
+              "type": "StringMap",
+            },
+            "MaxCredentialUsageAge": {
+              "allowedPattern": "^(?:[1-9]\\d{0,3}|10000)$",
+              "default": "90",
+              "description": "(Required) Maximum number of days a key can be unrotated. The default value is 90 days.",
+              "type": "String",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-RevokeUnrotatedKeys",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_IAM.3",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksIAM70A808F7C": {
+      "Condition": "ControlRunbooksEnableIAM7ConditionDF8E776B",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_IAM.7
+
+## What does this document do?
+This document establishes a default password policy.
+
+## Security Standards and Controls
+* AFSBP IAM.7
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+## Output Parameters
+* Remediation.Output
+
+## Documentation Links
+* [AFSBP IAM.7](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-iam-7)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "IAM.7",
+                    "IAM.11",
+                    "IAM.12",
+                    "IAM.13",
+                    "IAM.14",
+                    "IAM.15",
+                    "IAM.16",
+                    "IAM.17",
+                  ],
+                  "parse_id_pattern": "",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-SetIAMPasswordPolicy",
+                "RuntimeParameters": {
+                  "AllowUsersToChangePassword": true,
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "HardExpiry": true,
+                  "MaxPasswordAge": 90,
+                  "MinimumPasswordLength": 14,
+                  "PasswordReusePrevention": 24,
+                  "RequireLowercaseCharacters": true,
+                  "RequireNumbers": true,
+                  "RequireSymbols": true,
+                  "RequireUppercaseCharacters": true,
+                },
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Established a baseline password policy using the ASR-SetIAMPasswordPolicy runbook.",
+                  "UpdatedBy": "ASR-PCI_3.2.1_IAM.7",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the IAM.7 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-SetIAMPasswordPolicy",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_IAM.7",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksIAM8632E03ED": {
+      "Condition": "ControlRunbooksEnableIAM8Condition9CA5CB4B",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_IAM.8
+
+## What does this document do?
+This document ensures that credentials unused for 90 days or greater are disabled.
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Output Parameters
+* Remediation.Output - Output of remediation runbook
+
+SEE AWSConfigRemediation-RevokeUnusedIAMUserCredentials
+
+## Documentation Links
+* [AFSBP IAM.8](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-iam-8)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "IAM.8",
+                  ],
+                  "parse_id_pattern": "",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "IAMResourceId",
+                  "Selector": "$.Payload.details.AwsIamUser.UserId",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-RevokeUnusedIAMUserCredentials",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "IAMResourceId": "{{ ParseInput.IAMResourceId }}",
+                },
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Deactivated unused keys and expired logins using the ASR-RevokeUnusedIAMUserCredentials runbook.",
+                  "UpdatedBy": "ASR-PCI_3.2.1_IAM.8",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the IAM.8 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-RevokeUnusedIAMUserCredentials",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_IAM.8",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksKMS41A22BB8D": {
+      "Condition": "ControlRunbooksEnableKMS4Condition710C0C5C",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-CIS_1.2.0_2.8
+
+## What does this document do?
+Enables rotation for customer-managed KMS keys.
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Output Parameters
+* Remediation.Output - Remediation results
+
+## Documentation Links
+* [CIS v1.2.0 2.8](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#securityhub-cis-controls-2.8)
+* [PCI v3.2.1 PCI.KMS.1](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-pci-controls.html#pcidss-kms-1)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "KMS.4",
+                  ],
+                  "parse_id_pattern": "^arn:(?:aws|aws-cn|aws-us-gov):kms:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:key\\/([A-Za-z0-9-]{36})$",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "KeyId",
+                  "Selector": "$.Payload.resource_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationAccount",
+                  "Selector": "$.Payload.account_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationRegion",
+                  "Selector": "$.Payload.resource_region",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-EnableKeyRotation",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "KeyId": "{{ ParseInput.KeyId }}",
+                },
+                "TargetLocations": [
+                  {
+                    "Accounts": [
+                      "{{ ParseInput.RemediationAccount }}",
+                    ],
+                    "ExecutionRoleName": "{{ RemediationRoleName }}",
+                    "Regions": [
+                      "{{ ParseInput.RemediationRegion }}",
+                    ],
+                  },
+                ],
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Enabled KMS Customer Managed Key rotation for {{ ParseInput.KeyId }}",
+                  "UpdatedBy": "ASR-PCI_3.2.1_KMS.4",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the KMS.4 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-EnableKeyRotation",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_KMS.4",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksLambda1F6ECACF8": {
+      "Condition": "ControlRunbooksEnableLambda1Condition077CECAF",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_Lambda.1
+
+## What does this document do?
+This document removes the public resource policy. A public resource policy
+contains a principal "*" or AWS: "*", which allows public access to the
+function. The remediation is to remove the SID of the public policy.
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Documentation Links
+* [AFSBP Lambda.1](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-lambda-1)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "Lambda.1",
+                  ],
+                  "parse_id_pattern": "^arn:(?:aws|aws-us-gov|aws-cn):lambda:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:function:([a-zA-Z0-9\\-_]{1,64})$",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "FunctionName",
+                  "Selector": "$.Payload.resource_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationAccount",
+                  "Selector": "$.Payload.account_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationRegion",
+                  "Selector": "$.Payload.resource_region",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-RemoveLambdaPublicAccess",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "FunctionName": "{{ ParseInput.FunctionName }}",
+                },
+                "TargetLocations": [
+                  {
+                    "Accounts": [
+                      "{{ ParseInput.RemediationAccount }}",
+                    ],
+                    "ExecutionRoleName": "{{ RemediationRoleName }}",
+                    "Regions": [
+                      "{{ ParseInput.RemediationRegion }}",
+                    ],
+                  },
+                ],
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Lamdba {{ ParseInput.FunctionName }} policy updated to remove public access",
+                  "UpdatedBy": "ASR-PCI_3.2.1_Lambda.1",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the Lambda.1 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-RemoveLambdaPublicAccess",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_Lambda.1",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksRDS13FCEA51BD": {
+      "Condition": "ControlRunbooksEnableRDS13Condition0E8A44B3",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_RDS.13
+
+## What does this document do?
+This document enables \`Auto minor version upgrade\` on a given Amazon RDS instance by calling another SSM document.
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Output Parameters
+* Remediation.Output - The standard HTTP response from the ModifyDBInstance API.
+
+## Documentation Links
+* [AFSBP RDS.13](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-rds-13)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "RDS.13",
+                  ],
+                  "parse_id_pattern": "",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "RemediationAccount",
+                  "Selector": "$.Payload.account_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationRegion",
+                  "Selector": "$.Payload.resource_region",
+                  "Type": "String",
+                },
+                {
+                  "Name": "DbiResourceId",
+                  "Selector": "$.Payload.resource.Details.AwsRdsDbInstance.DbiResourceId",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-EnableMinorVersionUpgradeOnRDSDBInstance",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "DbiResourceId": "{{ ParseInput.DbiResourceId }}",
+                },
+                "TargetLocations": [
+                  {
+                    "Accounts": [
+                      "{{ ParseInput.RemediationAccount }}",
+                    ],
+                    "ExecutionRoleName": "{{ RemediationRoleName }}",
+                    "Regions": [
+                      "{{ ParseInput.RemediationRegion }}",
+                    ],
+                  },
+                ],
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Minor Version enabled on the RDS Instance.",
+                  "UpdatedBy": "ASR-PCI_3.2.1_RDS.13",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the RDS.13 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-EnableMinorVersionUpgradeOnRDSDBInstance",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_RDS.13",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksRDS16EB04DCBF": {
+      "Condition": "ControlRunbooksEnableRDS16ConditionCB5C3E8F",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_RDS.16
+
+## What does this document do?
+This document enables \`Copy tags to snapshots\` on a given Amazon RDS cluster by calling another SSM document.
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Output Parameters
+* Remediation.Output - The standard HTTP response from the ModifyDBCluster API.
+
+## Documentation Links
+* [AFSBP RDS.16](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-rds-16)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "RDS.16",
+                  ],
+                  "parse_id_pattern": "",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "RemediationAccount",
+                  "Selector": "$.Payload.account_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationRegion",
+                  "Selector": "$.Payload.resource_region",
+                  "Type": "String",
+                },
+                {
+                  "Name": "DbiResourceId",
+                  "Selector": "$.Payload.details.AwsRdsDbCluster.DbClusterResourceId",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-EnableCopyTagsToSnapshotOnRDSCluster",
+                "RuntimeParameters": {
+                  "ApplyImmediately": true,
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "DbClusterResourceId": "{{ ParseInput.DbiResourceId }}",
+                },
+                "TargetLocations": [
+                  {
+                    "Accounts": [
+                      "{{ ParseInput.RemediationAccount }}",
+                    ],
+                    "ExecutionRoleName": "{{ RemediationRoleName }}",
+                    "Regions": [
+                      "{{ ParseInput.RemediationRegion }}",
+                    ],
+                  },
+                ],
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Copy Tags to Snapshots enabled on RDS DB cluster",
+                  "UpdatedBy": "ASR-PCI_3.2.1_RDS.16",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the RDS.16 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-EnableCopyTagsToSnapshotOnRDSCluster",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_RDS.16",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksRDS1D73701E9": {
+      "Condition": "ControlRunbooksEnableRDS1ConditionFAE5B7EA",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_RDS.1
+## What does this document do?
+This document changes public RDS snapshot to private
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Documentation Links
+* [AFSBP RDS.1](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-rds-1)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "RDS.1",
+                  ],
+                  "parse_id_pattern": "^arn:(?:aws|aws-cn|aws-us-gov):rds:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:(cluster-snapshot|snapshot):([a-zA-Z](?:[0-9a-zA-Z]+-)*[0-9a-zA-Z]+)$",
+                  "resource_index": 2,
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "DBSnapshotId",
+                  "Selector": "$.Payload.resource_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationAccount",
+                  "Selector": "$.Payload.account_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationRegion",
+                  "Selector": "$.Payload.resource_region",
+                  "Type": "String",
+                },
+                {
+                  "Name": "DBSnapshotType",
+                  "Selector": "$.Payload.matches[0]",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-MakeRDSSnapshotPrivate",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "DBSnapshotId": "{{ ParseInput.DBSnapshotId }}",
+                  "DBSnapshotType": "{{ ParseInput.DBSnapshotType }}",
+                },
+                "TargetLocations": [
+                  {
+                    "Accounts": [
+                      "{{ ParseInput.RemediationAccount }}",
+                    ],
+                    "ExecutionRoleName": "{{ RemediationRoleName }}",
+                    "Regions": [
+                      "{{ ParseInput.RemediationRegion }}",
+                    ],
+                  },
+                ],
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "RDS DB Snapshot modified to private",
+                  "UpdatedBy": "ASR-PCI_3.2.1_RDS.1",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the RDS.1 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-MakeRDSSnapshotPrivate",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_RDS.1",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksRDS2FBE04686": {
+      "Condition": "ControlRunbooksEnableRDS2Condition4FD00FE6",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_RDS.2
+## What does this document do?
+This document disables public access to RDS instances by calling another SSM document
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Documentation Links
+* [AFSBP RDS.2](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-rds-2)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "RDS.2",
+                  ],
+                  "parse_id_pattern": "^arn:(?:aws|aws-cn|aws-us-gov):rds:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:db:((?!.*--.*)(?!.*-$)[a-z][a-z0-9-]{0,62})$",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "RemediationAccount",
+                  "Selector": "$.Payload.account_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationRegion",
+                  "Selector": "$.Payload.resource_region",
+                  "Type": "String",
+                },
+                {
+                  "Name": "DbiResourceId",
+                  "Selector": "$.Payload.resource.Details.AwsRdsDbInstance.DbiResourceId",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-DisablePublicAccessToRDSInstance",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "DbiResourceId": "{{ ParseInput.DbiResourceId }}",
+                },
+                "TargetLocations": [
+                  {
+                    "Accounts": [
+                      "{{ ParseInput.RemediationAccount }}",
+                    ],
+                    "ExecutionRoleName": "{{ RemediationRoleName }}",
+                    "Regions": [
+                      "{{ ParseInput.RemediationRegion }}",
+                    ],
+                  },
+                ],
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Disabled public access to RDS instance",
+                  "UpdatedBy": "ASR-PCI_3.2.1_RDS.2",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the RDS.2 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-DisablePublicAccessToRDSInstance",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_RDS.2",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksRDS4C82F2410": {
+      "Condition": "ControlRunbooksEnableRDS4Condition2E89346E",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_RDS.4
+
+## What does this document do?
+This document encrypts an unencrypted RDS snapshot by calling another SSM document
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Optional) The ARN of the role that allows Automation to perform the actions on your behalf.
+* RemediationRoleName: (Optional) The name of the role that allows Automation to remediate the finding on your behalf.
+* KMSKeyId: (Optional) ID, ARN or Alias for the AWS KMS Customer-Managed Key (CMK) to use to encrypt the snapshot.
+
+## Documentation Links
+* [AFSBP RDS.4](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-rds-4)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "RDS.4",
+                  ],
+                  "parse_id_pattern": "^(?:arn:(?:aws|aws-us-gov|aws-cn):kms:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:)?(?:(?:alias\\/[A-Za-z0-9/_-]+)|(?:key\\/(?:[0-9a-fA-F]{8}-(?:[0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12})))$",
+                  "resource_index": 2,
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "RemediationAccount",
+                  "Selector": "$.Payload.account_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationRegion",
+                  "Selector": "$.Payload.resource_region",
+                  "Type": "String",
+                },
+                {
+                  "Name": "SourceDBSnapshotIdentifier",
+                  "Selector": "$.Payload.matches[1]",
+                  "Type": "String",
+                },
+                {
+                  "Name": "SourceDBSnapshotIdentifierNoPrefix",
+                  "Selector": "$.Payload.matches[2]",
+                  "Type": "String",
+                },
+                {
+                  "Name": "DBSnapshotType",
+                  "Selector": "$.Payload.matches[0]",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-EncryptRDSSnapshot",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "DBSnapshotType": "{{ ParseInput.DBSnapshotType }}",
+                  "KmsKeyId": "{{ KMSKeyId }}",
+                  "SourceDBSnapshotIdentifier": "{{ ParseInput.SourceDBSnapshotIdentifier }}",
+                  "TargetDBSnapshotIdentifier": "{{ ParseInput.SourceDBSnapshotIdentifierNoPrefix }}-encrypted",
+                },
+                "TargetLocations": [
+                  {
+                    "Accounts": [
+                      "{{ ParseInput.RemediationAccount }}",
+                    ],
+                    "ExecutionRoleName": "{{ RemediationRoleName }}",
+                    "Regions": [
+                      "{{ ParseInput.RemediationRegion }}",
+                    ],
+                  },
+                ],
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Encrypted RDS snapshot",
+                  "UpdatedBy": "ASR-PCI_3.2.1_RDS.4",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the RDS.4 finding",
+              "type": "StringMap",
+            },
+            "KMSKeyId": {
+              "allowedPattern": "^(?:arn:(?:aws|aws-us-gov|aws-cn):kms:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:)?(?:(?:alias\\/[A-Za-z0-9/_-]+)|(?:key\\/(?:[0-9a-fA-F]{8}-(?:[0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12})))$",
+              "default": "alias/aws/rds",
+              "description": "(Optional) ID, ARN or Alias for the AWS KMS Customer-Managed Key (CMK) to use to encrypt the snapshot.",
+              "type": "String",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-EncryptRDSSnapshot",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_RDS.4",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksRDS5CECD9314": {
+      "Condition": "ControlRunbooksEnableRDS5ConditionEC2574C3",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.RDS.5
+
+## What does this document do?
+This document configures an RDS DB instance for multiple Availability Zones by calling another SSM document.
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Optional) The ARN of the role that allows Automation to perform the actions on your behalf.
+* RemediationRoleName: (Optional) The name of the role that allows Automation to remediate the finding on your behalf.
+
+## Documentation Links
+* [AFSBP RDS.5](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-rds-5)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "RDS.5",
+                  ],
+                  "parse_id_pattern": "",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "RemediationAccount",
+                  "Selector": "$.Payload.account_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationRegion",
+                  "Selector": "$.Payload.resource_region",
+                  "Type": "String",
+                },
+                {
+                  "Name": "DbiResourceId",
+                  "Selector": "$.Payload.resource.Details.AwsRdsDbInstance.DbiResourceId",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-EnableMultiAZOnRDSInstance",
+                "RuntimeParameters": {
+                  "ApplyImmediately": true,
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "DbiResourceId": "{{ ParseInput.DbiResourceId }}",
+                },
+                "TargetLocations": [
+                  {
+                    "Accounts": [
+                      "{{ ParseInput.RemediationAccount }}",
+                    ],
+                    "ExecutionRoleName": "{{ RemediationRoleName }}",
+                    "Regions": [
+                      "{{ ParseInput.RemediationRegion }}",
+                    ],
+                  },
+                ],
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Configured RDS cluster for multiple Availability Zones",
+                  "UpdatedBy": "ASR-PCI_3.2.1_RDS.5",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the RDS.5 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-EnableMultiAZOnRDSInstance",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_RDS.5",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksRDS6082B0D6B": {
+      "Condition": "ControlRunbooksEnableRDS6Condition4A60A39B",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_RDS.6
+
+## What does this document do?
+This document enables \`Enhanced Monitoring\` on a given Amazon RDS instance by calling another SSM document.
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Output Parameters
+* VerifyRemediation.Output - The standard HTTP response from the ModifyDBInstance API.
+## Documentation Links
+
+* [AFSBP RDS.6](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-rds-6)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "RDS.6",
+                  ],
+                  "parse_id_pattern": "",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "RemediationAccount",
+                  "Selector": "$.Payload.account_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationRegion",
+                  "Selector": "$.Payload.resource_region",
+                  "Type": "String",
+                },
+                {
+                  "Name": "DbiResourceId",
+                  "Selector": "$.Payload.resource.Details.AwsRdsDbInstance.DbiResourceId",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "GetRole",
+                "RoleName": "SO0111-RDSMonitoring-remediationRole",
+                "Service": "iam",
+              },
+              "name": "GetMonitoringRoleArn",
+              "outputs": [
+                {
+                  "Name": "Arn",
+                  "Selector": "$.Role.Arn",
+                  "Type": "String",
+                },
+              ],
+              "timeoutSeconds": 600,
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-EnableEnhancedMonitoringOnRDSInstance",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "MonitoringRoleArn": "{{ GetMonitoringRoleArn.Arn }}",
+                  "ResourceId": "{{ ParseInput.DbiResourceId }}",
+                },
+                "TargetLocations": [
+                  {
+                    "Accounts": [
+                      "{{ ParseInput.RemediationAccount }}",
+                    ],
+                    "ExecutionRoleName": "{{ RemediationRoleName }}",
+                    "Regions": [
+                      "{{ ParseInput.RemediationRegion }}",
+                    ],
+                  },
+                ],
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Enhanced Monitoring enabled on RDS DB cluster",
+                  "UpdatedBy": "ASR-PCI_3.2.1_RDS.6",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the RDS.6 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-EnableEnhancedMonitoringOnRDSInstance",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_RDS.6",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksRDS715C0A01A": {
+      "Condition": "ControlRunbooksEnableRDS7ConditionE53509B0",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_RDS.7
+
+## What does this document do?
+This document enables \`Deletion Protection\` on a given Amazon RDS cluster by calling another SSM document.
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Output Parameters
+* Remediation.Output - The standard HTTP response from the ModifyDBCluster API.
+
+## Documentation Links
+* [AFSBP RDS.7](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-rds-7)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "RDS.7",
+                  ],
+                  "parse_id_pattern": "",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "RemediationAccount",
+                  "Selector": "$.Payload.account_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationRegion",
+                  "Selector": "$.Payload.resource_region",
+                  "Type": "String",
+                },
+                {
+                  "Name": "DbiResourceId",
+                  "Selector": "$.Payload.details.AwsRdsDbCluster.DbClusterResourceId",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-EnableRDSClusterDeletionProtection",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "ClusterId": "{{ ParseInput.DbiResourceId }}",
+                },
+                "TargetLocations": [
+                  {
+                    "Accounts": [
+                      "{{ ParseInput.RemediationAccount }}",
+                    ],
+                    "ExecutionRoleName": "{{ RemediationRoleName }}",
+                    "Regions": [
+                      "{{ ParseInput.RemediationRegion }}",
+                    ],
+                  },
+                ],
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Deletion protection enabled on RDS DB cluster",
+                  "UpdatedBy": "ASR-PCI_3.2.1_RDS.7",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the RDS.7 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-EnableRDSClusterDeletionProtection",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_RDS.7",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksRDS89256480A": {
+      "Condition": "ControlRunbooksEnableRDS8Condition8F460AB5",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.RDS.8
+
+## What does this document do?
+This document enables \`Deletion Protection\` on a given Amazon RDS cluster by calling another SSM document.
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Optional) The ARN of the role that allows Automation to perform the actions on your behalf.
+* RemediationRoleName: (Optional) The name of the role that allows Automation to remediate the finding on your behalf.
+
+## Documentation Links
+* [AFSBP RDS.8](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-rds-8)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "RDS.8",
+                  ],
+                  "parse_id_pattern": "",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "RemediationAccount",
+                  "Selector": "$.Payload.account_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationRegion",
+                  "Selector": "$.Payload.resource_region",
+                  "Type": "String",
+                },
+                {
+                  "Name": "DbiResourceId",
+                  "Selector": "$.Payload.resource.Details.AwsRdsDbInstance.DbiResourceId",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-EnableRDSInstanceDeletionProtection",
+                "RuntimeParameters": {
+                  "ApplyImmediately": true,
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "DbInstanceResourceId": "{{ ParseInput.DbiResourceId }}",
+                },
+                "TargetLocations": [
+                  {
+                    "Accounts": [
+                      "{{ ParseInput.RemediationAccount }}",
+                    ],
+                    "ExecutionRoleName": "{{ RemediationRoleName }}",
+                    "Regions": [
+                      "{{ ParseInput.RemediationRegion }}",
+                    ],
+                  },
+                ],
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Enabled deletion protection on RDS instance",
+                  "UpdatedBy": "ASR-PCI_3.2.1_RDS.8",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the RDS.8 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-EnableRDSInstanceDeletionProtection",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_RDS.8",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksRedshift1789871EB": {
+      "Condition": "ControlRunbooksEnableRedshift1Condition3449D560",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_Redshift.1
+
+## What does this document do?
+This document disables public access to a Redshift cluster by calling another SSM document
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Optional) The ARN of the role that allows Automation to perform the actions on your behalf.
+* RemediationRoleName: (Optional) The name of the role that allows Automation to remediate the finding on your behalf.
+
+## Documentation Links
+* [AFSBP Redshift.4](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-redshift-1)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "Redshift.1",
+                  ],
+                  "parse_id_pattern": "^arn:(?:aws|aws-cn|aws-us-gov):redshift:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:cluster:(?!.*--)([a-z][a-z0-9-]{0,62})(?<!-)$",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "ClusterIdentifier",
+                  "Selector": "$.Payload.resource_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationAccount",
+                  "Selector": "$.Payload.account_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationRegion",
+                  "Selector": "$.Payload.resource_region",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-DisablePublicAccessToRedshiftCluster",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "ClusterIdentifier": "{{ ParseInput.ClusterIdentifier }}",
+                },
+                "TargetLocations": [
+                  {
+                    "Accounts": [
+                      "{{ ParseInput.RemediationAccount }}",
+                    ],
+                    "ExecutionRoleName": "{{ RemediationRoleName }}",
+                    "Regions": [
+                      "{{ ParseInput.RemediationRegion }}",
+                    ],
+                  },
+                ],
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Disabled public access to Redshift cluster",
+                  "UpdatedBy": "ASR-PCI_3.2.1_Redshift.1",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the Redshift.1 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-DisablePublicAccessToRedshiftCluster",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_Redshift.1",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksRedshift3106C10FF": {
+      "Condition": "ControlRunbooksEnableRedshift3ConditionC65BAEF6",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_Redshift.3
+
+## What does this document do?
+This document enables automatic snapshots on a Redshift cluster by calling another SSM document
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Optional) The ARN of the role that allows Automation to perform the actions on your behalf.
+* RemediationRoleName: (Optional) The name of the role that allows Automation to remediate the finding on your behalf.
+
+## Documentation Links
+* [AFSBP Redshift.1](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-redshift-3)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "Redshift.3",
+                  ],
+                  "parse_id_pattern": "^arn:(?:aws|aws-cn|aws-us-gov):redshift:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:cluster:(?!.*--)([a-z][a-z0-9-]{0,62})(?<!-)$",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "ClusterIdentifier",
+                  "Selector": "$.Payload.resource_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationAccount",
+                  "Selector": "$.Payload.account_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationRegion",
+                  "Selector": "$.Payload.resource_region",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RetentionPeriodSerialized",
+                  "Selector": "$.Payload.aws_config_rule.InputParameters",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "event_handler",
+                "InputPayload": {
+                  "SerializedJson": "{{ ParseInput.RetentionPeriodSerialized }}",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import json
+
+def event_handler(event, context):
+    try:
+        return json.loads(event['SerializedJson'])
+    except Exception as e:
+        print(e)
+        exit('Failed to deserialize data')
+",
+              },
+              "name": "ExtractConfigRuleParameters",
+              "outputs": [
+                {
+                  "Name": "MinRetentionPeriod",
+                  "Selector": "$.Payload.MinRetentionPeriod",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-EnableAutomaticSnapshotsOnRedshiftCluster",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "ClusterIdentifier": "{{ ParseInput.ClusterIdentifier }}",
+                  "MinRetentionPeriod": "{{ ExtractConfigRuleParameters.RetentionPeriodSerialized }}",
+                },
+                "TargetLocations": [
+                  {
+                    "Accounts": [
+                      "{{ ParseInput.RemediationAccount }}",
+                    ],
+                    "ExecutionRoleName": "{{ RemediationRoleName }}",
+                    "Regions": [
+                      "{{ ParseInput.RemediationRegion }}",
+                    ],
+                  },
+                ],
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Enabled automatic snapshots on Redshift cluster",
+                  "UpdatedBy": "ASR-PCI_3.2.1_Redshift.3",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the Redshift.3 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-EnableAutomaticSnapshotsOnRedshiftCluster",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_Redshift.3",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksRedshift475A78168": {
+      "Condition": "ControlRunbooksEnableRedshift4Condition2377F6B5",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_Redshift.4
+
+## What does this document do?
+This document disables public access to a Redshift cluster by calling another SSM document
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Optional) The ARN of the role that allows Automation to perform the actions on your behalf.
+* RemediationRoleName: (Optional) The name of the role that allows Automation to remediate the finding on your behalf.
+
+## Documentation Links
+* [AFSBP Redshift.4](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-redshift-1)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "Redshift.4",
+                  ],
+                  "parse_id_pattern": "^arn:(?:aws|aws-cn|aws-us-gov):redshift:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:cluster:(?!.*--)([a-z][a-z0-9-]{0,62})(?<!-)$",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "ClusterIdentifier",
+                  "Selector": "$.Payload.resource_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationAccount",
+                  "Selector": "$.Payload.account_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationRegion",
+                  "Selector": "$.Payload.resource_region",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "check_for_s3_bucket_name",
+                "InputPayload": {
+                  "SerializedJson": "{{ ParseInput.RetentionPeriodSerialized }}",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def check_for_s3_bucket_name(event, context):
+    try:
+        ssm = connect_to_ssm(
+            Config(
+                retries = {
+                    'mode': 'standard'
+                },
+                user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+            )
+        )
+        s3_bucket_name_for_audit_logging = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/afsbp/1.0.0/REDSHIFT.4/S3BucketNameForAuditLogging'
+        )['Parameter'].get('Value', 'unknown')
+    except Exception as e:
+        return {
+            "s3_bucket_name_for_redshift_audit_logging": "NOT_AVAILABLE"
+        }
+    return {
+        "s3_bucket_name_for_redshift_audit_logging": s3_bucket_name_for_audit_logging
+    }
+",
+              },
+              "name": "CheckIfSSMParameterWithS3BucketNameIsAvailable",
+              "outputs": [
+                {
+                  "Name": "BucketName",
+                  "Selector": "$.Payload.s3_bucket_name_for_redshift_audit_logging",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:branch",
+              "inputs": {
+                "Choices": [
+                  {
+                    "NextStep": "UpdateFindingThatS3BucketNameIsNotConfigured",
+                    "StringEquals": "NOT_AVAILABLE",
+                    "Variable": "{{ CheckIfSSMParameterWithS3BucketNameIsAvailable.BucketName }}",
+                  },
+                ],
+                "Default": "Remediation",
+              },
+              "name": "ValidateIfS3BucketNameIsConfigured",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "description": "Abort remediation as s3 bucket name is unavailable.",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Remediation failed the s3 bucket name is not available, review the cloudformation template and select the option Yes for create redshift.4 s3 bucket cloudformation parameter.",
+                  "UpdatedBy": "ASR-PCI_3.2.1_Redshift.4",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "NOTIFIED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFindingThatS3BucketNameIsNotConfigured",
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-EnableRedshiftClusterAuditLogging",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "ClusterIdentifier": "{{ ParseInput.ClusterIdentifier }}",
+                  "MinRetentionPeriod": "{{ ExtractConfigRuleParameters.RetentionPeriodSerialized }}",
+                },
+                "TargetLocations": [
+                  {
+                    "Accounts": [
+                      "{{ ParseInput.RemediationAccount }}",
+                    ],
+                    "ExecutionRoleName": "{{ RemediationRoleName }}",
+                    "Regions": [
+                      "{{ ParseInput.RemediationRegion }}",
+                    ],
+                  },
+                ],
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Enabled Audit logging for the Redshift cluster.",
+                  "UpdatedBy": "ASR-PCI_3.2.1_Redshift.4",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the Redshift.4 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-EnableRedshiftClusterAuditLogging",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_Redshift.4",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksRedshift658631424": {
+      "Condition": "ControlRunbooksEnableRedshift6Condition5A51FC97",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_Redshift.6
+
+## What does this document do?
+This document enables automatic version upgrade on a Redshift cluster by calling another SSM document
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Optional) The ARN of the role that allows Automation to perform the actions on your behalf.
+* RemediationRoleName: (Optional) The name of the role that allows Automation to remediate the finding on your behalf.
+
+## Documentation Links
+* [AFSBP Redshift.6](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-redshift-6)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "Redshift.6",
+                  ],
+                  "parse_id_pattern": "^arn:(?:aws|aws-cn|aws-us-gov):redshift:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:cluster:(?!.*--)([a-z][a-z0-9-]{0,62})(?<!-)$",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "ClusterIdentifier",
+                  "Selector": "$.Payload.resource_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationAccount",
+                  "Selector": "$.Payload.account_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationRegion",
+                  "Selector": "$.Payload.resource_region",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AllowVersionUpgradeSerialized",
+                  "Selector": "$.Payload.aws_config_rule.InputParameters",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "event_handler",
+                "InputPayload": {
+                  "SerializedJson": "{{ ParseInput.AllowVersionUpgradeSerialized }}",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import json
+
+def event_handler(event, context):
+    try:
+        return json.loads(event['SerializedJson'])
+    except Exception as e:
+        print(e)
+        exit('Failed to deserialize data')
+",
+              },
+              "name": "ExtractConfigRuleParameters",
+              "outputs": [
+                {
+                  "Name": "AllowVersionUpgrade",
+                  "Selector": "$.Payload.allowVersionUpgrade",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-EnableAutomaticVersionUpgradeOnRedshiftCluster",
+                "RuntimeParameters": {
+                  "AllowVersionUpgrade": "{{ ExtractConfigRuleParameters.AllowVersionUpgrade }}",
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "ClusterIdentifier": "{{ ParseInput.ClusterIdentifier }}",
+                },
+                "TargetLocations": [
+                  {
+                    "Accounts": [
+                      "{{ ParseInput.RemediationAccount }}",
+                    ],
+                    "ExecutionRoleName": "{{ RemediationRoleName }}",
+                    "Regions": [
+                      "{{ ParseInput.RemediationRegion }}",
+                    ],
+                  },
+                ],
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Enabled automatic version upgrade on Redshift cluster",
+                  "UpdatedBy": "ASR-PCI_3.2.1_Redshift.6",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the Redshift.6 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-EnableAutomaticVersionUpgradeOnRedshiftCluster",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_Redshift.6",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksS311C5AAD45": {
+      "Condition": "ControlRunbooksEnableS31Condition25C33B3F",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_S3.1
+
+## What does this document do?
+This document blocks public access to all buckets by default at the account level.
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Output Parameters
+* Remediation.Output
+
+## Documentation Links
+* [AFSBP v1.0.0 S3.1](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-s3-1)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "S3.1",
+                  ],
+                  "parse_id_pattern": "",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-ConfigureS3PublicAccessBlock",
+                "RuntimeParameters": {
+                  "AccountId": "{{ ParseInput.RemediationAccount }}",
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "BlockPublicAcls": true,
+                  "BlockPublicPolicy": true,
+                  "IgnorePublicAcls": true,
+                  "RestrictPublicBuckets": true,
+                },
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Configured the account to block public S3 access.",
+                  "UpdatedBy": "ASR-PCI_3.2.1_S3.1",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the S3.1 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-ConfigureS3PublicAccessBlock",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_S3.1",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksS3260D6E897": {
+      "Condition": "ControlRunbooksEnableS32ConditionD6F8CCE9",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_S3.2
+
+## What does this document do?
+This document blocks all public access to an S3 bucket.
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Output Parameters
+* Remediation.Output
+
+## Documentation Links
+* [AFSBP v1.0.0 S3.2](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-s3-2)
+* [AFSBP v1.0.0 S3.3](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-s3-3)
+* [AFSBP v1.0.0 S3.8](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-s3-8)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "S3.2",
+                    "S3.3",
+                    "S3.8",
+                  ],
+                  "parse_id_pattern": "^arn:(?:aws|aws-cn|aws-us-gov):s3:::([A-Za-z0-9.-]{3,63})$",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "BucketName",
+                  "Selector": "$.Payload.resource_id",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-ConfigureS3BucketPublicAccessBlock",
+                "RuntimeParameters": {
+                  "AccountId": "{{ ParseInput.RemediationAccount }}",
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "BlockPublicAcls": true,
+                  "BlockPublicPolicy": true,
+                  "BucketName": "{{ ParseInput.BucketName }}",
+                  "IgnorePublicAcls": true,
+                  "RestrictPublicBuckets": true,
+                },
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Disabled public access to S3 bucket.",
+                  "UpdatedBy": "ASR-PCI_3.2.1_S3.2",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the S3.2 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-ConfigureS3BucketPublicAccessBlock",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_S3.2",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksS34F82DA9F1": {
+      "Condition": "ControlRunbooksEnableS34ConditionC23F6623",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_S3.4
+
+## What does this document do?
+This document enables AES-256 as the default encryption for an S3 bucket.
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Output Parameters
+* Remediation.Output
+
+## Documentation Links
+* [AFSBP v1.0.0 S3.4](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-s3-4)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "S3.4",
+                  ],
+                  "parse_id_pattern": "^arn:(?:aws|aws-cn|aws-us-gov):s3:::([A-Za-z0-9.-]{3,63})$",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "BucketName",
+                  "Selector": "$.Payload.resource_id",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-EnableDefaultEncryptionS3",
+                "RuntimeParameters": {
+                  "AccountId": "{{ ParseInput.RemediationAccount }}",
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "BucketName": "{{ ParseInput.BucketName }}",
+                  "KmsKeyAlias": "{{ KmsKeyAlias }}",
+                },
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Enabled default encryption for {{ ParseInput.BucketName }}",
+                  "UpdatedBy": "ASR-PCI_3.2.1_S3.4",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the S3.4 finding",
+              "type": "StringMap",
+            },
+            "KmsKeyAlias": {
+              "allowedPattern": "^$|^[a-zA-Z0-9/_-]{1,256}$",
+              "default": "{{ssm:/Solutions/SO0111/afsbp/1.0.0/S3.4/KmsKeyAlias}}",
+              "description": "(Required) KMS Customer-Managed Key (CMK) alias or the default value which is created in the SSM parameter at solution deployment (default-s3-encryption) is used to identify that the s3 bucket encryption value should be set to AES-256.",
+              "type": "String",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-EnableDefaultEncryptionS3",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_S3.4",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksS356959B795": {
+      "Condition": "ControlRunbooksEnableS35ConditionD5E024B6",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_S3.5
+
+## What does this document do?
+This document adds a bucket policy to restrict internet access to https only.
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Output Parameters
+* Remediation.Output
+
+## Documentation Links
+* [AFSBP v1.0.0 S3.5](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-s3-5)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "S3.5",
+                  ],
+                  "parse_id_pattern": "^arn:(?:aws|aws-cn|aws-us-gov):s3:::([A-Za-z0-9.-]{3,63})$",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "BucketName",
+                  "Selector": "$.Payload.resource_id",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-SetSSLBucketPolicy",
+                "RuntimeParameters": {
+                  "AccountId": "{{ ParseInput.RemediationAccount }}",
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "BucketName": "{{ ParseInput.BucketName }}",
+                },
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Added SSL-only access policy to S3 bucket.",
+                  "UpdatedBy": "ASR-PCI_3.2.1_S3.5",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the S3.5 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-SetSSLBucketPolicy",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_S3.5",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksS360762680A": {
+      "Condition": "ControlRunbooksEnableS36ConditionD22273E2",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_S3.6
+
+## What does this document do?
+This document restricts cross-account access to a bucket in the local account.
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Output Parameters
+* Remediation.Output
+
+## Documentation Links
+* [AFSBP v1.0.0 S3.6](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-s3-6)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "S3.6",
+                  ],
+                  "parse_id_pattern": "^arn:(?:aws|aws-cn|aws-us-gov):s3:::([A-Za-z0-9.-]{3,63})$",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "BucketName",
+                  "Selector": "$.Payload.resource_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "DenyListSerialized",
+                  "Selector": "$.Payload.aws_config_rule.InputParameters",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "runbook_handler",
+                "InputPayload": {
+                  "SerializedList": "{{ ParseInput.DenyListSerialized }}",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import json
+
+def runbook_handler(event, context):
+    try:
+        deserialized = json.loads(event['SerializedList'])
+        if 'blacklistedActionPattern' in deserialized:
+            return deserialized['blacklistedActionPattern'] # Returns comma-delimited list in a string
+        else:
+            exit('Missing blacklistedActionPattern in AWS Config data')
+    except Exception as e:
+        print(e)
+        exit('Failed getting comma-delimited string list of sensitive API calls input data')
+",
+              },
+              "name": "ExtractSensitiveApis",
+              "outputs": [
+                {
+                  "Name": "ListOfApis",
+                  "Selector": "$.Payload",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-S3BlockDenylist",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "BucketName": "{{ ParseInput.BucketName }}",
+                  "DenyList": "{{ ExtractSensitiveApis.ListOfApis }}",
+                },
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Added explicit deny for sensitive bucket access from another account.",
+                  "UpdatedBy": "ASR-PCI_3.2.1_S3.6",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the S3.6 finding",
+              "type": "StringMap",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-S3BlockDenylist",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_S3.6",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksSNS145784CBB": {
+      "Condition": "ControlRunbooksEnableSNS1Condition7720D1CC",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "  ### Document Name - ASR-AFSBP_1.0.0_SNS.1
+
+  ## What does this document do?
+  This document enables encryption at rest using AWS KMS for SNS topics.
+
+  ## Input Parameters
+  * Finding: (Required) Security Hub finding details JSON
+  * AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+  ## Output Parameters
+  * Remediation.Output
+
+  ## Documentation Links
+  * [AFSBP v1.0.0 SNS.1](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-sns-1)",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "SNS.1",
+                  ],
+                  "parse_id_pattern": "",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "SNSTopicArn",
+                  "Selector": "$.Payload.resource_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationAccount",
+                  "Selector": "$.Payload.account_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationRegion",
+                  "Selector": "$.Payload.resource_region",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-EnableEncryptionForSNSTopic",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "KmsKeyArn": "{{ KmsKeyArn }}",
+                  "SNSTopicArn": "{{ ParseInput.SNSTopicArn }}",
+                },
+                "TargetLocations": [
+                  {
+                    "Accounts": [
+                      "{{ ParseInput.RemediationAccount }}",
+                    ],
+                    "ExecutionRoleName": "{{ RemediationRoleName }}",
+                    "Regions": [
+                      "{{ ParseInput.RemediationRegion }}",
+                    ],
+                  },
+                ],
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Encryption enabled on SNS Topic",
+                  "UpdatedBy": "ASR-PCI_3.2.1_SNS.1",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the SNS.1 finding",
+              "type": "StringMap",
+            },
+            "KmsKeyArn": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):kms:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:(?:(?:alias\\/[A-Za-z0-9/-_])|(?:key\\/(?:[0-9a-fA-F]{8}-(?:[0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12})))$",
+              "default": "{{ssm:/Solutions/SO0111/CMK_REMEDIATION_ARN}}",
+              "type": "String",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-EnableEncryptionForSNSTopic",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_SNS.1",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksSNS2112179CC": {
+      "Condition": "ControlRunbooksEnableSNS2Condition69621468",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "  ### Document Name - ASR-AFSBP_1.0.0_SNS.2
+
+  ## What does this document do?
+  This document enables logging of delivery status for notification messages sent to a topic.
+
+  ## Input Parameters
+  * Finding: (Required) Security Hub finding details JSON
+  * AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+  ## Output Parameters
+  * Remediation.Output
+
+  ## Documentation Links
+  * [AFSBP v1.0.0 SNS.2](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-sns-2)",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "SNS.2",
+                  ],
+                  "parse_id_pattern": "",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "SNSTopicArn",
+                  "Selector": "$.Payload.resource_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationAccount",
+                  "Selector": "$.Payload.account_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationRegion",
+                  "Selector": "$.Payload.resource_region",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-EnableDeliveryLoggingForSNSTopic",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "LoggingRole": "{{ LoggingRole }}",
+                  "SNSTopicArn": "{{ ParseInput.SNSTopicArn }}",
+                },
+                "TargetLocations": [
+                  {
+                    "Accounts": [
+                      "{{ ParseInput.RemediationAccount }}",
+                    ],
+                    "ExecutionRoleName": "{{ RemediationRoleName }}",
+                    "Regions": [
+                      "{{ ParseInput.RemediationRegion }}",
+                    ],
+                  },
+                ],
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Delivery Status Logging enabled on SNS Topic",
+                  "UpdatedBy": "ASR-PCI_3.2.1_SNS.2",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the SNS.2 finding",
+              "type": "StringMap",
+            },
+            "LoggingRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role/[\\w+=,.@-]+$",
+              "default": "{{ssm:/Solutions/SO0111/DeliveryStatusLoggingRole}}",
+              "type": "String",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-EnableDeliveryLoggingForSNSTopic",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_SNS.2",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksSQS173AA7C81": {
+      "Condition": "ControlRunbooksEnableSQS1Condition3065B4F2",
+      "Properties": {
+        "Content": {
+          "assumeRole": "{{ AutomationAssumeRole }}",
+          "description": "### Document Name - ASR-AFSBP_1.0.0_SQS.1
+
+## What does this document do?
+This document enables encryption at rest using AWS KMS for SQS Queues.
+
+## Input Parameters
+* Finding: (Required) Security Hub finding details JSON
+* AutomationAssumeRole: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
+
+## Output Parameters
+* Remediation.Output
+
+## Documentation Links
+* [AFSBP v1.0.0 SQS.1](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-sqs-1)
+",
+          "mainSteps": [
+            {
+              "action": "aws:executeScript",
+              "inputs": {
+                "Handler": "parse_event",
+                "InputPayload": {
+                  "Finding": "{{ Finding }}",
+                  "expected_control_id": [
+                    "SQS.1",
+                  ],
+                  "parse_id_pattern": "^arn:(?:aws|aws-us-gov|aws-cn):sqs:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:([a-zA-Z0-9_-]{1,80}(?:\\.fifo)?)$",
+                },
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import re
+import json
+import boto3
+from botocore.config import Config
+
+def connect_to_config(boto_config):
+    return boto3.client('config', config=boto_config)
+
+def connect_to_ssm(boto_config):
+    return boto3.client('ssm', config=boto_config)
+
+def get_solution_id():
+    return 'SO0111'
+
+def get_solution_version():
+    ssm = connect_to_ssm(
+        Config(
+            retries = {
+                'mode': 'standard'
+            },
+            user_agent_extra = f'AwsSolution/{get_solution_id()}/unknown'
+        )
+    )
+    solution_version = 'unknown'
+    try:
+        ssm_parm_value = ssm.get_parameter(
+            Name=f'/Solutions/{get_solution_id()}/member-version'
+        )['Parameter'].get('Value', 'unknown')
+        solution_version = ssm_parm_value
+    except Exception as e:
+        print(e)
+        print(f'ERROR getting solution version')
+    return solution_version
+
+def get_shortname(long_name):
+    short_name = {
+        'aws-foundational-security-best-practices': 'AFSBP',
+        'cis-aws-foundations-benchmark': 'CIS',
+        'pci-dss': 'PCI'
+    }
+    return short_name.get(long_name, None)
+
+def get_config_rule(rule_name):
+    boto_config = Config(
+        retries = {
+            'mode': 'standard'
+        },
+        user_agent_extra = f'AwsSolution/{get_solution_id()}/{get_solution_version()}'
+    )
+    config_rule = None
+    try:
+        configsvc = connect_to_config(boto_config)
+        config_rule = configsvc.describe_config_rules(
+            ConfigRuleNames=[ rule_name ]
+        ).get('ConfigRules', [])[0]
+    except Exception as e:
+        print(e)
+        exit(f'ERROR getting config rule {rule_name}')
+    return config_rule
+
+class FindingEvent:
+    """
+    Finding object returns the parse fields from an input finding json object
+    """
+    def _get_resource_id(self, parse_id_pattern, resource_index):
+        identifier_raw = self.finding_json['Resources'][0]['Id']
+        self.resource_id = identifier_raw
+        self.resource_id_matches = []
+
+        if parse_id_pattern:
+            identifier_match = re.match(
+                parse_id_pattern,
+                identifier_raw
+            )
+
+            if identifier_match:
+                for group in range(1, len(identifier_match.groups())+1):
+                    self.resource_id_matches.append(identifier_match.group(group))
+                self.resource_id = identifier_match.group(resource_index)
+            else:
+                exit(f'ERROR: Invalid resource Id {identifier_raw}')
+            return
+
+    def _get_standard_info(self):
+        match_finding_id = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:subscription/(.*?)/v/(\\d+\\.\\d+\\.\\d+)/(.*)/finding/(?i:[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12})$',
+            self.finding_json['Id']
+        )
+        if match_finding_id:
+            self.standard_id = get_shortname(match_finding_id.group(1))
+            self.standard_version = match_finding_id.group(2)
+            self.control_id = match_finding_id.group(3)
+        else:
+            self.valid_finding = False
+            self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]}'
+
+    def _get_aws_config_rule(self):
+        # config_rule_id refers to the AWS Config Rule that produced the finding
+        if "RelatedAWSResources:0/type" in self.finding_json['ProductFields'] and self.finding_json['ProductFields']['RelatedAWSResources:0/type'] == 'AWS::Config::ConfigRule':
+            self.aws_config_rule_id = self.finding_json['ProductFields']['RelatedAWSResources:0/name']
+            self.aws_config_rule = get_config_rule(self.aws_config_rule_id)
+        return
+
+    def _get_region_from_resource_id(self):
+        check_for_region = re.match(
+            r'^arn:(?:aws|aws-cn|aws-us-gov):[a-zA-Z0-9]+:([a-z]{2}(?:-gov)?-[a-z]+-\\d):.*:.*$',
+            self.finding_json['Resources'][0]['Id']
+        )
+        if check_for_region:
+            self.resource_region = check_for_region.group(1)
+
+    def __init__(self, finding_json, parse_id_pattern, expected_control_id, resource_index):
+        self.valid_finding = True
+        self.resource_region = None
+        self.control_id = None
+        self.aws_config_rule_id = None
+        self.aws_config_rule = {}
+
+        """Populate fields"""
+        # v1.5
+        self.finding_json = finding_json
+        self._get_resource_id(parse_id_pattern, resource_index)     # self.resource_id, self.resource_id_matches
+        self._get_standard_info()                                   # self.standard_id, self.standard_version, self.control_id
+
+        # V1.4
+        self.account_id = self.finding_json.get('AwsAccountId', None)    # deprecate - get Finding.AwsAccountId
+        if not re.match(r'^\\d{12}$', self.account_id):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'AwsAccountId is invalid: {self.account_id}'
+        self.finding_id = self.finding_json.get('Id', None)              # deprecate
+        self.product_arn = self.finding_json.get('ProductArn', None)
+        if not re.match(r'^arn:(?:aws|aws-cn|aws-us-gov):securityhub:[a-z]{2}(?:-gov)?-[a-z]+-\\d::product/aws/securityhub$', self.product_arn):
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'ProductArn is invalid: {self.product_arn}'
+        self.details = self.finding_json['Resources'][0].get('Details', {})
+        # Test mode is used with fabricated finding data to tell the
+        # remediation runbook to run in test more (where supported)
+        # Currently not widely-used and perhaps should be deprecated.
+        self.testmode = bool('testmode' in self.finding_json)
+        self.resource = self.finding_json['Resources'][0]
+        self._get_region_from_resource_id()
+        self._get_aws_config_rule()
+        self.affected_object = {'Type': self.resource['Type'], 'Id': self.resource_id, 'OutputKey': 'Remediation.Output'}
+
+        # Validate control_id
+        if not self.control_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Finding Id is invalid: {self.finding_json["Id"]} - missing Control Id'
+        elif self.control_id not in expected_control_id:  # ControlId is the expected value
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = f'Control Id from input ({self.control_id}) does not match {str(expected_control_id)}'
+
+        if not self.resource_id:
+            if self.valid_finding:
+                self.valid_finding = False
+                self.invalid_finding_reason = 'Resource Id is missing from the finding json Resources (Id)'
+
+        if not self.valid_finding:
+            # Error message and return error data
+            msg = f'ERROR: {self.invalid_finding_reason}'
+            exit(msg)
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+'''
+MAIN
+'''
+def parse_event(event, context):
+    finding_event = FindingEvent(event['Finding'], event['parse_id_pattern'], event['expected_control_id'], event.get('resource_index', 1))
+
+    if not finding_event.valid_finding:
+        exit('ERROR: Finding is not valid')
+
+    return {
+        "account_id": finding_event.account_id,
+        "resource_id": finding_event.resource_id,
+        "finding_id": finding_event.finding_id,         # Deprecate v1.5.0+
+        "control_id": finding_event.control_id,
+        "product_arn": finding_event.product_arn,       # Deprecate v1.5.0+
+        "object": finding_event.affected_object,
+        "matches": finding_event.resource_id_matches,
+        "details": finding_event.details,               # Deprecate v1.5.0+
+        "testmode": finding_event.testmode,             # Deprecate v1.5.0+
+        "resource": finding_event.resource,
+        "resource_region": finding_event.resource_region,
+        "finding": finding_event.finding_json,
+        "aws_config_rule": finding_event.aws_config_rule
+    }
+",
+              },
+              "name": "ParseInput",
+              "outputs": [
+                {
+                  "Name": "FindingId",
+                  "Selector": "$.Payload.finding_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "ProductArn",
+                  "Selector": "$.Payload.product_arn",
+                  "Type": "String",
+                },
+                {
+                  "Name": "AffectedObject",
+                  "Selector": "$.Payload.object",
+                  "Type": "StringMap",
+                },
+                {
+                  "Name": "SQSQueueName",
+                  "Selector": "$.Payload.resource_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationAccount",
+                  "Selector": "$.Payload.account_id",
+                  "Type": "String",
+                },
+                {
+                  "Name": "RemediationRegion",
+                  "Selector": "$.Payload.resource_region",
+                  "Type": "String",
+                },
+              ],
+            },
+            {
+              "action": "aws:executeAutomation",
+              "inputs": {
+                "DocumentName": "ASR-EnableEncryptionForSQSQueue",
+                "RuntimeParameters": {
+                  "AutomationAssumeRole": "arn:{{ global:AWS_PARTITION }}:iam::{{ global:ACCOUNT_ID }}:role/{{ RemediationRoleName }}",
+                  "KmsKeyArn": "{{ KmsKeyArn }}",
+                  "SNSTopicArn": "{{ ParseInput.SQSQueueName }}",
+                  "SQSQueueName": "{{ ParseInput.SQSQueueName }}",
+                },
+                "TargetLocations": [
+                  {
+                    "Accounts": [
+                      "{{ ParseInput.RemediationAccount }}",
+                    ],
+                    "ExecutionRoleName": "{{ RemediationRoleName }}",
+                    "Regions": [
+                      "{{ ParseInput.RemediationRegion }}",
+                    ],
+                  },
+                ],
+              },
+              "name": "Remediation",
+            },
+            {
+              "action": "aws:executeAwsApi",
+              "inputs": {
+                "Api": "BatchUpdateFindings",
+                "FindingIdentifiers": [
+                  {
+                    "Id": "{{ ParseInput.FindingId }}",
+                    "ProductArn": "{{ ParseInput.ProductArn }}",
+                  },
+                ],
+                "Note": {
+                  "Text": "Encryption enabled on SQS Topic",
+                  "UpdatedBy": "ASR-PCI_3.2.1_SQS.1",
+                },
+                "Service": "securityhub",
+                "Workflow": {
+                  "Status": "RESOLVED",
+                },
+              },
+              "isEnd": true,
+              "name": "UpdateFinding",
+            },
+          ],
+          "outputs": [
+            "Remediation.Output",
+            "ParseInput.AffectedObject",
+          ],
+          "parameters": {
+            "AutomationAssumeRole": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):iam::\\d{12}:role\\/[\\w+=,.@-]+$",
+              "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
+              "type": "String",
+            },
+            "Finding": {
+              "description": "The input from the Orchestrator Step function for the SQS.1 finding",
+              "type": "StringMap",
+            },
+            "KmsKeyArn": {
+              "allowedPattern": "^arn:(?:aws|aws-us-gov|aws-cn):kms:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:(?:(?:alias\\/[A-Za-z0-9/-_])|(?:key\\/(?:[0-9a-fA-F]{8}-(?:[0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12})))$",
+              "default": "{{ssm:/Solutions/SO0111/CMK_REMEDIATION_ARN}}",
+              "type": "String",
+            },
+            "RemediationRoleName": {
+              "allowedPattern": "^[\\w+=,.@-]+$",
+              "default": "SO0111-EnableEncryptionForSQSQueue",
+              "type": "String",
+            },
+          },
+          "schemaVersion": "0.3",
+        },
+        "DocumentFormat": "YAML",
+        "DocumentType": "Automation",
+        "Name": "ASR-PCI_3.2.1_SQS.1",
+        "Tags": [
+          {
+            "Key": "CdkGenerated",
+            "Value": "true",
+          },
+        ],
+        "UpdateMethod": "NewVersion",
+      },
+      "Type": "AWS::SSM::Document",
+    },
+  },
+}
+`;

--- a/source/playbooks/SC/test/__snapshots__/security_controls_stack.test.ts.snap
+++ b/source/playbooks/SC/test/__snapshots__/security_controls_stack.test.ts.snap
@@ -9757,6 +9757,10 @@ This document disables public access to RDS instances by calling another SSM doc
 
 ## Documentation Links
 * [AFSBP RDS.2](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-rds-2)
+
+## Troubleshooting
+* ModifyDBInstance isn't supported for a DB instance in a Multi-AZ DB Cluster.
+ - This remediation will not work on an instance within a MySQL or PostgreSQL Multi-AZ Cluster due to limitations with the RDS API. 
 ",
           "mainSteps": [
             {

--- a/source/playbooks/SC/test/security_controls_stack.test.ts
+++ b/source/playbooks/SC/test/security_controls_stack.test.ts
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 import { App, DefaultStackSynthesizer, Stack } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
-import { SecurityControlsPlaybookMemberStack, SecurityControlsPlaybookPrimaryStack } from '../lib/security_controls_playbook-construct';
+import {
+  SecurityControlsPlaybookMemberStack,
+  SecurityControlsPlaybookPrimaryStack,
+} from '../lib/security_controls_playbook-construct';
 
 function getTestStack(): Stack {
   const app = new App();

--- a/source/playbooks/SC/test/security_controls_stack.test.ts
+++ b/source/playbooks/SC/test/security_controls_stack.test.ts
@@ -1,45 +1,48 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { SynthUtils } from '@aws-cdk/assert';
-import * as cdk from 'aws-cdk-lib';
-import { PlaybookPrimaryStack, PlaybookMemberStack } from '../../../lib/sharrplaybook-construct';
+import { App, DefaultStackSynthesizer, Stack } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { SecurityControlsPlaybookMemberStack, SecurityControlsPlaybookPrimaryStack } from '../lib/security_controls_playbook-construct';
 
-function getTestStack(): cdk.Stack {
-  const app = new cdk.App();
-  const stack = new PlaybookPrimaryStack(app, 'stack', {
+function getTestStack(): Stack {
+  const app = new App();
+  const stack = new SecurityControlsPlaybookPrimaryStack(app, 'stack', {
+    synthesizer: new DefaultStackSynthesizer({ generateBootstrapVersionRule: false }),
     description: 'test;',
     solutionId: 'SO0111',
     solutionVersion: 'v1.1.1',
     solutionDistBucket: 'sharrbukkit',
     solutionDistName: 'aws-security-hub-automated-response-and-remediation',
     remediations: [{ control: 'Example.3' }, { control: 'Example.5' }, { control: 'Example.1' }],
-    securityStandard: 'PCI',
-    securityStandardLongName: 'pci-dss',
-    securityStandardVersion: '3.2.1',
+    securityStandard: 'SC',
+    securityStandardLongName: 'security-control',
+    securityStandardVersion: '2.0.0',
   });
   return stack;
 }
 
-test('default stack', () => {
-  expect(SynthUtils.toCloudFormation(getTestStack())).toMatchSnapshot();
+test('admin stack', () => {
+  expect(Template.fromStack(getTestStack())).toMatchSnapshot();
 });
 
-function getMemberStack(): cdk.Stack {
-  const app = new cdk.App();
-  const stack = new PlaybookMemberStack(app, 'memberStack', {
+function getMemberStack(): Stack {
+  const app = new App();
+  const stack = new SecurityControlsPlaybookMemberStack(app, 'memberStack', {
+    synthesizer: new DefaultStackSynthesizer({ generateBootstrapVersionRule: false }),
     description: 'test;',
     solutionId: 'SO0111',
     solutionVersion: 'v1.1.1',
     solutionDistBucket: 'sharrbukkit',
     ssmdocs: 'playbooks/NEWPLAYBOOK/ssmdocs',
-    remediations: [{ control: 'Example.3' }, { control: 'Example.5' }, { control: 'Example.1' }],
+    remediations: [{ control: 'AutoScaling.1' }, { control: 'CloudTrail.5' }, { control: 'Config.1' }],
     securityStandard: 'PCI',
     securityStandardLongName: 'pci-dss',
     securityStandardVersion: '3.2.1',
+    commonScripts: 'playbooks/common',
   });
   return stack;
 }
 
-test('default stack', () => {
-  expect(SynthUtils.toCloudFormation(getMemberStack())).toMatchSnapshot();
+test('member stack', () => {
+  expect(Template.fromStack(getMemberStack())).toMatchSnapshot();
 });

--- a/source/test/admin_account_parm.test.ts
+++ b/source/test/admin_account_parm.test.ts
@@ -1,13 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { SynthUtils } from '@aws-cdk/assert';
-import '@aws-cdk/assert/jest';
-import { App, Stack } from 'aws-cdk-lib';
+import { App, DefaultStackSynthesizer, Stack } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
 import { AdminAccountParm } from '../lib/admin_account_parm-construct';
 
 function createAdminAccountParm(): Stack {
   const app = new App();
   const stack = new Stack(app, 'testStack', {
+    synthesizer: new DefaultStackSynthesizer({ generateBootstrapVersionRule: false }),
     stackName: 'testStack',
   });
   new AdminAccountParm(stack, 'roles');
@@ -15,5 +15,5 @@ function createAdminAccountParm(): Stack {
 }
 
 test('AdminParm Test Stack', () => {
-  expect(SynthUtils.toCloudFormation(createAdminAccountParm())).toMatchSnapshot();
+  expect(Template.fromStack(createAdminAccountParm())).toMatchSnapshot();
 });

--- a/source/test/member_stack.test.ts
+++ b/source/test/member_stack.test.ts
@@ -1,26 +1,26 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { SynthUtils } from '@aws-cdk/assert';
-import * as lambda from 'aws-cdk-lib/aws-lambda';
-import * as cdk from 'aws-cdk-lib';
-import { MemberStack } from '../solution_deploy/lib/sharr_member-stack';
+import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import { App, Aspects, DefaultStackSynthesizer, Stack } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
 import { AwsSolutionsChecks } from 'cdk-nag';
-import { Aspects } from 'aws-cdk-lib';
+import { MemberStack } from '../solution_deploy/lib/sharr_member-stack';
 
-function getCatStack(): cdk.Stack {
-  const app = new cdk.App();
+function getCatStack(): Stack {
+  const app = new App();
   const stack = new MemberStack(app, 'CatalogStack', {
+    synthesizer: new DefaultStackSynthesizer({ generateBootstrapVersionRule: false }),
     description: 'test;',
     solutionId: 'SO0111',
     solutionVersion: 'v1.1.1',
     solutionDistBucket: 'sharrbukkit',
     solutionTMN: 'aws-security-hub-automated-response-and-remediation',
-    runtimePython: lambda.Runtime.PYTHON_3_9,
+    runtimePython: Runtime.PYTHON_3_9,
   });
   Aspects.of(app).add(new AwsSolutionsChecks({ verbose: true }));
   return stack;
 }
 
 test('default stack', () => {
-  expect(SynthUtils.toCloudFormation(getCatStack())).toMatchSnapshot();
+  expect(Template.fromStack(getCatStack())).toMatchSnapshot();
 });

--- a/source/test/orchestrator.test.ts
+++ b/source/test/orchestrator.test.ts
@@ -1,18 +1,17 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { SynthUtils } from '@aws-cdk/assert';
-import '@aws-cdk/assert/jest';
-import { App, Stack } from 'aws-cdk-lib';
-import { OrchestratorConstruct } from '../Orchestrator/lib/common-orchestrator-construct';
-import * as kms from 'aws-cdk-lib/aws-kms';
-import { StringParameter } from 'aws-cdk-lib/aws-ssm';
+import { App, Aspects, DefaultStackSynthesizer, Stack } from 'aws-cdk-lib';
 import { PolicyStatement, PolicyDocument, ServicePrincipal, AccountRootPrincipal } from 'aws-cdk-lib/aws-iam';
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { StringParameter } from 'aws-cdk-lib/aws-ssm';
+import { Template } from 'aws-cdk-lib/assertions';
 import { AwsSolutionsChecks } from 'cdk-nag';
-import { Aspects } from 'aws-cdk-lib';
+import { OrchestratorConstruct } from '../Orchestrator/lib/common-orchestrator-construct';
 
 test('test App Orchestrator Construct', () => {
   const app = new App();
   const stack = new Stack(app, 'testStack', {
+    synthesizer: new DefaultStackSynthesizer({ generateBootstrapVersionRule: false }),
     stackName: 'testStack',
   });
 
@@ -32,7 +31,7 @@ test('test App Orchestrator Construct', () => {
   });
   kmsKeyPolicy.addStatements(kmsRootPolicy);
 
-  const kmsKey = new kms.Key(stack, 'SHARR-key', {
+  const kmsKey = new Key(stack, 'SHARR-key', {
     enableKeyRotation: true,
     alias: 'TO0111-SHARR-Key',
     policy: kmsKeyPolicy,
@@ -58,5 +57,5 @@ test('test App Orchestrator Construct', () => {
     kmsKeyParm: kmsKeyParm,
   });
   Aspects.of(app).add(new AwsSolutionsChecks({ verbose: true }));
-  expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
+  expect(Template.fromStack(stack)).toMatchSnapshot();
 });

--- a/source/test/orchestrator_logs.test.ts
+++ b/source/test/orchestrator_logs.test.ts
@@ -1,14 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { SynthUtils } from '@aws-cdk/assert';
 import * as cdk from 'aws-cdk-lib';
 import { OrchLogStack } from '../solution_deploy/lib/orchestrator-log-stack';
 import { AwsSolutionsChecks } from 'cdk-nag';
-import { Aspects } from 'aws-cdk-lib';
+import { Aspects, DefaultStackSynthesizer } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
 
 function getTestStack(): cdk.Stack {
   const app = new cdk.App();
   const stack = new OrchLogStack(app, 'roles', {
+    synthesizer: new DefaultStackSynthesizer({ generateBootstrapVersionRule: false }),
     description: 'test;',
     solutionId: 'SO0111',
     logGroupName: 'TestLogGroup',
@@ -17,5 +18,5 @@ function getTestStack(): cdk.Stack {
   return stack;
 }
 test('Global Roles Stack', () => {
-  expect(SynthUtils.toCloudFormation(getTestStack())).toMatchSnapshot();
+  expect(Template.fromStack(getTestStack())).toMatchSnapshot()
 });

--- a/source/test/orchestrator_logs.test.ts
+++ b/source/test/orchestrator_logs.test.ts
@@ -18,5 +18,5 @@ function getTestStack(): cdk.Stack {
   return stack;
 }
 test('Global Roles Stack', () => {
-  expect(Template.fromStack(getTestStack())).toMatchSnapshot()
+  expect(Template.fromStack(getTestStack())).toMatchSnapshot();
 });

--- a/source/test/runbook_stack.test.ts
+++ b/source/test/runbook_stack.test.ts
@@ -1,14 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { SynthUtils } from '@aws-cdk/assert';
-import * as cdk from 'aws-cdk-lib';
-import { MemberRoleStack, RemediationRunbookStack } from '../solution_deploy/lib/remediation_runbook-stack';
+import { App, Aspects, DefaultStackSynthesizer, Stack } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
 import { AwsSolutionsChecks } from 'cdk-nag';
-import { Aspects } from 'aws-cdk-lib';
+import { MemberRoleStack, RemediationRunbookStack } from '../solution_deploy/lib/remediation_runbook-stack';
 
 function getRoleTestStack(): MemberRoleStack {
-  const app = new cdk.App();
+  const app = new App();
   const stack = new MemberRoleStack(app, 'roles', {
+    synthesizer: new DefaultStackSynthesizer({ generateBootstrapVersionRule: false }),
     description: 'test;',
     solutionId: 'SO0111',
     solutionVersion: 'v1.1.1',
@@ -17,12 +17,13 @@ function getRoleTestStack(): MemberRoleStack {
   return stack;
 }
 test('Global Roles Stack', () => {
-  expect(SynthUtils.toCloudFormation(getRoleTestStack())).toMatchSnapshot();
+  expect(Template.fromStack(getRoleTestStack())).toMatchSnapshot();
 });
 
-function getSsmTestStack(): cdk.Stack {
-  const app = new cdk.App();
+function getSsmTestStack(): Stack {
+  const app = new App();
   const stack = new RemediationRunbookStack(app, 'stack', {
+    synthesizer: new DefaultStackSynthesizer({ generateBootstrapVersionRule: false }),
     description: 'test;',
     solutionId: 'SO0111',
     solutionVersion: 'v1.1.1',
@@ -35,5 +36,5 @@ function getSsmTestStack(): cdk.Stack {
 }
 
 test('Regional Documents', () => {
-  expect(SynthUtils.toCloudFormation(getSsmTestStack())).toMatchSnapshot();
+  expect(Template.fromStack(getSsmTestStack())).toMatchSnapshot();
 });

--- a/source/test/solution_deploy.test.ts
+++ b/source/test/solution_deploy.test.ts
@@ -1,23 +1,23 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { SynthUtils } from '@aws-cdk/assert';
-import * as cdk from 'aws-cdk-lib';
-import * as lambda from 'aws-cdk-lib/aws-lambda';
-import * as SolutionDeploy from '../solution_deploy/lib/solution_deploy-stack';
+import { App, Aspects, DefaultStackSynthesizer, Stack } from 'aws-cdk-lib';
+import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import { Template } from 'aws-cdk-lib/assertions';
 import { AwsSolutionsChecks } from 'cdk-nag';
-import { Aspects } from 'aws-cdk-lib';
+import { SolutionDeployStack } from '../solution_deploy/lib/solution_deploy-stack';
 
-function getTestStack(): cdk.Stack {
+function getTestStack(): Stack {
   const envEU = { account: '111111111111', region: 'eu-west-1' };
-  const app = new cdk.App();
-  const stack = new SolutionDeploy.SolutionDeployStack(app, 'stack', {
+  const app = new App();
+  const stack = new SolutionDeployStack(app, 'stack', {
+    synthesizer: new DefaultStackSynthesizer({ generateBootstrapVersionRule: false }),
     env: envEU,
     solutionId: 'SO0111',
     solutionVersion: 'v1.0.0',
     solutionDistBucket: 'solutions',
     solutionTMN: 'aws-security-hub-automated-response-and-remediation',
     solutionName: 'AWS Security Hub Automated Response & Remediation',
-    runtimePython: lambda.Runtime.PYTHON_3_9,
+    runtimePython: Runtime.PYTHON_3_9,
     orchLogGroup: 'ORCH_LOG_GROUP',
   });
   Aspects.of(app).add(new AwsSolutionsChecks({ verbose: true }));
@@ -30,5 +30,5 @@ test('Test if the Stack has all the resources.', () => {
   process.env.DIST_VERSION = 'v1.0.0';
   process.env.SOLUTION_ID = 'SO0111111';
   process.env.SOLUTION_TRADEMARKEDNAME = 'aws-security-hub-automated-response-and-remediation';
-  expect(SynthUtils.toCloudFormation(getTestStack())).toMatchSnapshot();
+  expect(Template.fromStack(getTestStack())).toMatchSnapshot();
 });

--- a/source/test/ssmplaybook.test.ts
+++ b/source/test/ssmplaybook.test.ts
@@ -29,33 +29,29 @@ function getSsmPlaybook(): Stack {
 }
 
 test('Test SsmPlaybook Generation', () => {
-  Template.fromStack(getSsmPlaybook()).hasResourceProperties(
-    'AWS::SSM::Document',
-    {
-      Content: {
-        description: '### Document Name - ASR-SECTEST_1.2.3_TEST.1\n',
-        schemaVersion: '0.3',
-        assumeRole: '{{ AutomationAssumeRole }}',
-        outputs: ['VerifySGRules.Response'],
-        parameters: {
-          Finding: {
-            type: 'StringMap',
-            description: 'The input from Step function for TEST1 finding',
-          },
-          AutomationAssumeRole: {
-            type: 'String',
-            description:
-              '(Optional) The ARN of the role that allows Automation to perform the actions on your behalf.',
-            default: '',
-          },
+  Template.fromStack(getSsmPlaybook()).hasResourceProperties('AWS::SSM::Document', {
+    Content: {
+      description: '### Document Name - ASR-SECTEST_1.2.3_TEST.1\n',
+      schemaVersion: '0.3',
+      assumeRole: '{{ AutomationAssumeRole }}',
+      outputs: ['VerifySGRules.Response'],
+      parameters: {
+        Finding: {
+          type: 'StringMap',
+          description: 'The input from Step function for TEST1 finding',
+        },
+        AutomationAssumeRole: {
+          type: 'String',
+          description: '(Optional) The ARN of the role that allows Automation to perform the actions on your behalf.',
+          default: '',
         },
       },
-      DocumentType: 'Automation',
-      Name: 'ASR-SECTEST_1.2.3_TEST.1',
-      DocumentFormat: 'YAML',
-      UpdateMethod: 'NewVersion',
-    }
-  );
+    },
+    DocumentType: 'Automation',
+    Name: 'ASR-SECTEST_1.2.3_TEST.1',
+    DocumentFormat: 'YAML',
+    UpdateMethod: 'NewVersion',
+  });
 });
 
 // ---------------------
@@ -85,33 +81,29 @@ function getSsmRemediationRunbook(): Stack {
 }
 
 test('Test Shared Remediation Generation', () => {
-  Template.fromStack(getSsmRemediationRunbook()).hasResourceProperties(
-    'AWS::SSM::Document',
-    {
-      Content: {
-        description: '### Document Name - ASR-CIS_1.2.0_2.9\n',
-        schemaVersion: '0.3',
-        assumeRole: '{{ AutomationAssumeRole }}',
-        outputs: ['VerifySGRules.Response'],
-        parameters: {
-          Finding: {
-            type: 'StringMap',
-            description: 'The input from Step function for 2.9 finding',
-          },
-          AutomationAssumeRole: {
-            type: 'String',
-            description:
-              '(Optional) The ARN of the role that allows Automation to perform the actions on your behalf.',
-            default: '',
-          },
+  Template.fromStack(getSsmRemediationRunbook()).hasResourceProperties('AWS::SSM::Document', {
+    Content: {
+      description: '### Document Name - ASR-CIS_1.2.0_2.9\n',
+      schemaVersion: '0.3',
+      assumeRole: '{{ AutomationAssumeRole }}',
+      outputs: ['VerifySGRules.Response'],
+      parameters: {
+        Finding: {
+          type: 'StringMap',
+          description: 'The input from Step function for 2.9 finding',
+        },
+        AutomationAssumeRole: {
+          type: 'String',
+          description: '(Optional) The ARN of the role that allows Automation to perform the actions on your behalf.',
+          default: '',
         },
       },
-      DocumentType: 'Automation',
-      Name: 'ASR-blahblahblah',
-      DocumentFormat: 'YAML',
-      UpdateMethod: 'NewVersion',
-    }
-  );
+    },
+    DocumentType: 'Automation',
+    Name: 'ASR-blahblahblah',
+    DocumentFormat: 'YAML',
+    UpdateMethod: 'NewVersion',
+  });
 });
 
 // ------------------
@@ -141,66 +133,63 @@ function getSsmRemediationRoleCis(): Stack {
 }
 
 test('Test SsmRole Generation', () => {
-  Template.fromStack(getSsmRemediationRoleCis()).hasResourceProperties(
-    'AWS::IAM::Role',
-    {
-      AssumeRolePolicyDocument: {
-        Statement: [
-          {
-            Action: 'sts:AssumeRole',
-            Effect: 'Allow',
-            Principal: {
-              AWS: {
-                'Fn::Join': [
-                  '',
-                  [
-                    'arn:',
-                    {
-                      Ref: 'AWS::Partition',
-                    },
-                    ':iam::',
-                    {
-                      Ref: 'AWS::AccountId',
-                    },
-                    ':role/SO0111-SHARR-Orchestrator-Member',
-                  ],
+  Template.fromStack(getSsmRemediationRoleCis()).hasResourceProperties('AWS::IAM::Role', {
+    AssumeRolePolicyDocument: {
+      Statement: [
+        {
+          Action: 'sts:AssumeRole',
+          Effect: 'Allow',
+          Principal: {
+            AWS: {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:',
+                  {
+                    Ref: 'AWS::Partition',
+                  },
+                  ':iam::',
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  ':role/SO0111-SHARR-Orchestrator-Member',
                 ],
-              },
+              ],
             },
           },
-          {
-            Action: 'sts:AssumeRole',
-            Effect: 'Allow',
-            Principal: {
-              Service: "ssm.amazonaws.com",
-            },
+        },
+        {
+          Action: 'sts:AssumeRole',
+          Effect: 'Allow',
+          Principal: {
+            Service: 'ssm.amazonaws.com',
           },
-          {
-            Action: 'sts:AssumeRole',
-            Effect: 'Allow',
-            Principal: {
-              AWS: {
-                'Fn::Join': [
-                  '',
-                  [
-                    'arn:',
-                    {
-                      Ref: 'AWS::Partition',
-                    },
-                    ':iam::',
-                    {
-                      Ref: 'AWS::AccountId',
-                    },
-                    ':root',
-                  ],
+        },
+        {
+          Action: 'sts:AssumeRole',
+          Effect: 'Allow',
+          Principal: {
+            AWS: {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:',
+                  {
+                    Ref: 'AWS::Partition',
+                  },
+                  ':iam::',
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  ':root',
                 ],
-              },
+              ],
             },
           },
-        ],
-        Version: '2012-10-17',
-      },
-      RoleName: 'SHARR-RemediationRoleName',
-    }
-  );
+        },
+      ],
+      Version: '2012-10-17',
+    },
+    RoleName: 'SHARR-RemediationRoleName',
+  });
 });

--- a/source/test/ssmplaybook.test.ts
+++ b/source/test/ssmplaybook.test.ts
@@ -1,12 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { expect as expectCDK, haveResourceLike, ResourcePart } from '@aws-cdk/assert';
 import { App, Aspects, Stack } from 'aws-cdk-lib';
 import { Policy, PolicyStatement, Effect } from 'aws-cdk-lib/aws-iam';
-import { SsmRole } from '../lib/ssmplaybook';
-import { MemberRoleStack } from '../solution_deploy/lib/remediation_runbook-stack';
+import { Template } from 'aws-cdk-lib/assertions';
 import { AwsSolutionsChecks } from 'cdk-nag';
+import { SsmRole } from '../lib/ssmplaybook';
 import { RunbookFactory } from '../solution_deploy/lib/runbook_factory';
+import { MemberRoleStack } from '../solution_deploy/lib/remediation_runbook-stack';
 
 function getSsmPlaybook(): Stack {
   const app = new App();
@@ -29,35 +29,32 @@ function getSsmPlaybook(): Stack {
 }
 
 test('Test SsmPlaybook Generation', () => {
-  expectCDK(getSsmPlaybook()).to(
-    haveResourceLike(
-      'AWS::SSM::Document',
-      {
-        Content: {
-          description: '### Document Name - ASR-SECTEST_1.2.3_TEST.1\n',
-          schemaVersion: '0.3',
-          assumeRole: '{{ AutomationAssumeRole }}',
-          outputs: ['VerifySGRules.Response'],
-          parameters: {
-            Finding: {
-              type: 'StringMap',
-              description: 'The input from Step function for TEST1 finding',
-            },
-            AutomationAssumeRole: {
-              type: 'String',
-              description:
-                '(Optional) The ARN of the role that allows Automation to perform the actions on your behalf.',
-              default: '',
-            },
+  Template.fromStack(getSsmPlaybook()).hasResourceProperties(
+    'AWS::SSM::Document',
+    {
+      Content: {
+        description: '### Document Name - ASR-SECTEST_1.2.3_TEST.1\n',
+        schemaVersion: '0.3',
+        assumeRole: '{{ AutomationAssumeRole }}',
+        outputs: ['VerifySGRules.Response'],
+        parameters: {
+          Finding: {
+            type: 'StringMap',
+            description: 'The input from Step function for TEST1 finding',
+          },
+          AutomationAssumeRole: {
+            type: 'String',
+            description:
+              '(Optional) The ARN of the role that allows Automation to perform the actions on your behalf.',
+            default: '',
           },
         },
-        DocumentType: 'Automation',
-        Name: 'ASR-SECTEST_1.2.3_TEST.1',
-        DocumentFormat: 'YAML',
-        UpdateMethod: 'NewVersion',
       },
-      ResourcePart.Properties
-    )
+      DocumentType: 'Automation',
+      Name: 'ASR-SECTEST_1.2.3_TEST.1',
+      DocumentFormat: 'YAML',
+      UpdateMethod: 'NewVersion',
+    }
   );
 });
 
@@ -88,35 +85,32 @@ function getSsmRemediationRunbook(): Stack {
 }
 
 test('Test Shared Remediation Generation', () => {
-  expectCDK(getSsmRemediationRunbook()).to(
-    haveResourceLike(
-      'AWS::SSM::Document',
-      {
-        Content: {
-          description: '### Document Name - ASR-CIS_1.2.0_2.9\n',
-          schemaVersion: '0.3',
-          assumeRole: '{{ AutomationAssumeRole }}',
-          outputs: ['VerifySGRules.Response'],
-          parameters: {
-            Finding: {
-              type: 'StringMap',
-              description: 'The input from Step function for 2.9 finding',
-            },
-            AutomationAssumeRole: {
-              type: 'String',
-              description:
-                '(Optional) The ARN of the role that allows Automation to perform the actions on your behalf.',
-              default: '',
-            },
+  Template.fromStack(getSsmRemediationRunbook()).hasResourceProperties(
+    'AWS::SSM::Document',
+    {
+      Content: {
+        description: '### Document Name - ASR-CIS_1.2.0_2.9\n',
+        schemaVersion: '0.3',
+        assumeRole: '{{ AutomationAssumeRole }}',
+        outputs: ['VerifySGRules.Response'],
+        parameters: {
+          Finding: {
+            type: 'StringMap',
+            description: 'The input from Step function for 2.9 finding',
+          },
+          AutomationAssumeRole: {
+            type: 'String',
+            description:
+              '(Optional) The ARN of the role that allows Automation to perform the actions on your behalf.',
+            default: '',
           },
         },
-        DocumentType: 'Automation',
-        Name: 'ASR-blahblahblah',
-        DocumentFormat: 'YAML',
-        UpdateMethod: 'NewVersion',
       },
-      ResourcePart.Properties
-    )
+      DocumentType: 'Automation',
+      Name: 'ASR-blahblahblah',
+      DocumentFormat: 'YAML',
+      UpdateMethod: 'NewVersion',
+    }
   );
 });
 
@@ -147,40 +141,66 @@ function getSsmRemediationRoleCis(): Stack {
 }
 
 test('Test SsmRole Generation', () => {
-  expectCDK(getSsmRemediationRoleCis()).to(
-    haveResourceLike(
-      'AWS::IAM::Role',
-      {
-        AssumeRolePolicyDocument: {
-          Statement: [
-            {
-              Action: 'sts:AssumeRole',
-              Effect: 'Allow',
-              Principal: {
-                AWS: {
-                  'Fn::Join': [
-                    '',
-                    [
-                      'arn:',
-                      {
-                        Ref: 'AWS::Partition',
-                      },
-                      ':iam::',
-                      {
-                        Ref: 'AWS::AccountId',
-                      },
-                      ':role/SO0111-SHARR-Orchestrator-Member',
-                    ],
+  Template.fromStack(getSsmRemediationRoleCis()).hasResourceProperties(
+    'AWS::IAM::Role',
+    {
+      AssumeRolePolicyDocument: {
+        Statement: [
+          {
+            Action: 'sts:AssumeRole',
+            Effect: 'Allow',
+            Principal: {
+              AWS: {
+                'Fn::Join': [
+                  '',
+                  [
+                    'arn:',
+                    {
+                      Ref: 'AWS::Partition',
+                    },
+                    ':iam::',
+                    {
+                      Ref: 'AWS::AccountId',
+                    },
+                    ':role/SO0111-SHARR-Orchestrator-Member',
                   ],
-                },
+                ],
               },
             },
-          ],
-          Version: '2012-10-17',
-        },
-        RoleName: 'SHARR-RemediationRoleName',
+          },
+          {
+            Action: 'sts:AssumeRole',
+            Effect: 'Allow',
+            Principal: {
+              Service: "ssm.amazonaws.com",
+            },
+          },
+          {
+            Action: 'sts:AssumeRole',
+            Effect: 'Allow',
+            Principal: {
+              AWS: {
+                'Fn::Join': [
+                  '',
+                  [
+                    'arn:',
+                    {
+                      Ref: 'AWS::Partition',
+                    },
+                    ':iam::',
+                    {
+                      Ref: 'AWS::AccountId',
+                    },
+                    ':root',
+                  ],
+                ],
+              },
+            },
+          },
+        ],
+        Version: '2012-10-17',
       },
-      ResourcePart.Properties
-    )
+      RoleName: 'SHARR-RemediationRoleName',
+    }
   );
 });


### PR DESCRIPTION
- migrate deprecated @aws-cdk/assert to aws-cdk-lib/assertions
- start running snapshot tests for example stack and new stacks

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.