### PR TITLE
Bugfix/rds13multi az cluster

### DIFF
--- a/source/playbooks/AFSBP/ssmdocs/AFSBP_RDS.13.yaml
+++ b/source/playbooks/AFSBP/ssmdocs/AFSBP_RDS.13.yaml
@@ -39,8 +39,8 @@ mainSteps:
   - name: ParseInput
     action: 'aws:executeScript'
     outputs:
-      - Name: 'DbiResourceId'
-        Selector: '$.Payload.resource.Details.AwsRdsDbInstance.DbiResourceId'
+      - Name: 'DBInstanceIdentifier'
+        Selector: '$.Payload.resource.Details.AwsRdsDbInstance.DBInstanceIdentifier'
         Type: String
       - Name: FindingId
         Selector: $.Payload.finding_id
@@ -76,7 +76,7 @@ mainSteps:
           Regions: [ '{{ParseInput.RemediationRegion}}' ]
           ExecutionRoleName: '{{RemediationRoleName}}'
       RuntimeParameters:
-        DbiResourceId: '{{ ParseInput.DbiResourceId }}'
+        DBInstanceIdentifier: '{{ ParseInput.DBInstanceIdentifier }}'
         AutomationAssumeRole: 'arn:{{global:AWS_PARTITION}}:iam::{{global:ACCOUNT_ID}}:role/{{RemediationRoleName}}'
   - name: UpdateFinding
     action: 'aws:executeAwsApi'

--- a/source/playbooks/SC/ssmdocs/SC_RDS.13.ts
+++ b/source/playbooks/SC/ssmdocs/SC_RDS.13.ts
@@ -16,7 +16,7 @@ class RDS_13_ControlRunbookDocument extends ControlRunbookDocument {
       securityControlId: 'RDS.13',
       remediationName: 'EnableMinorVersionUpgradeOnRDSDBInstance',
       scope: RemediationScope.REGIONAL,
-      updateDescription: HardCodedString.of('Minor Version enabled on the RDS Instance.'),
+      updateDescription: HardCodedString.of('Minor Version enabled on the RDS Instance or Multi-AZ RDS Cluster.'),
     });
   }
 
@@ -25,9 +25,9 @@ class RDS_13_ControlRunbookDocument extends ControlRunbookDocument {
     const outputs = super.getParseInputStepOutputs();
 
     outputs.push({
-      name: 'DbiResourceId',
+      name: 'DBInstanceIdentifier',
       outputType: DataTypeEnum.STRING,
-      selector: '$.Payload.resource.Details.AwsRdsDbInstance.DbiResourceId',
+      selector: '$.Payload.resource.Details.AwsRdsDbInstance.DBInstanceIdentifier',
     });
 
     return outputs;
@@ -38,7 +38,7 @@ class RDS_13_ControlRunbookDocument extends ControlRunbookDocument {
   protected getRemediationParams(): { [_: string]: any } {
     const params = super.getRemediationParams();
 
-    params.DbiResourceId = StringVariable.of('ParseInput.DbiResourceId');
+    params.DBInstanceIdentifier = StringVariable.of('ParseInput.DBInstanceIdentifier');
 
     return params;
   }

--- a/source/remediation_runbooks/EnableMinorVersionUpgradeOnRDSDBInstance.yaml
+++ b/source/remediation_runbooks/EnableMinorVersionUpgradeOnRDSDBInstance.yaml
@@ -23,7 +23,7 @@ parameters:
   DBInstanceIdentifier:
     type: String
     description: (Required) Identifier of the Amazon RDS instance for which AutoMinorVersionUpgrade needs to be enabled.
-    allowedPattern: "^db-[A-Z0-9]{26}$"
+    allowedPattern: "^(?!.*--)[a-zA-Z][a-zA-Z0-9.,$;-]{0,58}[^-]$"
 outputs:
   - ModifyDBInstance.Output
 mainSteps:

--- a/source/remediation_runbooks/EnableMinorVersionUpgradeOnRDSDBInstance.yaml
+++ b/source/remediation_runbooks/EnableMinorVersionUpgradeOnRDSDBInstance.yaml
@@ -20,76 +20,23 @@ parameters:
     type: String
     description: (Required) The ARN of the role that allows Automation to perform the actions on your behalf.
     allowedPattern: '^arn:(?:aws|aws-us-gov|aws-cn):iam::\d{12}:role/[\w+=,.@-]+$'
-  DbiResourceId:
+  DBInstanceIdentifier:
     type: String
-    description: (Required) Resource ID of the Amazon RDS instance for which AutoMinorVersionUpgrade needs to be enabled.
+    description: (Required) Identifier of the Amazon RDS instance for which AutoMinorVersionUpgrade needs to be enabled.
     allowedPattern: "^db-[A-Z0-9]{26}$"
 outputs:
   - ModifyDBInstance.Output
 mainSteps:
-  - name: GetRDSInstanceIdentifier
-    action: "aws:executeAwsApi"
-    description: |
-      ## GetRDSInstanceIdentifier
-      Makes DescribeDBInstances API call using the database instance resource identifier to get DBInstanceIdentifier.
-      ## Outputs
-      * DBInstanceIdentifier: DBInstance identifier of the Amazon RDS instance.
-    timeoutSeconds: 600
-    isEnd: false
-    inputs:
-      Service: rds
-      Api: DescribeDBInstances
-      Filters:
-        - Name: dbi-resource-id
-          Values:
-            - "{{ DbiResourceId }}"
-    outputs:
-      - Name: DBInstanceIdentifier
-        Selector: "$.DBInstances[0].DBInstanceIdentifier"
-        Type: String
-  - name: VerifyDBInstanceStatus
-    action: "aws:assertAwsResourceProperty"
-    timeoutSeconds: 600
-    isEnd: false
-    description: |
-      ## VerifyDBInstanceStatus
-      Verifies whether AWS RDS DBInstance status is available before enabling AutoMiniorVersionUpgrade.
-    inputs:
-      Service: rds
-      Api: DescribeDBInstances
-      DBInstanceIdentifier: "{{ GetRDSInstanceIdentifier.DBInstanceIdentifier }}"
-      PropertySelector: "$.DBInstances[0].DBInstanceStatus"
-      DesiredValues:
-        - "available"
   - name: ModifyDBInstance
-    action: "aws:executeAwsApi"
-    description: |
-      ## ModifyDBInstance
-      Makes ModifyDBInstance API call to enable AutoMinorVersionUpgrade on the Amazon RDS instance using the DBInstanceIdentifier.
-      ## Outputs
-      * Output: The standard HTTP response from the ModifyDBInstance API.
-    timeoutSeconds: 600
-    isEnd: false
-    inputs:
-      Service: rds
-      Api: ModifyDBInstance
-      DBInstanceIdentifier: "{{ GetRDSInstanceIdentifier.DBInstanceIdentifier }}"
-      AutoMinorVersionUpgrade: true
+    action: 'aws:executeScript'
     outputs:
       - Name: Output
-        Selector: $
+        Selector: $.Payload.response
         Type: StringMap
-  - name: VerifyDBInstanceState
-    action: "aws:assertAwsResourceProperty"
-    timeoutSeconds: 600
-    isEnd: true
-    description: |
-      ## VerifyDBInstanceState
-      Verifies the Amazon RDS Instance's "AutoMinorVersionUpgrade" property is set to "True".
     inputs:
-      Service: rds
-      Api: DescribeDBInstances
-      DBInstanceIdentifier: "{{ GetRDSInstanceIdentifier.DBInstanceIdentifier }}"
-      PropertySelector: "$.DBInstances[0].AutoMinorVersionUpgrade"
-      DesiredValues:
-        - "True"
+      InputPayload:
+        DBInstanceIdentifier: "{{DBInstanceIdentifier}}"
+      Runtime: python3.8
+      Handler: lambda_handler
+      Script: |-
+        %%SCRIPT=enable_minor_version_upgrade_rds.py%%

--- a/source/remediation_runbooks/scripts/enable_minor_version_upgrade_rds.py
+++ b/source/remediation_runbooks/scripts/enable_minor_version_upgrade_rds.py
@@ -1,0 +1,120 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import boto3
+from botocore.config import Config
+
+boto_config = Config(
+    retries = {
+            'mode': 'standard',
+            'max_attempts': 10
+        }
+    )
+
+multiAZClusterEngines = ["mysql","postgres"]
+
+def connect_to_rds():
+    return boto3.client('rds', config=boto_config)
+
+def lambda_handler(event, _):
+    """
+     Enable auto minor version upgrades on an instance or a Multi-AZ Cluster
+ 
+     `event` should have the following keys and values:
+     `DBInstanceIdentifier`: The identifier of the database instance that is to be modified.
+ 
+     `context` is ignored
+    """
+    dbInstanceID = event["DBInstanceIdentifier"]
+
+    rds = connect_to_rds()
+
+    foundInstance = rds.describe_db_instances(DBInstanceIdentifier=dbInstanceID)
+
+    instanceInfo = foundInstance['DBInstances'][0]
+
+    response = False
+
+    if ("DBClusterIdentifier" in instanceInfo.keys()):
+        if (multi_az_check(instanceInfo["DBClusterIdentifier"])):
+            clusterID = instanceInfo["DBClusterIdentifier"]
+            enable_minor_version_upgrade_cluster(clusterID)
+            response = verify_cluster_changes(clusterID)
+        else:
+            enable_minor_version_upgrade_instance(dbInstanceID)
+            response = verify_instance_changes(dbInstanceID)
+    else:
+        enable_minor_version_upgrade_instance(dbInstanceID)
+        response = verify_instance_changes(dbInstanceID)
+        
+    if response == True:
+        return {
+            "AutoMinorVersionUpgrade": response
+        }
+    
+    raise Exception(f'ASR Remediation failed - {dbInstanceID} did not have enable auto minor version upgrades enabled.')
+
+def multi_az_check(clusterID):
+    """
+    Checks to see if the cluster is Multi-AZ. Instances within clusters that match this check are not able to be modified.
+    """  
+
+    rds = connect_to_rds()
+    try:
+        foundCluster = rds.describe_db_clusters(DBClusterIdentifier=clusterID)
+        clusterInfo = foundCluster['DBCluster']
+    except Exception as e:
+        exit(f'Failed to get information about the cluster: {clusterID} ')
+
+    return ((clusterInfo["MultiAZ"] == True) and (clusterInfo["Engine"] in multiAZClusterEngines))
+
+
+def enable_minor_version_upgrade_cluster(clusterID):
+    """
+    Enables automatic minor version upgrade for a Multi-AZ Cluster.
+    """ 
+
+    rds = connect_to_rds()
+    try:
+        rds.modify_db_cluster(DBClusterIdentifier=clusterID,AutoMinorVersionUpgrade=True)
+    except Exception as e:
+        exit(f'Failed to modify the cluster: {clusterID}. Error: {e}')
+
+def enable_minor_version_upgrade_instance(instanceID):
+    """
+    Enables automatic minor version upgrade for an instance.
+    """ 
+
+    rds = connect_to_rds()
+    try:
+        rds.modify_db_instance(DBInstanceIdentifier=instanceID,AutoMinorVersionUpgrade=True)
+    except Exception as e:
+        exit(f'Failed to modify the instance: {instanceID}. Error: {e}')
+
+def verify_cluster_changes(clusterID):
+    """
+    Verifies automatic minor version upgrade for a Multi-AZ cluster.
+    """ 
+    rds = connect_to_rds()
+    try:
+        foundCluster = rds.describe_db_clusters(DBClusterIdentifier=clusterID, MaxRecords=100)
+        clusterInfo = foundCluster['DBCluster']
+
+    except Exception as e:
+        exit(f'Failed to verify cluster changes: {clusterID}. Error: {e}')
+
+    return clusterInfo['AutoMinorVersionUpgrade']
+        
+def verify_instance_changes(instanceID):
+    """
+    Verifies automatic minor version upgrade for an instance.
+    """ 
+    rds = connect_to_rds()
+    try:
+        foundInstance = rds.describe_db_instances(DBInstanceIdentifier=instanceID, MaxRecords=100)
+        instanceInfo = foundInstance['DBInstances'][0]
+    except Exception as e:
+
+        exit(f'Failed to verify instance changes: {instanceID}. Error: {e}')
+
+    return instanceInfo['AutoMinorVersionUpgrade'] 
+

--- a/source/remediation_runbooks/scripts/enable_minor_version_upgrade_rds.py
+++ b/source/remediation_runbooks/scripts/enable_minor_version_upgrade_rds.py
@@ -61,7 +61,7 @@ def multi_az_check(clusterID):
     rds = connect_to_rds()
     try:
         foundCluster = rds.describe_db_clusters(DBClusterIdentifier=clusterID)
-        clusterInfo = foundCluster['DBCluster']
+        clusterInfo = foundCluster['DBClusters'][0]
     except Exception as e:
         exit(f'Failed to get information about the cluster: {clusterID} ')
 
@@ -97,7 +97,7 @@ def verify_cluster_changes(clusterID):
     rds = connect_to_rds()
     try:
         foundCluster = rds.describe_db_clusters(DBClusterIdentifier=clusterID, MaxRecords=100)
-        clusterInfo = foundCluster['DBCluster']
+        clusterInfo = foundCluster['DBClusters'][0]
 
     except Exception as e:
         exit(f'Failed to verify cluster changes: {clusterID}. Error: {e}')

--- a/source/remediation_runbooks/scripts/test/test_enable_minor_version_upgrade_rds.py
+++ b/source/remediation_runbooks/scripts/test/test_enable_minor_version_upgrade_rds.py
@@ -82,7 +82,7 @@ def test_enable_minor_version_upgrade_rds_instance(mocker):
  
     stub_rds.add_response(
        'describe_db_instances',
-       describedInstanceCluster,
+       describedInstance,
        { 
          "DBInstanceIdentifier": instanceId
        }
@@ -115,53 +115,6 @@ def test_enable_minor_version_upgrade_rds_instance(mocker):
             "AutoMinorVersionUpgrade": True
 }
 
-
-describedInstance = {
-    'DBInstances': 
-    [{
-        'DBInstanceIdentifier': 'database-instance', 
-        'DBInstanceClass': 'db.r6g.2xlarge', 
-        'Engine': 'aurora-mysql', 
-        'DBInstanceStatus': 'available', 
-        'MasterUsername': 'admin', 
-        'Endpoint': 
-        {
-            'Address': 'test.amazonaws.com', 
-            'Port': 321, 
-            'HostedZoneId': 'test'
-        }, 
-        'AllocatedStorage': 1, 
-        'PreferredBackupWindow': '09:05-09:35', 
-        'BackupRetentionPeriod': 1, 'DBSecurityGroups': [], 
-        'VpcSecurityGroups': [{'VpcSecurityGroupId': 'sg-', 'Status': 'active'}], 
-        'DBParameterGroups': [{'DBParameterGroupName': 'default.aurora-mysql5.7', 'ParameterApplyStatus': 'in-sync'}], 
-        'AvailabilityZone': 'us-east-1a', 'DBSubnetGroup': {'DBSubnetGroupName': 'default-vpc-', 
-        'DBSubnetGroupDescription': 'Created from the RDS Management Console', 'VpcId': 'vpc-', 
-        'SubnetGroupStatus': 'Complete', 'Subnets': [{'SubnetIdentifier': 'subnet-', 
-        'SubnetAvailabilityZone': {'Name': 'us-east-1c'}, 'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, 
-        {'SubnetIdentifier': 'subnet-', 'SubnetAvailabilityZone': {'Name': 'us-east-1f'}, 
-        'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, {'SubnetIdentifier': 'subnet-', 
-        'SubnetAvailabilityZone': {'Name': 'us-east-1b'}, 'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, 
-        {'SubnetIdentifier': 'subnet-', 'SubnetAvailabilityZone': {'Name': 'us-east-1a'}, 
-        'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, {'SubnetIdentifier': 'subnet-', 
-        'SubnetAvailabilityZone': {'Name': 'us-east-1e'}, 'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, 
-        {'SubnetIdentifier': 'subnet-', 'SubnetAvailabilityZone': {'Name': 'us-east-1d'}, 
-        'SubnetOutpost': {}, 'SubnetStatus': 'Active'}]}, 'PreferredMaintenanceWindow': 'sun:07:48-sun:08:18', 
-        'PendingModifiedValues': {}, 'MultiAZ': False, 'EngineVersion': '5.7.mysql_aurora.2.10.2', 
-        'AutoMinorVersionUpgrade': False, 'ReadReplicaDBInstanceIdentifiers': [], 'LicenseModel': 'general-public-license',
-        'OptionGroupMemberships': [{'OptionGroupName': 'default:aurora-mysql-5-7', 'Status': 'in-sync'}], 
-        'PubliclyAccessible': False, 'StorageType': 'aurora', 'DbInstancePort': 0, 
-        'StorageEncrypted': False, 'DbiResourceId': 'db-',
-        'CACertificateIdentifier': 'rds-ca-2019', 'DomainMemberships': [], 'CopyTagsToSnapshot': False, 
-        'MonitoringInterval': 60, 
-        'EnhancedMonitoringResourceArn': '', 
-        'MonitoringRoleArn': '', 
-        'PromotionTier': 1, 
-        'DBInstanceArn': '', 
-        'IAMDatabaseAuthenticationEnabled': False, 'PerformanceInsightsEnabled': False, 
-        'DeletionProtection': False, 'AssociatedRoles': [], 'TagList': [], 'CustomerOwnedIpEnabled': False, 'BackupTarget': 'region', 'NetworkType': 'IPV4', 'StorageThroughput': 0}], 'ResponseMetadata': {'RequestId': '319d76ec-75e9-4030-9c4c-a5b648c0186e', 'HTTPStatusCode': 200, 'HTTPHeaders': {'x-amzn-requestid': '319d76ec-75e9-4030-9c4c-a5b648c0186e', 'strict-transport-security': 'max-age=31536000', 
-        'content-type': 'text/xml', 'content-length': '6206', 'date': 'Wed, 25 Jan 2023 22:48:55 GMT'}, 'RetryAttempts': 0}}
-
 describedInstanceCluster = {
     'DBInstances': 
     [{
@@ -179,40 +132,118 @@ describedInstanceCluster = {
         }, 
         'AllocatedStorage': 1, 
         'PreferredBackupWindow': '09:05-09:35', 
-        'BackupRetentionPeriod': 1, 'DBSecurityGroups': [], 
-        'VpcSecurityGroups': [{'VpcSecurityGroupId': 'sg-', 'Status': 'active'}], 
-        'DBParameterGroups': [{'DBParameterGroupName': 'default.aurora-mysql5.7', 'ParameterApplyStatus': 'in-sync'}], 
-        'AvailabilityZone': 'us-east-1a', 'DBSubnetGroup': {'DBSubnetGroupName': 'default-vpc-', 
-        'DBSubnetGroupDescription': 'Created from the RDS Management Console', 'VpcId': 'vpc-', 
-        'SubnetGroupStatus': 'Complete', 'Subnets': [{'SubnetIdentifier': 'subnet-', 
-        'SubnetAvailabilityZone': {'Name': 'us-east-1c'}, 'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, 
-        {'SubnetIdentifier': 'subnet-', 'SubnetAvailabilityZone': {'Name': 'us-east-1f'}, 
-        'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, {'SubnetIdentifier': 'subnet-', 
-        'SubnetAvailabilityZone': {'Name': 'us-east-1b'}, 'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, 
-        {'SubnetIdentifier': 'subnet-', 'SubnetAvailabilityZone': {'Name': 'us-east-1a'}, 
-        'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, {'SubnetIdentifier': 'subnet-', 
-        'SubnetAvailabilityZone': {'Name': 'us-east-1e'}, 'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, 
-        {'SubnetIdentifier': 'subnet-', 'SubnetAvailabilityZone': {'Name': 'us-east-1d'}, 
-        'SubnetOutpost': {}, 'SubnetStatus': 'Active'}]}, 'PreferredMaintenanceWindow': 'sun:07:48-sun:08:18', 
-        'PendingModifiedValues': {}, 'MultiAZ': False, 'EngineVersion': '5.7.mysql_aurora.2.10.2', 
-        'AutoMinorVersionUpgrade': False, 'ReadReplicaDBInstanceIdentifiers': [], 'LicenseModel': 'general-public-license',
-        'OptionGroupMemberships': [{'OptionGroupName': 'default:aurora-mysql-5-7', 'Status': 'in-sync'}], 
-        'PubliclyAccessible': False, 'StorageType': 'aurora', 'DbInstancePort': 0, 
-        'StorageEncrypted': False, 'DbiResourceId': 'db-',
-        'CACertificateIdentifier': 'rds-ca-2019', 'DomainMemberships': [], 'CopyTagsToSnapshot': False, 
+        'BackupRetentionPeriod': 1, 
+        'DBSecurityGroups': [], 
+        'VpcSecurityGroups': 
+        [{
+            'VpcSecurityGroupId': 
+            'sg-', 
+            'Status': 'active'
+        }], 
+        'DBParameterGroups': 
+        [{
+            'DBParameterGroupName': 'default.aurora-mysql5.7', 
+            'ParameterApplyStatus': 'in-sync'
+        }], 
+        'AvailabilityZone': 'us-east-1a', 
+        'DBSubnetGroup': 
+        {
+            'DBSubnetGroupName': 'default-vpc-', 
+            'DBSubnetGroupDescription': 'Created from the RDS Management Console', 
+            'VpcId': 'vpc-', 
+            'SubnetGroupStatus': 'Complete', 
+            'Subnets': 
+            [{
+                'SubnetIdentifier': 'subnet-', 
+                'SubnetAvailabilityZone': {'Name': 'us-east-1c'}, 
+                'SubnetOutpost': {}, 
+                'SubnetStatus': 'Active'
+            }, 
+            {
+                'SubnetIdentifier': 
+                'subnet-', 
+                'SubnetAvailabilityZone': {'Name': 'us-east-1f'}, 
+                'SubnetOutpost': {}, 
+                'SubnetStatus': 'Active'
+            }, 
+            {
+                'SubnetIdentifier': 'subnet-', 
+                'SubnetAvailabilityZone': {'Name': 'us-east-1b'}, 
+                'SubnetOutpost': {}, 
+                'SubnetStatus': 'Active'
+            }, 
+            {
+                'SubnetIdentifier': 'subnet-', 
+                'SubnetAvailabilityZone': {'Name': 'us-east-1a'}, 
+                'SubnetOutpost': {}, 
+                'SubnetStatus': 'Active'
+            }, 
+            {
+                'SubnetIdentifier': 'subnet-', 
+                'SubnetAvailabilityZone': {'Name': 'us-east-1e'}, 
+                'SubnetOutpost': {}, 
+                'SubnetStatus': 'Active'
+            }, 
+            {
+                'SubnetIdentifier': 'subnet-', 
+                'SubnetAvailabilityZone': {'Name': 'us-east-1d'}, 
+                'SubnetOutpost': {}, 'SubnetStatus': 'Active'
+            }
+            ]
+        }, 
+        'PreferredMaintenanceWindow': 'sun:07:48-sun:08:18', 
+        'PendingModifiedValues': {}, 
+        'MultiAZ': False, 
+        'EngineVersion': '5.7.mysql_aurora.2.10.2', 
+        'AutoMinorVersionUpgrade': False, 
+        'ReadReplicaDBInstanceIdentifiers': [], 
+        'LicenseModel': 'general-public-license',
+        'OptionGroupMemberships': 
+        [{
+            'OptionGroupName': 'default:aurora-mysql-5-7', 
+            'Status': 'in-sync'
+        }], 
+        'PubliclyAccessible': False, 
+        'StorageType': 'aurora', 
+        'DbInstancePort': 0, 
+        'StorageEncrypted': False, 
+        'DbiResourceId': 'db-',
+        'CACertificateIdentifier': 'rds-ca-2019', 
+        'DomainMemberships': [],
+        'CopyTagsToSnapshot': False, 
         'MonitoringInterval': 60, 
         'EnhancedMonitoringResourceArn': '', 
         'MonitoringRoleArn': '', 
         'PromotionTier': 1, 
         'DBInstanceArn': '', 
-        'IAMDatabaseAuthenticationEnabled': False, 'PerformanceInsightsEnabled': False, 
-        'DeletionProtection': False, 'AssociatedRoles': [], 'TagList': [], 'CustomerOwnedIpEnabled': False, 'BackupTarget': 'region', 'NetworkType': 'IPV4', 'StorageThroughput': 0}], 'ResponseMetadata': {'RequestId': '319d76ec-75e9-4030-9c4c-a5b648c0186e', 'HTTPStatusCode': 200, 'HTTPHeaders': {'x-amzn-requestid': '319d76ec-75e9-4030-9c4c-a5b648c0186e', 'strict-transport-security': 'max-age=31536000', 
-        'content-type': 'text/xml', 'content-length': '6206', 'date': 'Wed, 25 Jan 2023 22:48:55 GMT'}, 'RetryAttempts': 0}}
+        'IAMDatabaseAuthenticationEnabled': False, 
+        'PerformanceInsightsEnabled': False, 
+        'DeletionProtection': False, 
+        'AssociatedRoles': [], 
+        'TagList': [], 
+        'CustomerOwnedIpEnabled': False,
+        'BackupTarget': 'region', 
+        'NetworkType': 'IPV4', 
+        'StorageThroughput': 0
+        }], 
+        'ResponseMetadata': 
+        {'RequestId': '319d76ec-75e9-4030-9c4c-a5b648c0186e', 
+        'HTTPStatusCode': 200, 
+        'HTTPHeaders': 
+        {
+            'x-amzn-requestid': '319d76ec-75e9-4030-9c4c-a5b648c0186e', 
+            'strict-transport-security': 'max-age=31536000', 
+            'content-type': 'text/xml', 
+            'content-length': '6206', 
+            'date': 'Wed, 25 Jan 2023 22:48:55 GMT'
+        }, 
+        'RetryAttempts': 0
+        }}
 
 describedInstanceMinorVersionUpgrade = {
     'DBInstances': 
     [{
-        'DBInstanceIdentifier': 'database-instance', 
+        'DBInstanceIdentifier': 'database-instance',
         'DBInstanceClass': 'db.r6g.2xlarge', 
         'Engine': 'aurora-mysql', 
         'DBInstanceStatus': 'available', 
@@ -225,42 +256,120 @@ describedInstanceMinorVersionUpgrade = {
         }, 
         'AllocatedStorage': 1, 
         'PreferredBackupWindow': '09:05-09:35', 
-        'BackupRetentionPeriod': 1, 'DBSecurityGroups': [], 
-        'VpcSecurityGroups': [{'VpcSecurityGroupId': 'sg-', 'Status': 'active'}], 
-        'DBParameterGroups': [{'DBParameterGroupName': 'default.aurora-mysql5.7', 'ParameterApplyStatus': 'in-sync'}], 
-        'AvailabilityZone': 'us-east-1a', 'DBSubnetGroup': {'DBSubnetGroupName': 'default-vpc-', 
-        'DBSubnetGroupDescription': 'Created from the RDS Management Console', 'VpcId': 'vpc-', 
-        'SubnetGroupStatus': 'Complete', 'Subnets': [{'SubnetIdentifier': 'subnet-', 
-        'SubnetAvailabilityZone': {'Name': 'us-east-1c'}, 'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, 
-        {'SubnetIdentifier': 'subnet-', 'SubnetAvailabilityZone': {'Name': 'us-east-1f'}, 
-        'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, {'SubnetIdentifier': 'subnet-', 
-        'SubnetAvailabilityZone': {'Name': 'us-east-1b'}, 'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, 
-        {'SubnetIdentifier': 'subnet-', 'SubnetAvailabilityZone': {'Name': 'us-east-1a'}, 
-        'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, {'SubnetIdentifier': 'subnet-', 
-        'SubnetAvailabilityZone': {'Name': 'us-east-1e'}, 'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, 
-        {'SubnetIdentifier': 'subnet-', 'SubnetAvailabilityZone': {'Name': 'us-east-1d'}, 
-        'SubnetOutpost': {}, 'SubnetStatus': 'Active'}]}, 'PreferredMaintenanceWindow': 'sun:07:48-sun:08:18', 
-        'PendingModifiedValues': {}, 'MultiAZ': False, 'EngineVersion': '5.7.mysql_aurora.2.10.2', 
-        'AutoMinorVersionUpgrade': True, 'ReadReplicaDBInstanceIdentifiers': [], 'LicenseModel': 'general-public-license',
-        'OptionGroupMemberships': [{'OptionGroupName': 'default:aurora-mysql-5-7', 'Status': 'in-sync'}], 
-        'PubliclyAccessible': False, 'StorageType': 'aurora', 'DbInstancePort': 0, 
-        'StorageEncrypted': False, 'DbiResourceId': 'db-',
-        'CACertificateIdentifier': 'rds-ca-2019', 'DomainMemberships': [], 'CopyTagsToSnapshot': False, 
+        'BackupRetentionPeriod': 1, 
+        'DBSecurityGroups': [], 
+        'VpcSecurityGroups': 
+        [{
+            'VpcSecurityGroupId': 
+            'sg-', 
+            'Status': 'active'
+        }], 
+        'DBParameterGroups': 
+        [{
+            'DBParameterGroupName': 'default.aurora-mysql5.7', 
+            'ParameterApplyStatus': 'in-sync'
+        }], 
+        'AvailabilityZone': 'us-east-1a', 
+        'DBSubnetGroup': 
+        {
+            'DBSubnetGroupName': 'default-vpc-', 
+            'DBSubnetGroupDescription': 'Created from the RDS Management Console', 
+            'VpcId': 'vpc-', 
+            'SubnetGroupStatus': 'Complete', 
+            'Subnets': 
+            [{
+                'SubnetIdentifier': 'subnet-', 
+                'SubnetAvailabilityZone': {'Name': 'us-east-1c'}, 
+                'SubnetOutpost': {}, 
+                'SubnetStatus': 'Active'
+            }, 
+            {
+                'SubnetIdentifier': 
+                'subnet-', 
+                'SubnetAvailabilityZone': {'Name': 'us-east-1f'}, 
+                'SubnetOutpost': {}, 
+                'SubnetStatus': 'Active'
+            }, 
+            {
+                'SubnetIdentifier': 'subnet-', 
+                'SubnetAvailabilityZone': {'Name': 'us-east-1b'}, 
+                'SubnetOutpost': {}, 
+                'SubnetStatus': 'Active'
+            }, 
+            {
+                'SubnetIdentifier': 'subnet-', 
+                'SubnetAvailabilityZone': {'Name': 'us-east-1a'}, 
+                'SubnetOutpost': {}, 
+                'SubnetStatus': 'Active'
+            }, 
+            {
+                'SubnetIdentifier': 'subnet-', 
+                'SubnetAvailabilityZone': {'Name': 'us-east-1e'}, 
+                'SubnetOutpost': {}, 
+                'SubnetStatus': 'Active'
+            }, 
+            {
+                'SubnetIdentifier': 'subnet-', 
+                'SubnetAvailabilityZone': {'Name': 'us-east-1d'}, 
+                'SubnetOutpost': {}, 'SubnetStatus': 'Active'
+            }
+            ]
+        }, 
+        'PreferredMaintenanceWindow': 'sun:07:48-sun:08:18', 
+        'PendingModifiedValues': {}, 
+        'MultiAZ': False, 
+        'EngineVersion': '5.7.mysql_aurora.2.10.2', 
+        'AutoMinorVersionUpgrade': True, 
+        'ReadReplicaDBInstanceIdentifiers': [], 
+        'LicenseModel': 'general-public-license',
+        'OptionGroupMemberships': 
+        [{
+            'OptionGroupName': 'default:aurora-mysql-5-7', 
+            'Status': 'in-sync'
+        }], 
+        'PubliclyAccessible': False, 
+        'StorageType': 'aurora', 
+        'DbInstancePort': 0, 
+        'StorageEncrypted': False, 
+        'DbiResourceId': 'db-',
+        'CACertificateIdentifier': 'rds-ca-2019', 
+        'DomainMemberships': [],
+        'CopyTagsToSnapshot': False, 
         'MonitoringInterval': 60, 
         'EnhancedMonitoringResourceArn': '', 
         'MonitoringRoleArn': '', 
         'PromotionTier': 1, 
         'DBInstanceArn': '', 
-        'IAMDatabaseAuthenticationEnabled': False, 'PerformanceInsightsEnabled': False, 
-        'DeletionProtection': False, 'AssociatedRoles': [], 'TagList': [], 'CustomerOwnedIpEnabled': False, 'BackupTarget': 'region', 'NetworkType': 'IPV4', 'StorageThroughput': 0}], 'ResponseMetadata': {'RequestId': '319d76ec-75e9-4030-9c4c-a5b648c0186e', 'HTTPStatusCode': 200, 'HTTPHeaders': {'x-amzn-requestid': '319d76ec-75e9-4030-9c4c-a5b648c0186e', 'strict-transport-security': 'max-age=31536000', 
-        'content-type': 'text/xml', 'content-length': '6206', 'date': 'Wed, 25 Jan 2023 22:48:55 GMT'}, 'RetryAttempts': 0}}
+        'IAMDatabaseAuthenticationEnabled': False, 
+        'PerformanceInsightsEnabled': False, 
+        'DeletionProtection': False, 
+        'AssociatedRoles': [], 
+        'TagList': [], 
+        'CustomerOwnedIpEnabled': False,
+        'BackupTarget': 'region', 
+        'NetworkType': 'IPV4', 
+        'StorageThroughput': 0
+        }], 
+        'ResponseMetadata': 
+        {'RequestId': '319d76ec-75e9-4030-9c4c-a5b648c0186e', 
+        'HTTPStatusCode': 200, 
+        'HTTPHeaders': 
+        {
+            'x-amzn-requestid': '319d76ec-75e9-4030-9c4c-a5b648c0186e', 
+            'strict-transport-security': 'max-age=31536000', 
+            'content-type': 'text/xml', 
+            'content-length': '6206', 
+            'date': 'Wed, 25 Jan 2023 22:48:55 GMT'
+        }, 
+        'RetryAttempts': 0
+        }}
 
-describedInstanceMultiAZ = {
+describedInstance = {
     'DBInstances': 
     [{
-        'DBInstanceIdentifier': 'database-instance', 
+        'DBInstanceIdentifier': 'database-instance',
         'DBInstanceClass': 'db.r6g.2xlarge', 
-        'Engine': 'mysql', 
+        'Engine': 'aurora-mysql', 
         'DBInstanceStatus': 'available', 
         'MasterUsername': 'admin', 
         'Endpoint': 
@@ -271,35 +380,113 @@ describedInstanceMultiAZ = {
         }, 
         'AllocatedStorage': 1, 
         'PreferredBackupWindow': '09:05-09:35', 
-        'BackupRetentionPeriod': 1, 'DBSecurityGroups': [], 
-        'VpcSecurityGroups': [{'VpcSecurityGroupId': 'sg-', 'Status': 'active'}], 
-        'DBParameterGroups': [{'DBParameterGroupName': 'default.aurora-mysql5.7', 'ParameterApplyStatus': 'in-sync'}], 
-        'AvailabilityZone': 'us-east-1a', 'DBSubnetGroup': {'DBSubnetGroupName': 'default-vpc-', 
-        'DBSubnetGroupDescription': 'Created from the RDS Management Console', 'VpcId': 'vpc-', 
-        'SubnetGroupStatus': 'Complete', 'Subnets': [{'SubnetIdentifier': 'subnet-', 
-        'SubnetAvailabilityZone': {'Name': 'us-east-1c'}, 'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, 
-        {'SubnetIdentifier': 'subnet-', 'SubnetAvailabilityZone': {'Name': 'us-east-1f'}, 
-        'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, {'SubnetIdentifier': 'subnet-', 
-        'SubnetAvailabilityZone': {'Name': 'us-east-1b'}, 'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, 
-        {'SubnetIdentifier': 'subnet-', 'SubnetAvailabilityZone': {'Name': 'us-east-1a'}, 
-        'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, {'SubnetIdentifier': 'subnet-', 
-        'SubnetAvailabilityZone': {'Name': 'us-east-1e'}, 'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, 
-        {'SubnetIdentifier': 'subnet-', 'SubnetAvailabilityZone': {'Name': 'us-east-1d'}, 
-        'SubnetOutpost': {}, 'SubnetStatus': 'Active'}]}, 'PreferredMaintenanceWindow': 'sun:07:48-sun:08:18', 
-        'PendingModifiedValues': {}, 'MultiAZ': False, 'EngineVersion': '5.7.mysql_aurora.2.10.2', 
-        'AutoMinorVersionUpgrade': False, 'ReadReplicaDBInstanceIdentifiers': [], 'LicenseModel': 'general-public-license',
-        'OptionGroupMemberships': [{'OptionGroupName': 'default:aurora-mysql-5-7', 'Status': 'in-sync'}], 
-        'PubliclyAccessible': False, 'StorageType': 'aurora', 'DbInstancePort': 0, 
-        'DBClusterIdentifier': 'database-cluster', 'StorageEncrypted': False, 'DbiResourceId': 'db-',
-        'CACertificateIdentifier': 'rds-ca-2019', 'DomainMemberships': [], 'CopyTagsToSnapshot': False, 
+        'BackupRetentionPeriod': 1, 
+        'DBSecurityGroups': [], 
+        'VpcSecurityGroups': 
+        [{
+            'VpcSecurityGroupId': 
+            'sg-', 
+            'Status': 'active'
+        }], 
+        'DBParameterGroups': 
+        [{
+            'DBParameterGroupName': 'default.aurora-mysql5.7', 
+            'ParameterApplyStatus': 'in-sync'
+        }], 
+        'AvailabilityZone': 'us-east-1a', 
+        'DBSubnetGroup': 
+        {
+            'DBSubnetGroupName': 'default-vpc-', 
+            'DBSubnetGroupDescription': 'Created from the RDS Management Console', 
+            'VpcId': 'vpc-', 
+            'SubnetGroupStatus': 'Complete', 
+            'Subnets': 
+            [{
+                'SubnetIdentifier': 'subnet-', 
+                'SubnetAvailabilityZone': {'Name': 'us-east-1c'}, 
+                'SubnetOutpost': {}, 
+                'SubnetStatus': 'Active'
+            }, 
+            {
+                'SubnetIdentifier': 
+                'subnet-', 
+                'SubnetAvailabilityZone': {'Name': 'us-east-1f'}, 
+                'SubnetOutpost': {}, 
+                'SubnetStatus': 'Active'
+            }, 
+            {
+                'SubnetIdentifier': 'subnet-', 
+                'SubnetAvailabilityZone': {'Name': 'us-east-1b'}, 
+                'SubnetOutpost': {}, 
+                'SubnetStatus': 'Active'
+            }, 
+            {
+                'SubnetIdentifier': 'subnet-', 
+                'SubnetAvailabilityZone': {'Name': 'us-east-1a'}, 
+                'SubnetOutpost': {}, 
+                'SubnetStatus': 'Active'
+            }, 
+            {
+                'SubnetIdentifier': 'subnet-', 
+                'SubnetAvailabilityZone': {'Name': 'us-east-1e'}, 
+                'SubnetOutpost': {}, 
+                'SubnetStatus': 'Active'
+            }, 
+            {
+                'SubnetIdentifier': 'subnet-', 
+                'SubnetAvailabilityZone': {'Name': 'us-east-1d'}, 
+                'SubnetOutpost': {}, 'SubnetStatus': 'Active'
+            }
+            ]
+        }, 
+        'PreferredMaintenanceWindow': 'sun:07:48-sun:08:18', 
+        'PendingModifiedValues': {}, 
+        'MultiAZ': False, 
+        'EngineVersion': '5.7.mysql_aurora.2.10.2', 
+        'AutoMinorVersionUpgrade': False, 
+        'ReadReplicaDBInstanceIdentifiers': [], 
+        'LicenseModel': 'general-public-license',
+        'OptionGroupMemberships': 
+        [{
+            'OptionGroupName': 'default:aurora-mysql-5-7', 
+            'Status': 'in-sync'
+        }], 
+        'PubliclyAccessible': False, 
+        'StorageType': 'aurora', 
+        'DbInstancePort': 0, 
+        'StorageEncrypted': False, 
+        'DbiResourceId': 'db-',
+        'CACertificateIdentifier': 'rds-ca-2019', 
+        'DomainMemberships': [],
+        'CopyTagsToSnapshot': False, 
         'MonitoringInterval': 60, 
         'EnhancedMonitoringResourceArn': '', 
         'MonitoringRoleArn': '', 
         'PromotionTier': 1, 
         'DBInstanceArn': '', 
-        'IAMDatabaseAuthenticationEnabled': False, 'PerformanceInsightsEnabled': False, 
-        'DeletionProtection': False, 'AssociatedRoles': [], 'TagList': [], 'CustomerOwnedIpEnabled': False, 'BackupTarget': 'region', 'NetworkType': 'IPV4', 'StorageThroughput': 0}], 'ResponseMetadata': {'RequestId': '319d76ec-75e9-4030-9c4c-a5b648c0186e', 'HTTPStatusCode': 200, 'HTTPHeaders': {'x-amzn-requestid': '319d76ec-75e9-4030-9c4c-a5b648c0186e', 'strict-transport-security': 'max-age=31536000', 
-        'content-type': 'text/xml', 'content-length': '6206', 'date': 'Wed, 25 Jan 2023 22:48:55 GMT'}, 'RetryAttempts': 0}}
+        'IAMDatabaseAuthenticationEnabled': False, 
+        'PerformanceInsightsEnabled': False, 
+        'DeletionProtection': False, 
+        'AssociatedRoles': [], 
+        'TagList': [], 
+        'CustomerOwnedIpEnabled': False,
+        'BackupTarget': 'region', 
+        'NetworkType': 'IPV4', 
+        'StorageThroughput': 0
+        }], 
+        'ResponseMetadata': 
+        {'RequestId': '319d76ec-75e9-4030-9c4c-a5b648c0186e', 
+        'HTTPStatusCode': 200, 
+        'HTTPHeaders': 
+        {
+            'x-amzn-requestid': '319d76ec-75e9-4030-9c4c-a5b648c0186e', 
+            'strict-transport-security': 'max-age=31536000', 
+            'content-type': 'text/xml', 
+            'content-length': '6206', 
+            'date': 'Wed, 25 Jan 2023 22:48:55 GMT'
+        }, 
+        'RetryAttempts': 0
+        }}
 
 describedClusterMultiAZ = {
     'DBClusters': 

--- a/source/remediation_runbooks/scripts/test/test_enable_minor_version_upgrade_rds.py
+++ b/source/remediation_runbooks/scripts/test/test_enable_minor_version_upgrade_rds.py
@@ -1,0 +1,477 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Test the functionality of the `enable_minor_version_upgrade_rds` remediation script"""
+ 
+from unittest.mock import patch
+import boto3
+from botocore.stub import Stubber
+from botocore.config import Config
+from enable_minor_version_upgrade_rds import lambda_handler
+ 
+def test_enable_minor_version_upgrade_rds_cluster(mocker):
+    
+    BOTO_CONFIG = Config(
+    retries = {
+            'mode': 'standard',
+            'max_attempts': 10
+        }
+    )
+    rds = boto3.client('ec2', config=BOTO_CONFIG)
+    stub_rds = Stubber(rds)
+    clients = { 'rds': rds }
+
+    instanceId = 'database-instance'
+    clusterId = 'database-cluster'
+ 
+    stub_rds.add_response(
+       'describe_db_instances',
+       describedInstanceCluster,
+       { 
+         "DBInstanceIdentifier": instanceId
+       }
+    )
+
+    stub_rds.add_response(
+       'describe_db_clusters',
+       describedClusterMultiAZ,
+       { 
+         "DBInstanceIdentifier": clusterId
+       }
+    )
+
+    stub_rds.add_response(
+       'modify_db_cluster',
+       {},
+       { 
+         "DBInstanceIdentifier": clusterId,
+         "AutoMinorVersionUpgrade": True
+       }
+     )
+
+    stub_rds.add_response(
+       'describe_db_clusters',
+       describedClusterMultiAZMinorVersionUpgrade,
+       { 
+         "DBInstanceIdentifier": clusterId,
+         "MaxRecords":100
+       }
+     )
+ 
+    stub_rds.activate()
+ 
+    with patch('boto3.client', side_effect=lambda service, **_ : clients[service]):
+         event = { 'DBInstanceIdentifier': instanceId }
+         response = lambda_handler(event, {})
+         assert response == { 
+            "AutoMinorVersionUpgrade": True
+        }
+
+def test_enable_minor_version_upgrade_rds_instance(mocker):
+    
+    BOTO_CONFIG = Config(
+    retries = {
+            'mode': 'standard',
+            'max_attempts': 10
+        }
+    )
+    rds = boto3.client('ec2', config=BOTO_CONFIG)
+    stub_rds = Stubber(rds)
+    clients = { 'rds': rds }
+
+    instanceId = 'database-instance'
+ 
+    stub_rds.add_response(
+       'describe_db_instances',
+       describedInstanceCluster,
+       { 
+         "DBInstanceIdentifier": instanceId
+       }
+    )
+
+    stub_rds.add_response(
+       'modify_db_instance',
+       {},
+       { 
+         "DBInstanceIdentifier": instanceId,
+         "AutoMinorVersionUpgrade": True
+       }
+     )
+
+    stub_rds.add_response(
+       'describe_db_instances',
+       describedInstanceMinorVersionUpgrade,
+       { 
+         "DBInstanceIdentifier": instanceId,
+         "MaxRecords":100
+       }
+    )
+
+    stub_rds.activate()
+ 
+    with patch('boto3.client', side_effect=lambda service, **_ : clients[service]):
+         event = { 'DBInstanceIdentifier': instanceId }
+         response = lambda_handler(event, {})
+         assert response == { 
+            "AutoMinorVersionUpgrade": True
+}
+
+
+describedInstance = {
+    'DBInstances': 
+    [{
+        'DBInstanceIdentifier': 'database-instance', 
+        'DBInstanceClass': 'db.r6g.2xlarge', 
+        'Engine': 'aurora-mysql', 
+        'DBInstanceStatus': 'available', 
+        'MasterUsername': 'admin', 
+        'Endpoint': 
+        {
+            'Address': 'test.amazonaws.com', 
+            'Port': 321, 
+            'HostedZoneId': 'test'
+        }, 
+        'AllocatedStorage': 1, 
+        'PreferredBackupWindow': '09:05-09:35', 
+        'BackupRetentionPeriod': 1, 'DBSecurityGroups': [], 
+        'VpcSecurityGroups': [{'VpcSecurityGroupId': 'sg-', 'Status': 'active'}], 
+        'DBParameterGroups': [{'DBParameterGroupName': 'default.aurora-mysql5.7', 'ParameterApplyStatus': 'in-sync'}], 
+        'AvailabilityZone': 'us-east-1a', 'DBSubnetGroup': {'DBSubnetGroupName': 'default-vpc-', 
+        'DBSubnetGroupDescription': 'Created from the RDS Management Console', 'VpcId': 'vpc-', 
+        'SubnetGroupStatus': 'Complete', 'Subnets': [{'SubnetIdentifier': 'subnet-', 
+        'SubnetAvailabilityZone': {'Name': 'us-east-1c'}, 'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, 
+        {'SubnetIdentifier': 'subnet-', 'SubnetAvailabilityZone': {'Name': 'us-east-1f'}, 
+        'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, {'SubnetIdentifier': 'subnet-', 
+        'SubnetAvailabilityZone': {'Name': 'us-east-1b'}, 'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, 
+        {'SubnetIdentifier': 'subnet-', 'SubnetAvailabilityZone': {'Name': 'us-east-1a'}, 
+        'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, {'SubnetIdentifier': 'subnet-', 
+        'SubnetAvailabilityZone': {'Name': 'us-east-1e'}, 'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, 
+        {'SubnetIdentifier': 'subnet-', 'SubnetAvailabilityZone': {'Name': 'us-east-1d'}, 
+        'SubnetOutpost': {}, 'SubnetStatus': 'Active'}]}, 'PreferredMaintenanceWindow': 'sun:07:48-sun:08:18', 
+        'PendingModifiedValues': {}, 'MultiAZ': False, 'EngineVersion': '5.7.mysql_aurora.2.10.2', 
+        'AutoMinorVersionUpgrade': False, 'ReadReplicaDBInstanceIdentifiers': [], 'LicenseModel': 'general-public-license',
+        'OptionGroupMemberships': [{'OptionGroupName': 'default:aurora-mysql-5-7', 'Status': 'in-sync'}], 
+        'PubliclyAccessible': False, 'StorageType': 'aurora', 'DbInstancePort': 0, 
+        'StorageEncrypted': False, 'DbiResourceId': 'db-',
+        'CACertificateIdentifier': 'rds-ca-2019', 'DomainMemberships': [], 'CopyTagsToSnapshot': False, 
+        'MonitoringInterval': 60, 
+        'EnhancedMonitoringResourceArn': '', 
+        'MonitoringRoleArn': '', 
+        'PromotionTier': 1, 
+        'DBInstanceArn': '', 
+        'IAMDatabaseAuthenticationEnabled': False, 'PerformanceInsightsEnabled': False, 
+        'DeletionProtection': False, 'AssociatedRoles': [], 'TagList': [], 'CustomerOwnedIpEnabled': False, 'BackupTarget': 'region', 'NetworkType': 'IPV4', 'StorageThroughput': 0}], 'ResponseMetadata': {'RequestId': '319d76ec-75e9-4030-9c4c-a5b648c0186e', 'HTTPStatusCode': 200, 'HTTPHeaders': {'x-amzn-requestid': '319d76ec-75e9-4030-9c4c-a5b648c0186e', 'strict-transport-security': 'max-age=31536000', 
+        'content-type': 'text/xml', 'content-length': '6206', 'date': 'Wed, 25 Jan 2023 22:48:55 GMT'}, 'RetryAttempts': 0}}
+
+describedInstanceCluster = {
+    'DBInstances': 
+    [{
+        'DBInstanceIdentifier': 'database-instance',
+        'DBClusterIdentifier': 'database-cluster', 
+        'DBInstanceClass': 'db.r6g.2xlarge', 
+        'Engine': 'aurora-mysql', 
+        'DBInstanceStatus': 'available', 
+        'MasterUsername': 'admin', 
+        'Endpoint': 
+        {
+            'Address': 'test.amazonaws.com', 
+            'Port': 321, 
+            'HostedZoneId': 'test'
+        }, 
+        'AllocatedStorage': 1, 
+        'PreferredBackupWindow': '09:05-09:35', 
+        'BackupRetentionPeriod': 1, 'DBSecurityGroups': [], 
+        'VpcSecurityGroups': [{'VpcSecurityGroupId': 'sg-', 'Status': 'active'}], 
+        'DBParameterGroups': [{'DBParameterGroupName': 'default.aurora-mysql5.7', 'ParameterApplyStatus': 'in-sync'}], 
+        'AvailabilityZone': 'us-east-1a', 'DBSubnetGroup': {'DBSubnetGroupName': 'default-vpc-', 
+        'DBSubnetGroupDescription': 'Created from the RDS Management Console', 'VpcId': 'vpc-', 
+        'SubnetGroupStatus': 'Complete', 'Subnets': [{'SubnetIdentifier': 'subnet-', 
+        'SubnetAvailabilityZone': {'Name': 'us-east-1c'}, 'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, 
+        {'SubnetIdentifier': 'subnet-', 'SubnetAvailabilityZone': {'Name': 'us-east-1f'}, 
+        'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, {'SubnetIdentifier': 'subnet-', 
+        'SubnetAvailabilityZone': {'Name': 'us-east-1b'}, 'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, 
+        {'SubnetIdentifier': 'subnet-', 'SubnetAvailabilityZone': {'Name': 'us-east-1a'}, 
+        'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, {'SubnetIdentifier': 'subnet-', 
+        'SubnetAvailabilityZone': {'Name': 'us-east-1e'}, 'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, 
+        {'SubnetIdentifier': 'subnet-', 'SubnetAvailabilityZone': {'Name': 'us-east-1d'}, 
+        'SubnetOutpost': {}, 'SubnetStatus': 'Active'}]}, 'PreferredMaintenanceWindow': 'sun:07:48-sun:08:18', 
+        'PendingModifiedValues': {}, 'MultiAZ': False, 'EngineVersion': '5.7.mysql_aurora.2.10.2', 
+        'AutoMinorVersionUpgrade': False, 'ReadReplicaDBInstanceIdentifiers': [], 'LicenseModel': 'general-public-license',
+        'OptionGroupMemberships': [{'OptionGroupName': 'default:aurora-mysql-5-7', 'Status': 'in-sync'}], 
+        'PubliclyAccessible': False, 'StorageType': 'aurora', 'DbInstancePort': 0, 
+        'StorageEncrypted': False, 'DbiResourceId': 'db-',
+        'CACertificateIdentifier': 'rds-ca-2019', 'DomainMemberships': [], 'CopyTagsToSnapshot': False, 
+        'MonitoringInterval': 60, 
+        'EnhancedMonitoringResourceArn': '', 
+        'MonitoringRoleArn': '', 
+        'PromotionTier': 1, 
+        'DBInstanceArn': '', 
+        'IAMDatabaseAuthenticationEnabled': False, 'PerformanceInsightsEnabled': False, 
+        'DeletionProtection': False, 'AssociatedRoles': [], 'TagList': [], 'CustomerOwnedIpEnabled': False, 'BackupTarget': 'region', 'NetworkType': 'IPV4', 'StorageThroughput': 0}], 'ResponseMetadata': {'RequestId': '319d76ec-75e9-4030-9c4c-a5b648c0186e', 'HTTPStatusCode': 200, 'HTTPHeaders': {'x-amzn-requestid': '319d76ec-75e9-4030-9c4c-a5b648c0186e', 'strict-transport-security': 'max-age=31536000', 
+        'content-type': 'text/xml', 'content-length': '6206', 'date': 'Wed, 25 Jan 2023 22:48:55 GMT'}, 'RetryAttempts': 0}}
+
+describedInstanceMinorVersionUpgrade = {
+    'DBInstances': 
+    [{
+        'DBInstanceIdentifier': 'database-instance', 
+        'DBInstanceClass': 'db.r6g.2xlarge', 
+        'Engine': 'aurora-mysql', 
+        'DBInstanceStatus': 'available', 
+        'MasterUsername': 'admin', 
+        'Endpoint': 
+        {
+            'Address': 'test.amazonaws.com', 
+            'Port': 321, 
+            'HostedZoneId': 'test'
+        }, 
+        'AllocatedStorage': 1, 
+        'PreferredBackupWindow': '09:05-09:35', 
+        'BackupRetentionPeriod': 1, 'DBSecurityGroups': [], 
+        'VpcSecurityGroups': [{'VpcSecurityGroupId': 'sg-', 'Status': 'active'}], 
+        'DBParameterGroups': [{'DBParameterGroupName': 'default.aurora-mysql5.7', 'ParameterApplyStatus': 'in-sync'}], 
+        'AvailabilityZone': 'us-east-1a', 'DBSubnetGroup': {'DBSubnetGroupName': 'default-vpc-', 
+        'DBSubnetGroupDescription': 'Created from the RDS Management Console', 'VpcId': 'vpc-', 
+        'SubnetGroupStatus': 'Complete', 'Subnets': [{'SubnetIdentifier': 'subnet-', 
+        'SubnetAvailabilityZone': {'Name': 'us-east-1c'}, 'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, 
+        {'SubnetIdentifier': 'subnet-', 'SubnetAvailabilityZone': {'Name': 'us-east-1f'}, 
+        'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, {'SubnetIdentifier': 'subnet-', 
+        'SubnetAvailabilityZone': {'Name': 'us-east-1b'}, 'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, 
+        {'SubnetIdentifier': 'subnet-', 'SubnetAvailabilityZone': {'Name': 'us-east-1a'}, 
+        'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, {'SubnetIdentifier': 'subnet-', 
+        'SubnetAvailabilityZone': {'Name': 'us-east-1e'}, 'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, 
+        {'SubnetIdentifier': 'subnet-', 'SubnetAvailabilityZone': {'Name': 'us-east-1d'}, 
+        'SubnetOutpost': {}, 'SubnetStatus': 'Active'}]}, 'PreferredMaintenanceWindow': 'sun:07:48-sun:08:18', 
+        'PendingModifiedValues': {}, 'MultiAZ': False, 'EngineVersion': '5.7.mysql_aurora.2.10.2', 
+        'AutoMinorVersionUpgrade': True, 'ReadReplicaDBInstanceIdentifiers': [], 'LicenseModel': 'general-public-license',
+        'OptionGroupMemberships': [{'OptionGroupName': 'default:aurora-mysql-5-7', 'Status': 'in-sync'}], 
+        'PubliclyAccessible': False, 'StorageType': 'aurora', 'DbInstancePort': 0, 
+        'StorageEncrypted': False, 'DbiResourceId': 'db-',
+        'CACertificateIdentifier': 'rds-ca-2019', 'DomainMemberships': [], 'CopyTagsToSnapshot': False, 
+        'MonitoringInterval': 60, 
+        'EnhancedMonitoringResourceArn': '', 
+        'MonitoringRoleArn': '', 
+        'PromotionTier': 1, 
+        'DBInstanceArn': '', 
+        'IAMDatabaseAuthenticationEnabled': False, 'PerformanceInsightsEnabled': False, 
+        'DeletionProtection': False, 'AssociatedRoles': [], 'TagList': [], 'CustomerOwnedIpEnabled': False, 'BackupTarget': 'region', 'NetworkType': 'IPV4', 'StorageThroughput': 0}], 'ResponseMetadata': {'RequestId': '319d76ec-75e9-4030-9c4c-a5b648c0186e', 'HTTPStatusCode': 200, 'HTTPHeaders': {'x-amzn-requestid': '319d76ec-75e9-4030-9c4c-a5b648c0186e', 'strict-transport-security': 'max-age=31536000', 
+        'content-type': 'text/xml', 'content-length': '6206', 'date': 'Wed, 25 Jan 2023 22:48:55 GMT'}, 'RetryAttempts': 0}}
+
+describedInstanceMultiAZ = {
+    'DBInstances': 
+    [{
+        'DBInstanceIdentifier': 'database-instance', 
+        'DBInstanceClass': 'db.r6g.2xlarge', 
+        'Engine': 'mysql', 
+        'DBInstanceStatus': 'available', 
+        'MasterUsername': 'admin', 
+        'Endpoint': 
+        {
+            'Address': 'test.amazonaws.com', 
+            'Port': 321, 
+            'HostedZoneId': 'test'
+        }, 
+        'AllocatedStorage': 1, 
+        'PreferredBackupWindow': '09:05-09:35', 
+        'BackupRetentionPeriod': 1, 'DBSecurityGroups': [], 
+        'VpcSecurityGroups': [{'VpcSecurityGroupId': 'sg-', 'Status': 'active'}], 
+        'DBParameterGroups': [{'DBParameterGroupName': 'default.aurora-mysql5.7', 'ParameterApplyStatus': 'in-sync'}], 
+        'AvailabilityZone': 'us-east-1a', 'DBSubnetGroup': {'DBSubnetGroupName': 'default-vpc-', 
+        'DBSubnetGroupDescription': 'Created from the RDS Management Console', 'VpcId': 'vpc-', 
+        'SubnetGroupStatus': 'Complete', 'Subnets': [{'SubnetIdentifier': 'subnet-', 
+        'SubnetAvailabilityZone': {'Name': 'us-east-1c'}, 'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, 
+        {'SubnetIdentifier': 'subnet-', 'SubnetAvailabilityZone': {'Name': 'us-east-1f'}, 
+        'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, {'SubnetIdentifier': 'subnet-', 
+        'SubnetAvailabilityZone': {'Name': 'us-east-1b'}, 'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, 
+        {'SubnetIdentifier': 'subnet-', 'SubnetAvailabilityZone': {'Name': 'us-east-1a'}, 
+        'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, {'SubnetIdentifier': 'subnet-', 
+        'SubnetAvailabilityZone': {'Name': 'us-east-1e'}, 'SubnetOutpost': {}, 'SubnetStatus': 'Active'}, 
+        {'SubnetIdentifier': 'subnet-', 'SubnetAvailabilityZone': {'Name': 'us-east-1d'}, 
+        'SubnetOutpost': {}, 'SubnetStatus': 'Active'}]}, 'PreferredMaintenanceWindow': 'sun:07:48-sun:08:18', 
+        'PendingModifiedValues': {}, 'MultiAZ': False, 'EngineVersion': '5.7.mysql_aurora.2.10.2', 
+        'AutoMinorVersionUpgrade': False, 'ReadReplicaDBInstanceIdentifiers': [], 'LicenseModel': 'general-public-license',
+        'OptionGroupMemberships': [{'OptionGroupName': 'default:aurora-mysql-5-7', 'Status': 'in-sync'}], 
+        'PubliclyAccessible': False, 'StorageType': 'aurora', 'DbInstancePort': 0, 
+        'DBClusterIdentifier': 'database-cluster', 'StorageEncrypted': False, 'DbiResourceId': 'db-',
+        'CACertificateIdentifier': 'rds-ca-2019', 'DomainMemberships': [], 'CopyTagsToSnapshot': False, 
+        'MonitoringInterval': 60, 
+        'EnhancedMonitoringResourceArn': '', 
+        'MonitoringRoleArn': '', 
+        'PromotionTier': 1, 
+        'DBInstanceArn': '', 
+        'IAMDatabaseAuthenticationEnabled': False, 'PerformanceInsightsEnabled': False, 
+        'DeletionProtection': False, 'AssociatedRoles': [], 'TagList': [], 'CustomerOwnedIpEnabled': False, 'BackupTarget': 'region', 'NetworkType': 'IPV4', 'StorageThroughput': 0}], 'ResponseMetadata': {'RequestId': '319d76ec-75e9-4030-9c4c-a5b648c0186e', 'HTTPStatusCode': 200, 'HTTPHeaders': {'x-amzn-requestid': '319d76ec-75e9-4030-9c4c-a5b648c0186e', 'strict-transport-security': 'max-age=31536000', 
+        'content-type': 'text/xml', 'content-length': '6206', 'date': 'Wed, 25 Jan 2023 22:48:55 GMT'}, 'RetryAttempts': 0}}
+
+describedClusterMultiAZ = {
+    'DBClusters': 
+    [
+        {
+            'AllocatedStorage': 400, 
+            'AvailabilityZones': ['us-east-1a', 'us-east-1d', 'us-east-1f'], 
+            'BackupRetentionPeriod': 7, 
+            'DBClusterIdentifier': 'database-cluster', 
+            'DBClusterParameterGroup': 'default.postgres13', 
+            'DBSubnetGroup': 'default-vpc-', 
+            'Status': 'available', 
+            'Endpoint': '', 
+            'ReaderEndpoint': '', 
+            'MultiAZ': True, 
+            'Engine': 'postgres', 
+            'EngineVersion': '13.7', 
+            'Port': 5432, 
+            'MasterUsername': 'postgres', 
+            'PreferredBackupWindow': '08:46-09:16', 
+            'PreferredMaintenanceWindow': 'thu:09:24-thu:09:54', 
+            'ReadReplicaIdentifiers': [], 
+            'DBClusterMembers': 
+            [{
+                'DBInstanceIdentifier': 'database-3-instance-1', 
+                'IsClusterWriter': True, 
+                'DBClusterParameterGroupStatus': 'in-sync', 
+                'PromotionTier': 1
+                }, 
+                {
+                    'DBInstanceIdentifier': 'database-3-instance-2', 
+                    'IsClusterWriter': False, 
+                    'DBClusterParameterGroupStatus': 'in-sync', 
+                    'PromotionTier': 1
+                }, 
+                {
+                    'DBInstanceIdentifier': 'database-3-instance-3', 
+                    'IsClusterWriter': False, 
+                    'DBClusterParameterGroupStatus': 'in-sync', 
+                    'PromotionTier': 1
+                }
+            ], 
+            'VpcSecurityGroups': 
+            [
+                {
+                    'VpcSecurityGroupId': 'sg-', 
+                    'Status': 'active'
+                    }
+            ], 
+            'HostedZoneId': '', 
+            'StorageEncrypted': True, 
+            'KmsKeyId': '', 
+            'DbClusterResourceId': '', 
+            'DBClusterArn': '', 
+            'AssociatedRoles': [], 
+            'IAMDatabaseAuthenticationEnabled': False, 
+            'EngineMode': 'provisioned', 
+            'DeletionProtection': False, 
+            'HttpEndpointEnabled': False, 
+            'ActivityStreamStatus': 'stopped', 
+            'CopyTagsToSnapshot': False, 
+            'CrossAccountClone': False, 
+            'DomainMemberships': [], 
+            'TagList': [], 
+            'DBClusterInstanceClass': 'db.m5d.large', 
+            'StorageType': 'io1', 
+            'Iops': 3000, 
+            'PubliclyAccessible': False, 
+            'AutoMinorVersionUpgrade': False, 
+            'MonitoringInterval': 0, 
+            'PerformanceInsightsEnabled': False, 
+            'NetworkType': 'IPV4'}], 
+            'ResponseMetadata': 
+            {
+                'RequestId': '', 
+                'HTTPStatusCode': 200, 
+                'HTTPHeaders': {
+                    'x-amzn-requestid': '9', 
+                    'strict-transport-security': 'max-age=31536000', 
+                    'content-type': 'text/xml', 
+                    'content-length': '4369', 
+                    'date': 'Wed, 25 Jan 2023 22:57:06 GMT'
+                }, 
+                'RetryAttempts': 0
+            }
+        }
+
+describedClusterMultiAZMinorVersionUpgrade = {
+    'DBClusters': 
+    [
+        {
+            'AllocatedStorage': 400, 
+            'AvailabilityZones': ['us-east-1a', 'us-east-1d', 'us-east-1f'], 
+            'BackupRetentionPeriod': 7, 
+            'DBClusterIdentifier': 'database-cluster', 
+            'DBClusterParameterGroup': 'default.postgres13', 
+            'DBSubnetGroup': 'default-vpc-', 
+            'Status': 'available', 
+            'Endpoint': '', 
+            'ReaderEndpoint': '', 
+            'MultiAZ': True, 
+            'Engine': 'postgres', 
+            'EngineVersion': '13.7', 
+            'Port': 5432, 
+            'MasterUsername': 'postgres', 
+            'PreferredBackupWindow': '08:46-09:16', 
+            'PreferredMaintenanceWindow': 'thu:09:24-thu:09:54', 
+            'ReadReplicaIdentifiers': [], 
+            'DBClusterMembers': 
+            [{
+                'DBInstanceIdentifier': 'database-3-instance-1', 
+                'IsClusterWriter': True, 
+                'DBClusterParameterGroupStatus': 'in-sync', 
+                'PromotionTier': 1
+                }, 
+                {
+                    'DBInstanceIdentifier': 'database-3-instance-2', 
+                    'IsClusterWriter': False, 
+                    'DBClusterParameterGroupStatus': 'in-sync', 
+                    'PromotionTier': 1
+                }, 
+                {
+                    'DBInstanceIdentifier': 'database-3-instance-3', 
+                    'IsClusterWriter': False, 
+                    'DBClusterParameterGroupStatus': 'in-sync', 
+                    'PromotionTier': 1
+                }
+            ], 
+            'VpcSecurityGroups': 
+            [
+                {
+                    'VpcSecurityGroupId': 'sg-', 
+                    'Status': 'active'
+                    }
+            ], 
+            'HostedZoneId': '', 
+            'StorageEncrypted': True, 
+            'KmsKeyId': '', 
+            'DbClusterResourceId': '', 
+            'DBClusterArn': '', 
+            'AssociatedRoles': [], 
+            'IAMDatabaseAuthenticationEnabled': False, 
+            'EngineMode': 'provisioned', 
+            'DeletionProtection': False, 
+            'HttpEndpointEnabled': False, 
+            'ActivityStreamStatus': 'stopped', 
+            'CopyTagsToSnapshot': False, 
+            'CrossAccountClone': False, 
+            'DomainMemberships': [], 
+            'TagList': [], 
+            'DBClusterInstanceClass': 'db.m5d.large', 
+            'StorageType': 'io1', 
+            'Iops': 3000, 
+            'PubliclyAccessible': False, 
+            'AutoMinorVersionUpgrade': True, 
+            'MonitoringInterval': 0, 
+            'PerformanceInsightsEnabled': False, 
+            'NetworkType': 'IPV4'}], 
+            'ResponseMetadata': 
+            {
+                'RequestId': '', 
+                'HTTPStatusCode': 200, 
+                'HTTPHeaders': {
+                    'x-amzn-requestid': '9', 
+                    'strict-transport-security': 'max-age=31536000', 
+                    'content-type': 'text/xml', 
+                    'content-length': '4369', 
+                    'date': 'Wed, 25 Jan 2023 22:57:06 GMT'
+                }, 
+                'RetryAttempts': 0
+            }
+        }
+
+
+

--- a/source/remediation_runbooks/scripts/test/test_enable_minor_version_upgrade_rds.py
+++ b/source/remediation_runbooks/scripts/test/test_enable_minor_version_upgrade_rds.py
@@ -16,7 +16,7 @@ def test_enable_minor_version_upgrade_rds_cluster(mocker):
             'max_attempts': 10
         }
     )
-    rds = boto3.client('ec2', config=BOTO_CONFIG)
+    rds = boto3.client('rds', config=BOTO_CONFIG)
     stub_rds = Stubber(rds)
     clients = { 'rds': rds }
 
@@ -74,7 +74,7 @@ def test_enable_minor_version_upgrade_rds_instance(mocker):
             'max_attempts': 10
         }
     )
-    rds = boto3.client('ec2', config=BOTO_CONFIG)
+    rds = boto3.client('rds', config=BOTO_CONFIG)
     stub_rds = Stubber(rds)
     clients = { 'rds': rds }
 

--- a/source/remediation_runbooks/scripts/test/test_enable_minor_version_upgrade_rds.py
+++ b/source/remediation_runbooks/scripts/test/test_enable_minor_version_upgrade_rds.py
@@ -223,9 +223,7 @@ def getDescribedClusterInstance():
         'AssociatedRoles': [], 
         'TagList': [], 
         'CustomerOwnedIpEnabled': False,
-        'BackupTarget': 'region', 
-        'NetworkType': 'IPV4', 
-        'StorageThroughput': 0
+        'BackupTarget': 'region'
         }], 
         'ResponseMetadata': 
         {'RequestId': '319d76ec-75e9-4030-9c4c-a5b648c0186e', 
@@ -348,9 +346,7 @@ def getDescribedInstanceMinorVersionUpgrade():
         'AssociatedRoles': [], 
         'TagList': [], 
         'CustomerOwnedIpEnabled': False,
-        'BackupTarget': 'region', 
-        'NetworkType': 'IPV4', 
-        'StorageThroughput': 0
+        'BackupTarget': 'region'
         }], 
         'ResponseMetadata': 
         {'RequestId': '319d76ec-75e9-4030-9c4c-a5b648c0186e', 
@@ -560,8 +556,9 @@ def getDescribedMultiAZCluster():
             'PubliclyAccessible': False, 
             'AutoMinorVersionUpgrade': False, 
             'MonitoringInterval': 0, 
-            'PerformanceInsightsEnabled': False, 
-            'NetworkType': 'IPV4'}], 
+            'PerformanceInsightsEnabled': False
+            }
+            ], 
             'ResponseMetadata': 
             {
                 'RequestId': '', 
@@ -647,8 +644,8 @@ def getDescribedMultiAZClusterMinorVersionUpgrade():
             'PubliclyAccessible': False, 
             'AutoMinorVersionUpgrade': True, 
             'MonitoringInterval': 0, 
-            'PerformanceInsightsEnabled': False, 
-            'NetworkType': 'IPV4'}], 
+            'PerformanceInsightsEnabled': False
+            }], 
             'ResponseMetadata': 
             {
                 'RequestId': '', 

--- a/source/remediation_runbooks/scripts/test/test_enable_minor_version_upgrade_rds.py
+++ b/source/remediation_runbooks/scripts/test/test_enable_minor_version_upgrade_rds.py
@@ -25,7 +25,7 @@ def test_enable_minor_version_upgrade_rds_cluster(mocker):
  
     stub_rds.add_response(
        'describe_db_instances',
-       describedInstanceCluster,
+       getDescribedClusterInstance(),
        { 
          "DBInstanceIdentifier": instanceId
        }
@@ -33,7 +33,7 @@ def test_enable_minor_version_upgrade_rds_cluster(mocker):
 
     stub_rds.add_response(
        'describe_db_clusters',
-       describedClusterMultiAZ,
+       getDescribedMultiAZCluster(),
        { 
          "DBInstanceIdentifier": clusterId
        }
@@ -50,7 +50,7 @@ def test_enable_minor_version_upgrade_rds_cluster(mocker):
 
     stub_rds.add_response(
        'describe_db_clusters',
-       describedClusterMultiAZMinorVersionUpgrade,
+       getDescribedMultiAZClusterMinorVersionUpgrade(),
        { 
          "DBInstanceIdentifier": clusterId,
          "MaxRecords":100
@@ -82,7 +82,7 @@ def test_enable_minor_version_upgrade_rds_instance(mocker):
  
     stub_rds.add_response(
        'describe_db_instances',
-       describedInstance,
+       getDescribedInstance(),
        { 
          "DBInstanceIdentifier": instanceId
        }
@@ -99,7 +99,7 @@ def test_enable_minor_version_upgrade_rds_instance(mocker):
 
     stub_rds.add_response(
        'describe_db_instances',
-       describedInstanceMinorVersionUpgrade,
+       getDescribedInstanceMinorVersionUpgrade(),
        { 
          "DBInstanceIdentifier": instanceId,
          "MaxRecords":100
@@ -115,7 +115,8 @@ def test_enable_minor_version_upgrade_rds_instance(mocker):
             "AutoMinorVersionUpgrade": True
 }
 
-describedInstanceCluster = {
+def getDescribedClusterInstance():
+ return {
     'DBInstances': 
     [{
         'DBInstanceIdentifier': 'database-instance',
@@ -240,7 +241,8 @@ describedInstanceCluster = {
         'RetryAttempts': 0
         }}
 
-describedInstanceMinorVersionUpgrade = {
+def getDescribedInstanceMinorVersionUpgrade():
+    return {
     'DBInstances': 
     [{
         'DBInstanceIdentifier': 'database-instance',
@@ -364,9 +366,11 @@ describedInstanceMinorVersionUpgrade = {
         'RetryAttempts': 0
         }}
 
-describedInstance = {
+def getDescribedInstance(): 
+    return {
     'DBInstances': 
-    [{
+    [
+        {
         'DBInstanceIdentifier': 'database-instance',
         'DBInstanceClass': 'db.r6g.2xlarge', 
         'Engine': 'aurora-mysql', 
@@ -470,9 +474,7 @@ describedInstance = {
         'AssociatedRoles': [], 
         'TagList': [], 
         'CustomerOwnedIpEnabled': False,
-        'BackupTarget': 'region', 
-        'NetworkType': 'IPV4', 
-        'StorageThroughput': 0
+        'BackupTarget': 'region'
         }], 
         'ResponseMetadata': 
         {'RequestId': '319d76ec-75e9-4030-9c4c-a5b648c0186e', 
@@ -488,7 +490,8 @@ describedInstance = {
         'RetryAttempts': 0
         }}
 
-describedClusterMultiAZ = {
+def getDescribedMultiAZCluster():
+    return {
     'DBClusters': 
     [
         {
@@ -574,7 +577,8 @@ describedClusterMultiAZ = {
             }
         }
 
-describedClusterMultiAZMinorVersionUpgrade = {
+def getDescribedMultiAZClusterMinorVersionUpgrade(): 
+    return {
     'DBClusters': 
     [
         {

--- a/source/remediation_runbooks/scripts/test/test_enable_minor_version_upgrade_rds.py
+++ b/source/remediation_runbooks/scripts/test/test_enable_minor_version_upgrade_rds.py
@@ -35,7 +35,7 @@ def test_enable_minor_version_upgrade_rds_cluster(mocker):
        'describe_db_clusters',
        getDescribedMultiAZCluster(),
        { 
-         "DBInstanceIdentifier": clusterId
+         "DBClusterIdentifier": clusterId
        }
     )
 
@@ -43,7 +43,7 @@ def test_enable_minor_version_upgrade_rds_cluster(mocker):
        'modify_db_cluster',
        {},
        { 
-         "DBInstanceIdentifier": clusterId,
+         "DBClusterIdentifier": clusterId,
          "AutoMinorVersionUpgrade": True
        }
      )
@@ -52,7 +52,7 @@ def test_enable_minor_version_upgrade_rds_cluster(mocker):
        'describe_db_clusters',
        getDescribedMultiAZClusterMinorVersionUpgrade(),
        { 
-         "DBInstanceIdentifier": clusterId,
+         "DBClusterIdentifier": clusterId,
          "MaxRecords":100
        }
      )
@@ -558,7 +558,7 @@ def getDescribedMultiAZCluster():
             'MonitoringInterval': 0, 
             'PerformanceInsightsEnabled': False
             }
-            ], 
+        ], 
             'ResponseMetadata': 
             {
                 'RequestId': '', 

--- a/source/solution_deploy/lib/remediation_runbook-stack.ts
+++ b/source/solution_deploy/lib/remediation_runbook-stack.ts
@@ -2130,7 +2130,12 @@ export class RemediationRunbookStack extends cdk.Stack {
       const inlinePolicy = new Policy(props.roleStack, `SHARR-Remediation-Policy-${remediationName}`);
 
       const remediationPolicy = new PolicyStatement();
-      remediationPolicy.addActions('rds:DescribeDBInstances', 'rds:ModifyDBInstance', 'rds:DescribeDBClusters', 'rds:ModifyDBCluster');
+      remediationPolicy.addActions(
+        'rds:DescribeDBInstances', 
+        'rds:ModifyDBInstance', 
+        'rds:DescribeDBClusters', 
+        'rds:ModifyDBCluster'
+      );
       remediationPolicy.effect = Effect.ALLOW;
       remediationPolicy.addResources('*');
       inlinePolicy.addStatements(remediationPolicy);

--- a/source/solution_deploy/lib/remediation_runbook-stack.ts
+++ b/source/solution_deploy/lib/remediation_runbook-stack.ts
@@ -2130,7 +2130,7 @@ export class RemediationRunbookStack extends cdk.Stack {
       const inlinePolicy = new Policy(props.roleStack, `SHARR-Remediation-Policy-${remediationName}`);
 
       const remediationPolicy = new PolicyStatement();
-      remediationPolicy.addActions('rds:DescribeDBInstances', 'rds:ModifyDBInstance');
+      remediationPolicy.addActions('rds:DescribeDBInstances', 'rds:ModifyDBInstance', 'rds:DescribeDBClusters', 'rds:ModifyDBCluster');
       remediationPolicy.effect = Effect.ALLOW;
       remediationPolicy.addResources('*');
       inlinePolicy.addStatements(remediationPolicy);

--- a/source/test/__snapshots__/runbook_stack.test.ts.snap
+++ b/source/test/__snapshots__/runbook_stack.test.ts.snap
@@ -4584,7 +4584,7 @@ def multi_az_check(clusterID):
     rds = connect_to_rds()
     try:
         foundCluster = rds.describe_db_clusters(DBClusterIdentifier=clusterID)
-        clusterInfo = foundCluster['DBCluster']
+        clusterInfo = foundCluster['DBClusters'][0]
     except Exception as e:
         exit(f'Failed to get information about the cluster: {clusterID} ')
 
@@ -4620,7 +4620,7 @@ def verify_cluster_changes(clusterID):
     rds = connect_to_rds()
     try:
         foundCluster = rds.describe_db_clusters(DBClusterIdentifier=clusterID, MaxRecords=100)
-        clusterInfo = foundCluster['DBCluster']
+        clusterInfo = foundCluster['DBClusters'][0]
 
     except Exception as e:
         exit(f'Failed to verify cluster changes: {clusterID}. Error: {e}')

--- a/source/test/__snapshots__/runbook_stack.test.ts.snap
+++ b/source/test/__snapshots__/runbook_stack.test.ts.snap
@@ -4661,7 +4661,7 @@ def verify_instance_changes(instanceID):
               "type": "String",
             },
             "DBInstanceIdentifier": {
-              "allowedPattern": "^db-[A-Z0-9]{26}$",
+              "allowedPattern": "^(?!.*--)[a-zA-Z][a-zA-Z0-9.,$;-]{0,58}[^-]$",
               "description": "(Required) Identifier of the Amazon RDS instance for which AutoMinorVersionUpgrade needs to be enabled.",
               "type": "String",
             },

--- a/source/test/__snapshots__/runbook_stack.test.ts.snap
+++ b/source/test/__snapshots__/runbook_stack.test.ts.snap
@@ -4514,94 +4514,141 @@ This document enables AutoMinorVersionUpgrade on the Amazon Relational Database 
 ",
           "mainSteps": [
             {
-              "action": "aws:executeAwsApi",
-              "description": "## GetRDSInstanceIdentifier
-Makes DescribeDBInstances API call using the database instance resource identifier to get DBInstanceIdentifier.
-## Outputs
-* DBInstanceIdentifier: DBInstance identifier of the Amazon RDS instance.
-",
+              "action": "aws:executeScript",
               "inputs": {
-                "Api": "DescribeDBInstances",
-                "Filters": [
-                  {
-                    "Name": "dbi-resource-id",
-                    "Values": [
-                      "{{ DbiResourceId }}",
-                    ],
-                  },
-                ],
-                "Service": "rds",
-              },
-              "isEnd": false,
-              "name": "GetRDSInstanceIdentifier",
-              "outputs": [
-                {
-                  "Name": "DBInstanceIdentifier",
-                  "Selector": "$.DBInstances[0].DBInstanceIdentifier",
-                  "Type": "String",
+                "Handler": "lambda_handler",
+                "InputPayload": {
+                  "DBInstanceIdentifier": "{{DBInstanceIdentifier}}",
                 },
-              ],
-              "timeoutSeconds": 600,
-            },
-            {
-              "action": "aws:assertAwsResourceProperty",
-              "description": "## VerifyDBInstanceStatus
-Verifies whether AWS RDS DBInstance status is available before enabling AutoMiniorVersionUpgrade.
-",
-              "inputs": {
-                "Api": "DescribeDBInstances",
-                "DBInstanceIdentifier": "{{ GetRDSInstanceIdentifier.DBInstanceIdentifier }}",
-                "DesiredValues": [
-                  "available",
-                ],
-                "PropertySelector": "$.DBInstances[0].DBInstanceStatus",
-                "Service": "rds",
+                "Runtime": "python3.8",
+                "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import boto3
+from botocore.config import Config
+
+boto_config = Config(
+    retries = {
+            'mode': 'standard',
+            'max_attempts': 10
+        }
+    )
+
+multiAZClusterEngines = ["mysql","postgres"]
+
+def connect_to_rds():
+    return boto3.client('rds', config=boto_config)
+
+def lambda_handler(event, _):
+    """
+     Enable auto minor version upgrades on an instance or a Multi-AZ Cluster
+ 
+     \`event\` should have the following keys and values:
+     \`DBInstanceIdentifier\`: The identifier of the database instance that is to be modified.
+ 
+     \`context\` is ignored
+    """
+    dbInstanceID = event["DBInstanceIdentifier"]
+
+    rds = connect_to_rds()
+
+    foundInstance = rds.describe_db_instances(DBInstanceIdentifier=dbInstanceID)
+
+    instanceInfo = foundInstance['DBInstances'][0]
+
+    response = False
+
+    if ("DBClusterIdentifier" in instanceInfo.keys()):
+        if (multi_az_check(instanceInfo["DBClusterIdentifier"])):
+            clusterID = instanceInfo["DBClusterIdentifier"]
+            enable_minor_version_upgrade_cluster(clusterID)
+            response = verify_cluster_changes(clusterID)
+        else:
+            enable_minor_version_upgrade_instance(dbInstanceID)
+            response = verify_instance_changes(dbInstanceID)
+    else:
+        enable_minor_version_upgrade_instance(dbInstanceID)
+        response = verify_instance_changes(dbInstanceID)
+        
+    if response == True:
+        return {
+            "AutoMinorVersionUpgrade": response
+        }
+    
+    raise Exception(f'ASR Remediation failed - {dbInstanceID} did not have enable auto minor version upgrades enabled.')
+
+def multi_az_check(clusterID):
+    """
+    Checks to see if the cluster is Multi-AZ. Instances within clusters that match this check are not able to be modified.
+    """  
+
+    rds = connect_to_rds()
+    try:
+        foundCluster = rds.describe_db_clusters(DBClusterIdentifier=clusterID)
+        clusterInfo = foundCluster['DBCluster']
+    except Exception as e:
+        exit(f'Failed to get information about the cluster: {clusterID} ')
+
+    return ((clusterInfo["MultiAZ"] == True) and (clusterInfo["Engine"] in multiAZClusterEngines))
+
+
+def enable_minor_version_upgrade_cluster(clusterID):
+    """
+    Enables automatic minor version upgrade for a Multi-AZ Cluster.
+    """ 
+
+    rds = connect_to_rds()
+    try:
+        rds.modify_db_cluster(DBClusterIdentifier=clusterID,AutoMinorVersionUpgrade=True)
+    except Exception as e:
+        exit(f'Failed to modify the cluster: {clusterID}. Error: {e}')
+
+def enable_minor_version_upgrade_instance(instanceID):
+    """
+    Enables automatic minor version upgrade for an instance.
+    """ 
+
+    rds = connect_to_rds()
+    try:
+        rds.modify_db_instance(DBInstanceIdentifier=instanceID,AutoMinorVersionUpgrade=True)
+    except Exception as e:
+        exit(f'Failed to modify the instance: {instanceID}. Error: {e}')
+
+def verify_cluster_changes(clusterID):
+    """
+    Verifies automatic minor version upgrade for a Multi-AZ cluster.
+    """ 
+    rds = connect_to_rds()
+    try:
+        foundCluster = rds.describe_db_clusters(DBClusterIdentifier=clusterID, MaxRecords=100)
+        clusterInfo = foundCluster['DBCluster']
+
+    except Exception as e:
+        exit(f'Failed to verify cluster changes: {clusterID}. Error: {e}')
+
+    return clusterInfo['AutoMinorVersionUpgrade']
+        
+def verify_instance_changes(instanceID):
+    """
+    Verifies automatic minor version upgrade for an instance.
+    """ 
+    rds = connect_to_rds()
+    try:
+        foundInstance = rds.describe_db_instances(DBInstanceIdentifier=instanceID, MaxRecords=100)
+        instanceInfo = foundInstance['DBInstances'][0]
+    except Exception as e:
+
+        exit(f'Failed to verify instance changes: {instanceID}. Error: {e}')
+
+    return instanceInfo['AutoMinorVersionUpgrade'] ",
               },
-              "isEnd": false,
-              "name": "VerifyDBInstanceStatus",
-              "timeoutSeconds": 600,
-            },
-            {
-              "action": "aws:executeAwsApi",
-              "description": "## ModifyDBInstance
-Makes ModifyDBInstance API call to enable AutoMinorVersionUpgrade on the Amazon RDS instance using the DBInstanceIdentifier.
-## Outputs
-* Output: The standard HTTP response from the ModifyDBInstance API.
-",
-              "inputs": {
-                "Api": "ModifyDBInstance",
-                "AutoMinorVersionUpgrade": true,
-                "DBInstanceIdentifier": "{{ GetRDSInstanceIdentifier.DBInstanceIdentifier }}",
-                "Service": "rds",
-              },
-              "isEnd": false,
               "name": "ModifyDBInstance",
               "outputs": [
                 {
                   "Name": "Output",
-                  "Selector": "$",
+                  "Selector": "$.Payload.response",
                   "Type": "StringMap",
                 },
               ],
-              "timeoutSeconds": 600,
-            },
-            {
-              "action": "aws:assertAwsResourceProperty",
-              "description": "## VerifyDBInstanceState
-Verifies the Amazon RDS Instance's "AutoMinorVersionUpgrade" property is set to "True".
-",
-              "inputs": {
-                "Api": "DescribeDBInstances",
-                "DBInstanceIdentifier": "{{ GetRDSInstanceIdentifier.DBInstanceIdentifier }}",
-                "DesiredValues": [
-                  "True",
-                ],
-                "PropertySelector": "$.DBInstances[0].AutoMinorVersionUpgrade",
-                "Service": "rds",
-              },
-              "isEnd": true,
-              "name": "VerifyDBInstanceState",
-              "timeoutSeconds": 600,
             },
           ],
           "outputs": [
@@ -4613,9 +4660,9 @@ Verifies the Amazon RDS Instance's "AutoMinorVersionUpgrade" property is set to 
               "description": "(Required) The ARN of the role that allows Automation to perform the actions on your behalf.",
               "type": "String",
             },
-            "DbiResourceId": {
+            "DBInstanceIdentifier": {
               "allowedPattern": "^db-[A-Z0-9]{26}$",
-              "description": "(Required) Resource ID of the Amazon RDS instance for which AutoMinorVersionUpgrade needs to be enabled.",
+              "description": "(Required) Identifier of the Amazon RDS instance for which AutoMinorVersionUpgrade needs to be enabled.",
               "type": "String",
             },
           },

--- a/source/test/regex_registry.ts
+++ b/source/test/regex_registry.ts
@@ -255,6 +255,15 @@ export function getRegexRegistry(): RegexRegistry {
     )
   );
 
+  registry.addCase(
+    new RegexTestCase(
+      String.raw`^(?!.*--)[a-zA-Z][a-zA-Z0-9.,$;-]{0,58}[^-]$`,
+      'RDS DB Instance Identifier',
+      ['database-1'],
+      ['not--valid', 'notvalid--', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']
+    )
+  )
+
   registry.addCase(new RegexTestCase(String.raw`^[A-Za-z0-9._-]{3,128}$`, 'CloudTrail Name', [], []));
 
   registry.addCase(

--- a/source/test/regex_registry.ts
+++ b/source/test/regex_registry.ts
@@ -260,7 +260,11 @@ export function getRegexRegistry(): RegexRegistry {
       String.raw`^(?!.*--)[a-zA-Z][a-zA-Z0-9.,$;-]{0,58}[^-]$`,
       'RDS DB Instance Identifier',
       ['database-1'],
-      ['not--valid', 'notvalid--', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']
+      [
+        'not--valid', 
+        'notvalid--', 
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+      ]
     )
   )
 


### PR DESCRIPTION
*Description of changes:*
Fixed RDS.13 Remediation not being able to run on an instance within a Multi-AZ cluster.

Behavior now checks if the affected instance is in a cluster, checks to see if that cluster is MySQL or Postgres Multi-AZ cluster, if so the remediation will be run at the cluster level.

Tested manually on an instance within a Multi-AZ cluster, an instance within a regular cluster, and on an instance within a Multi-AZ cluster that already had versioning on.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.