### PR TITLE
Added Lambda.1 support for removing public S3 resource policies

### DIFF
--- a/source/remediation_runbooks/scripts/RemoveLambdaPublicAccess.py
+++ b/source/remediation_runbooks/scripts/RemoveLambdaPublicAccess.py
@@ -24,14 +24,14 @@ def public_s3_statement_check(statement, principal):
     This function checks if the user has given access to an S3 bucket without providing an AWS account.
     """
     try:
-        sourceAccountCheck = False
+        emptySourceAccountCheck = False
         if ("StringEquals" in statement["Condition"]):
-            sourceAccountCheck = ("AWS:SourceAccount" not in statement["Condition"]["StringEquals"])
+            emptySourceAccountCheck = ("AWS:SourceAccount" not in statement["Condition"]["StringEquals"])
         else:
-            sourceAccountCheck = True
-        return principal.get("Service", "") == "s3.amazonaws.com" and sourceAccountCheck
+            emptySourceAccountCheck = True
+        return principal.get("Service", "") == "s3.amazonaws.com" and emptySourceAccountCheck
     except KeyError:
-        pass
+        return principal.get("Service", "") == "s3.amazonaws.com"
 
 def remove_resource_policy(functionname, sid, client):
     try:
@@ -44,8 +44,7 @@ def remove_resource_policy(functionname, sid, client):
         exit(f'FAILED: SID {sid} was NOT removed from Lambda function {functionname} - {str(e)}')
 
 def remove_public_statement(client, functionname, statement, principal):
-    if principal == "*" or (isinstance(principal, dict) and principal.get("AWS","") == "*") or (isinstance(principal, dict) and public_s3_statement_check(statement, principal)):
-        print('here')
+    if principal == "*" or (isinstance(principal, dict) and (principal.get("AWS","") == "*" or public_s3_statement_check(statement, principal))):
         print_policy_before(statement)
         remove_resource_policy(functionname, statement['Sid'], client)
 

--- a/source/remediation_runbooks/scripts/RemoveLambdaPublicAccess.py
+++ b/source/remediation_runbooks/scripts/RemoveLambdaPublicAccess.py
@@ -62,7 +62,6 @@ def remove_lambda_public_access(event, context):
         print('Scanning for public resource policies in ' + functionname)
 
         for statement in statements:
-            print(statement)
             remove_public_statement(client, functionname, statement, statement['Principal'])
 
         client.get_policy(FunctionName=functionname)

--- a/source/remediation_runbooks/scripts/RemoveLambdaPublicAccess.py
+++ b/source/remediation_runbooks/scripts/RemoveLambdaPublicAccess.py
@@ -20,8 +20,16 @@ def print_policy_before(policy):
     print(json.dumps(policy, indent=2, default=str))
 
 def public_s3_statement_check(statement, principal):
+    """
+    This function checks if the user has given access to an S3 bucket without providing an AWS account.
+    """
     try:
-        return principal.get("Service", "") == "s3.amazonaws.com" and ("AWS:SourceAccount" not in statement["Condition"]["StringEquals"])
+        sourceAccountCheck = False
+        if ("StringEquals" in statement["Condition"]):
+            sourceAccountCheck = ("AWS:SourceAccount" not in statement["Condition"]["StringEquals"])
+        else:
+            sourceAccountCheck = True
+        return principal.get("Service", "") == "s3.amazonaws.com" and sourceAccountCheck
     except KeyError:
         pass
 
@@ -35,12 +43,11 @@ def remove_resource_policy(functionname, sid, client):
     except Exception as e:
         exit(f'FAILED: SID {sid} was NOT removed from Lambda function {functionname} - {str(e)}')
 
-def remove_public_statement(client, functionname, statement, principal_source):
-    for principal in list(principal_source):
-        if principal == "*" or (isinstance(principal, dict) and principal.get("AWS","") == "*") or (isinstance(principal, dict) and public_s3_statement_check(statement, principal)):
-            print_policy_before(statement)
-            remove_resource_policy(functionname, statement['Sid'], client)
-            break # there will only be one that matches
+def remove_public_statement(client, functionname, statement, principal):
+    if principal == "*" or (isinstance(principal, dict) and principal.get("AWS","") == "*") or (isinstance(principal, dict) and public_s3_statement_check(statement, principal)):
+        print('here')
+        print_policy_before(statement)
+        remove_resource_policy(functionname, statement['Sid'], client)
 
 def remove_lambda_public_access(event, context):
 
@@ -56,7 +63,8 @@ def remove_lambda_public_access(event, context):
         print('Scanning for public resource policies in ' + functionname)
 
         for statement in statements:
-            remove_public_statement(client, functionname, statement, list(statement['Principal']))
+            print(statement)
+            remove_public_statement(client, functionname, statement, statement['Principal'])
 
         client.get_policy(FunctionName=functionname)
 

--- a/source/remediation_runbooks/scripts/RemoveLambdaPublicAccess.py
+++ b/source/remediation_runbooks/scripts/RemoveLambdaPublicAccess.py
@@ -37,7 +37,7 @@ def remove_resource_policy(functionname, sid, client):
 
 def remove_public_statement(client, functionname, statement, principal_source):
     for principal in list(principal_source):
-        if principal == "*" or (isinstance(principal, dict) and principal.get("AWS","") == "*") or public_s3_statement_check(statement, principal):
+        if principal == "*" or (isinstance(principal, dict) and principal.get("AWS","") == "*") or (isinstance(principal, dict) and public_s3_statement_check(statement, principal)):
             print_policy_before(statement)
             remove_resource_policy(functionname, statement['Sid'], client)
             break # there will only be one that matches

--- a/source/remediation_runbooks/scripts/RemoveLambdaPublicAccess.py
+++ b/source/remediation_runbooks/scripts/RemoveLambdaPublicAccess.py
@@ -19,6 +19,12 @@ def print_policy_before(policy):
     print('Resource Policy to be deleted:')
     print(json.dumps(policy, indent=2, default=str))
 
+def public_s3_statement_check(statement, principal):
+    try:
+        return principal.get("Service", "") == "s3.amazonaws.com" and ("AWS:SourceAccount" not in statement["Condition"]["StringEquals"])
+    except KeyError:
+        pass
+
 def remove_resource_policy(functionname, sid, client):
     try:
         client.remove_permission(
@@ -31,7 +37,7 @@ def remove_resource_policy(functionname, sid, client):
 
 def remove_public_statement(client, functionname, statement, principal_source):
     for principal in list(principal_source):
-        if principal == "*" or (isinstance(principal, dict) and principal.get("AWS","") == "*"):
+        if principal == "*" or (isinstance(principal, dict) and principal.get("AWS","") == "*") or public_s3_statement_check(statement, principal):
             print_policy_before(statement)
             remove_resource_policy(functionname, statement['Sid'], client)
             break # there will only be one that matches

--- a/source/remediation_runbooks/scripts/test/test_removelambdapublicaccess.py
+++ b/source/remediation_runbooks/scripts/test/test_removelambdapublicaccess.py
@@ -103,6 +103,97 @@ def test_success(mocker):
 
     lambda_stubber.deactivate()
 
+def test_success_aws_star(mocker):
+    event = {
+        'FunctionName': 'myPublicTestFunction'
+    }
+
+    get_policy_initial_response = {
+        "ResponseMetadata": {
+            "RequestId": "8a2cc603-ba43-467d-be12-a4f7a28f93bf",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+            "date": "Tue, 27 Jul 2021 13:02:30 GMT",
+            "content-type": "application/json",
+            "content-length": "341",
+            "connection": "keep-alive",
+            "x-amzn-requestid": "8a2cc603-ba43-467d-be12-a4f7a28f93bf"
+            },
+            "RetryAttempts": 0
+        },
+        'Policy':  "{\"Version\":\"2012-10-17\",\"Id\":\"default\",\"Statement\":[{\"Sid\":\"sdfsdf\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"events.amazonaws.com\"},\"Action\":\"lambda:InvokeFunction\",\"Resource\":\"arn:aws:lambda:us-east-1:111111111111:function:myPublicTestFunction\"},{\"Sid\":\"SHARRTest\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Action\":\"lambda:InvokeFunction\",\"Resource\":\"arn:aws:lambda:us-east-1:111111111111:function:myPublicTestFunction\"}]}",
+        "RevisionId": "43f41078-ecd3-406d-b862-d770019c262c"
+    }
+
+    get_policy_after_response = {
+        "ResponseMetadata": {
+            "RequestId": "8a2cc603-ba43-467d-be12-a4f7a28f93bf",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+            "date": "Tue, 27 Jul 2021 13:02:30 GMT",
+            "content-type": "application/json",
+            "content-length": "341",
+            "connection": "keep-alive",
+            "x-amzn-requestid": "8a2cc603-ba43-467d-be12-a4f7a28f93bf"
+            },
+            "RetryAttempts": 0
+        },
+        "Policy": "{\"Version\":\"2012-10-17\",\"Id\":\"default\",\"Statement\":[{\"Sid\":\"sdfsdf\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"events.amazonaws.com\"},\"Action\":\"lambda:InvokeFunction\",\"Resource\":\"arn:aws:lambda:us-east-1:111111111111:function:myPublicTestFunction\"}]}",
+        "RevisionId": "43f41078-ecd3-406d-b862-d770019c262c"
+    }
+
+    BOTO_CONFIG = Config(
+        retries ={
+          'mode': 'standard'
+        },
+        region_name=my_region
+    )
+
+    ### Clients
+    lambda_client = botocore.session.get_session().create_client('lambda', config=BOTO_CONFIG)
+    lambda_stubber = Stubber(lambda_client)
+
+    lambda_stubber.add_response(
+        'get_policy',
+        get_policy_initial_response,
+        {
+            'FunctionName': 'myPublicTestFunction'
+        }
+    )
+
+    lambda_stubber.add_response(
+        'remove_permission',
+        {},
+        {
+            'FunctionName': 'myPublicTestFunction',
+            'StatementId': 'SHARRTest'
+        }
+    )
+
+    lambda_stubber.add_response(
+        'get_policy',
+        get_policy_after_response,
+        {
+            'FunctionName': 'myPublicTestFunction'
+        }
+    )
+
+    lambda_stubber.add_response(
+        'get_policy',
+        get_policy_after_response,
+        {
+            'FunctionName': 'myPublicTestFunction'
+        }
+    )
+
+    lambda_stubber.activate()
+
+    mocker.patch('RemoveLambdaPublicAccess.connect_to_lambda', return_value=lambda_client)
+
+    assert remediation.remove_lambda_public_access(event, {}) == None
+
+    lambda_stubber.deactivate()
+
 def test_success_s3_statement(mocker):
     event = {
         'FunctionName': 'myPublicS3TestFunction'

--- a/source/remediation_runbooks/scripts/test/test_removelambdapublicaccess.py
+++ b/source/remediation_runbooks/scripts/test/test_removelambdapublicaccess.py
@@ -12,9 +12,6 @@ import RemoveLambdaPublicAccess as remediation
 my_session = boto3.session.Session()
 my_region = my_session.region_name
 
-#=====================================================================================
-# EnableVPCFlowLogging_enable_flow_logs SUCCESS
-#=====================================================================================
 def test_success(mocker):
     event = {
         'FunctionName': 'myPublicTestFunction'
@@ -37,6 +34,96 @@ def test_success(mocker):
         "RevisionId": "43f41078-ecd3-406d-b862-d770019c262c"
     }
 
+    get_policy_after_response = {
+        "ResponseMetadata": {
+            "RequestId": "8a2cc603-ba43-467d-be12-a4f7a28f93bf",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+            "date": "Tue, 27 Jul 2021 13:02:30 GMT",
+            "content-type": "application/json",
+            "content-length": "341",
+            "connection": "keep-alive",
+            "x-amzn-requestid": "8a2cc603-ba43-467d-be12-a4f7a28f93bf"
+            },
+            "RetryAttempts": 0
+        },
+        "Policy": "{\"Version\":\"2012-10-17\",\"Id\":\"default\",\"Statement\":[{\"Sid\":\"sdfsdf\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"events.amazonaws.com\"},\"Action\":\"lambda:InvokeFunction\",\"Resource\":\"arn:aws:lambda:us-east-1:111111111111:function:myPublicTestFunction\"}]}",
+        "RevisionId": "43f41078-ecd3-406d-b862-d770019c262c"
+    }
+
+    BOTO_CONFIG = Config(
+        retries ={
+          'mode': 'standard'
+        },
+        region_name=my_region
+    )
+
+    ### Clients
+    lambda_client = botocore.session.get_session().create_client('lambda', config=BOTO_CONFIG)
+    lambda_stubber = Stubber(lambda_client)
+
+    lambda_stubber.add_response(
+        'get_policy',
+        get_policy_initial_response,
+        {
+            'FunctionName': 'myPublicTestFunction'
+        }
+    )
+
+    lambda_stubber.add_response(
+        'remove_permission',
+        {},
+        {
+            'FunctionName': 'myPublicTestFunction',
+            'StatementId': 'SHARRTest'
+        }
+    )
+
+    lambda_stubber.add_response(
+        'get_policy',
+        get_policy_after_response,
+        {
+            'FunctionName': 'myPublicTestFunction'
+        }
+    )
+
+    lambda_stubber.add_response(
+        'get_policy',
+        get_policy_after_response,
+        {
+            'FunctionName': 'myPublicTestFunction'
+        }
+    )
+
+    lambda_stubber.activate()
+
+    mocker.patch('RemoveLambdaPublicAccess.connect_to_lambda', return_value=lambda_client)
+
+    assert remediation.remove_lambda_public_access(event, {}) == None
+
+    lambda_stubber.deactivate()
+
+def test_success_s3_statement(mocker):
+    event = {
+        'FunctionName': 'myPublicTestFunction'
+    }
+
+    get_policy_initial_response = {
+        "ResponseMetadata": {
+            "RequestId": "8a2cc603-ba43-467d-be12-a4f7a28f93bf",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+            "date": "Tue, 27 Jul 2021 13:02:30 GMT",
+            "content-type": "application/json",
+            "content-length": "341",
+            "connection": "keep-alive",
+            "x-amzn-requestid": "8a2cc603-ba43-467d-be12-a4f7a28f93bf"
+            },
+            "RetryAttempts": 0
+        },
+        'Policy':  "{\"Version\":\"2012-10-17\",\"Id\":\"default\",\"Statement\":[{\"Sid\":\"sdfsdf\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"events.amazonaws.com\"},\"Action\":\"lambda:InvokeFunction\",\"Resource\":\"arn:aws:lambda:us-east-1:111111111111:function:myPublicTestFunction\"},{\"Sid\": \"lambda-allow-s3-my-function\",\"Effect\": \"Allow\",\"Principa\": {\"Service\": \"s3.amazonaws.com\"},\"Action\": \"lambda:InvokeFunction\",\"Resource\":\"arn:aws:lambda:us-east-2:123456789012:function:my-function\",\"Condition\": {\"ArnLike\": {\"AWS:SourceArn\": \"arn:aws:s3:::my-bucket\"}}},\"RevisionId\": \"43f41078-ecd3-406d-b862-d770019c262c\"}"
+    }
+    
     get_policy_after_response = {
         "ResponseMetadata": {
             "RequestId": "8a2cc603-ba43-467d-be12-a4f7a28f93bf",

--- a/source/remediation_runbooks/scripts/test/test_removelambdapublicaccess.py
+++ b/source/remediation_runbooks/scripts/test/test_removelambdapublicaccess.py
@@ -121,7 +121,7 @@ def test_success_s3_statement(mocker):
             },
             "RetryAttempts": 0
         },
-        "Policy": "{\"Version\":\"2012-10-17\",\"Id\":\"default\",\"Statement\":[{\"Sid\":\"sdfsdf\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"events.amazonaws.com\"},\"Action\":\"lambda:InvokeFunction\",\"Resource\":\"arn:aws:lambda:us-east-1:111111111111:function:myPublicTestFunction\"},{\"Sid\": \"lambda-allow-s3-my-function\",\"Effect\": \"Allow\",\"Principal\": {\"Service\": \"s3.amazonaws.com\"},\"Action\": \"lambda:InvokeFunction\",\"Resource\":\"arn:aws:lambda:us-east-2:123456789012:function:my-function\", \"Condition\": {\"ArnLike\": {\"AWS:SourceArn\": \"arn:aws:s3:::my-bucket\"}},\"RevisionId\":\"43f41078-ecd3-406d-b862-d770019c262c\"}]}"
+        "Policy": "{\"Version\":\"2012-10-17\",\"Id\":\"default\",\"Statement\":[{\"Sid\":\"sdfsdf\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"events.amazonaws.com\"},\"Action\":\"lambda:InvokeFunction\",\"Resource\":\"arn:aws:lambda:us-east-1:111111111111:function:myPublicTestFunction\"},{\"Sid\": \"lambda-allow-s3-my-function-test\",\"Effect\": \"Allow\",\"Principal\": {\"Service\": \"s3.amazonaws.com\"},\"Action\": \"lambda:InvokeFunction\",\"Resource\":\"arn:aws:lambda:us-east-2:123456789012:function:my-function\", \"Condition\": {\"ArnLike\": {\"AWS:SourceArn\": \"arn:aws:s3:::my-bucket\"}},\"RevisionId\":\"43f41078-ecd3-406d-b862-d770019c262c\"}]}"
     }
     
     get_policy_after_response = {
@@ -165,7 +165,7 @@ def test_success_s3_statement(mocker):
         {},
         {
             'FunctionName': 'myPublicTestFunction',
-            'StatementId': 'SHARRTest'
+            'StatementId': 'lambda-allow-s3-my-function-test'
         }
     )
 

--- a/source/remediation_runbooks/scripts/test/test_removelambdapublicaccess.py
+++ b/source/remediation_runbooks/scripts/test/test_removelambdapublicaccess.py
@@ -105,7 +105,7 @@ def test_success(mocker):
 
 def test_success_s3_statement(mocker):
     event = {
-        'FunctionName': 'myPublicTestFunction'
+        'FunctionName': 'myPublicS3TestFunction'
     }
 
     get_policy_initial_response = {
@@ -121,7 +121,7 @@ def test_success_s3_statement(mocker):
             },
             "RetryAttempts": 0
         },
-        "Policy": "{\"Version\":\"2012-10-17\",\"Id\":\"default\",\"Statement\":[{\"Sid\":\"sdfsdf\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"events.amazonaws.com\"},\"Action\":\"lambda:InvokeFunction\",\"Resource\":\"arn:aws:lambda:us-east-1:111111111111:function:myPublicTestFunction\"},{\"Sid\": \"lambda-allow-s3-my-function-test\",\"Effect\": \"Allow\",\"Principal\": {\"Service\": \"s3.amazonaws.com\"},\"Action\": \"lambda:InvokeFunction\",\"Resource\":\"arn:aws:lambda:us-east-2:123456789012:function:my-function\", \"Condition\": {\"ArnLike\": {\"AWS:SourceArn\": \"arn:aws:s3:::my-bucket\"}},\"RevisionId\":\"43f41078-ecd3-406d-b862-d770019c262c\"}]}"
+        "Policy": "{\"Version\":\"2012-10-17\",\"Id\":\"default\",\"Statement\":[{\"Sid\":\"sdfsdf\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"events.amazonaws.com\"},\"Action\":\"lambda:InvokeFunction\",\"Resource\":\"arn:aws:lambda:us-east-1:111111111111:function:myPublicS3TestFunction\"},{\"Sid\": \"lambda-allow-s3-my-function-test\",\"Effect\": \"Allow\",\"Principal\": {\"Service\": \"s3.amazonaws.com\"},\"Action\": \"lambda:InvokeFunction\",\"Resource\":\"arn:aws:lambda:us-east-1:111111111111:function:myPublicS3TestFunction\", \"Condition\": {\"ArnLike\": {\"AWS:SourceArn\": \"arn:aws:s3:::my-bucket\"}},\"RevisionId\":\"43f41078-ecd3-406d-b862-d770019c262c\"}]}"
     }
     
     get_policy_after_response = {
@@ -137,7 +137,7 @@ def test_success_s3_statement(mocker):
             },
             "RetryAttempts": 0
         },
-        "Policy": "{\"Version\":\"2012-10-17\",\"Id\":\"default\",\"Statement\":[{\"Sid\":\"sdfsdf\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"events.amazonaws.com\"},\"Action\":\"lambda:InvokeFunction\",\"Resource\":\"arn:aws:lambda:us-east-1:111111111111:function:myPublicTestFunction\"}]}",
+        "Policy": "{\"Version\":\"2012-10-17\",\"Id\":\"default\",\"Statement\":[{\"Sid\":\"sdfsdf\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"events.amazonaws.com\"},\"Action\":\"lambda:InvokeFunction\",\"Resource\":\"arn:aws:lambda:us-east-1:111111111111:function:myPublicS3TestFunction\"}]}",
         "RevisionId": "43f41078-ecd3-406d-b862-d770019c262c"
     }
 
@@ -156,7 +156,7 @@ def test_success_s3_statement(mocker):
         'get_policy',
         get_policy_initial_response,
         {
-            'FunctionName': 'myPublicTestFunction'
+            'FunctionName': 'myPublicS3TestFunction'
         }
     )
 
@@ -164,7 +164,7 @@ def test_success_s3_statement(mocker):
         'remove_permission',
         {},
         {
-            'FunctionName': 'myPublicTestFunction',
+            'FunctionName': 'myPublicS3TestFunction',
             'StatementId': 'lambda-allow-s3-my-function-test'
         }
     )
@@ -173,7 +173,7 @@ def test_success_s3_statement(mocker):
         'get_policy',
         get_policy_after_response,
         {
-            'FunctionName': 'myPublicTestFunction'
+            'FunctionName': 'myPublicS3TestFunction'
         }
     )
 
@@ -181,7 +181,7 @@ def test_success_s3_statement(mocker):
         'get_policy',
         get_policy_after_response,
         {
-            'FunctionName': 'myPublicTestFunction'
+            'FunctionName': 'myPublicS3TestFunction'
         }
     )
 

--- a/source/remediation_runbooks/scripts/test/test_removelambdapublicaccess.py
+++ b/source/remediation_runbooks/scripts/test/test_removelambdapublicaccess.py
@@ -121,7 +121,7 @@ def test_success_s3_statement(mocker):
             },
             "RetryAttempts": 0
         },
-        'Policy':  "{\"Version\":\"2012-10-17\",\"Id\":\"default\",\"Statement\":[{\"Sid\":\"sdfsdf\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"events.amazonaws.com\"},\"Action\":\"lambda:InvokeFunction\",\"Resource\":\"arn:aws:lambda:us-east-1:111111111111:function:myPublicTestFunction\"},{\"Sid\": \"lambda-allow-s3-my-function\",\"Effect\": \"Allow\",\"Principa\": {\"Service\": \"s3.amazonaws.com\"},\"Action\": \"lambda:InvokeFunction\",\"Resource\":\"arn:aws:lambda:us-east-2:123456789012:function:my-function\",\"Condition\": {\"ArnLike\": {\"AWS:SourceArn\": \"arn:aws:s3:::my-bucket\"}}},\"RevisionId\": \"43f41078-ecd3-406d-b862-d770019c262c\"}"
+        "Policy": "{\"Version\":\"2012-10-17\",\"Id\":\"default\",\"Statement\":[{\"Sid\":\"sdfsdf\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"events.amazonaws.com\"},\"Action\":\"lambda:InvokeFunction\",\"Resource\":\"arn:aws:lambda:us-east-1:111111111111:function:myPublicTestFunction\"},{\"Sid\": \"lambda-allow-s3-my-function\",\"Effect\": \"Allow\",\"Principal\": {\"Service\": \"s3.amazonaws.com\"},\"Action\": \"lambda:InvokeFunction\",\"Resource\":\"arn:aws:lambda:us-east-2:123456789012:function:my-function\", \"Condition\": {\"ArnLike\": {\"AWS:SourceArn\": \"arn:aws:s3:::my-bucket\"}},\"RevisionId\":\"43f41078-ecd3-406d-b862-d770019c262c\"}]}"
     }
     
     get_policy_after_response = {

--- a/source/test/__snapshots__/runbook_stack.test.ts.snap
+++ b/source/test/__snapshots__/runbook_stack.test.ts.snap
@@ -6082,14 +6082,14 @@ def public_s3_statement_check(statement, principal):
     This function checks if the user has given access to an S3 bucket without providing an AWS account.
     """
     try:
-        sourceAccountCheck = False
+        emptySourceAccountCheck = False
         if ("StringEquals" in statement["Condition"]):
-            sourceAccountCheck = ("AWS:SourceAccount" not in statement["Condition"]["StringEquals"])
+            emptySourceAccountCheck = ("AWS:SourceAccount" not in statement["Condition"]["StringEquals"])
         else:
-            sourceAccountCheck = True
-        return principal.get("Service", "") == "s3.amazonaws.com" and sourceAccountCheck
+            emptySourceAccountCheck = True
+        return principal.get("Service", "") == "s3.amazonaws.com" and emptySourceAccountCheck
     except KeyError:
-        pass
+        return principal.get("Service", "") == "s3.amazonaws.com"
 
 def remove_resource_policy(functionname, sid, client):
     try:
@@ -6102,8 +6102,7 @@ def remove_resource_policy(functionname, sid, client):
         exit(f'FAILED: SID {sid} was NOT removed from Lambda function {functionname} - {str(e)}')
 
 def remove_public_statement(client, functionname, statement, principal):
-    if principal == "*" or (isinstance(principal, dict) and principal.get("AWS","") == "*") or (isinstance(principal, dict) and public_s3_statement_check(statement, principal)):
-        print('here')
+    if principal == "*" or (isinstance(principal, dict) and (principal.get("AWS","") == "*" or public_s3_statement_check(statement, principal))):
         print_policy_before(statement)
         remove_resource_policy(functionname, statement['Sid'], client)
 

--- a/source/test/__snapshots__/runbook_stack.test.ts.snap
+++ b/source/test/__snapshots__/runbook_stack.test.ts.snap
@@ -6078,8 +6078,16 @@ def print_policy_before(policy):
     print(json.dumps(policy, indent=2, default=str))
 
 def public_s3_statement_check(statement, principal):
+    """
+    This function checks if the user has given access to an S3 bucket without providing an AWS account.
+    """
     try:
-        return principal.get("Service", "") == "s3.amazonaws.com" and ("AWS:SourceAccount" not in statement["Condition"]["StringEquals"])
+        sourceAccountCheck = False
+        if ("StringEquals" in statement["Condition"]):
+            sourceAccountCheck = ("AWS:SourceAccount" not in statement["Condition"]["StringEquals"])
+        else:
+            sourceAccountCheck = True
+        return principal.get("Service", "") == "s3.amazonaws.com" and sourceAccountCheck
     except KeyError:
         pass
 
@@ -6093,12 +6101,11 @@ def remove_resource_policy(functionname, sid, client):
     except Exception as e:
         exit(f'FAILED: SID {sid} was NOT removed from Lambda function {functionname} - {str(e)}')
 
-def remove_public_statement(client, functionname, statement, principal_source):
-    for principal in list(principal_source):
-        if principal == "*" or (isinstance(principal, dict) and principal.get("AWS","") == "*") or (isinstance(principal, dict) and public_s3_statement_check(statement, principal)):
-            print_policy_before(statement)
-            remove_resource_policy(functionname, statement['Sid'], client)
-            break # there will only be one that matches
+def remove_public_statement(client, functionname, statement, principal):
+    if principal == "*" or (isinstance(principal, dict) and principal.get("AWS","") == "*") or (isinstance(principal, dict) and public_s3_statement_check(statement, principal)):
+        print('here')
+        print_policy_before(statement)
+        remove_resource_policy(functionname, statement['Sid'], client)
 
 def remove_lambda_public_access(event, context):
 
@@ -6114,7 +6121,8 @@ def remove_lambda_public_access(event, context):
         print('Scanning for public resource policies in ' + functionname)
 
         for statement in statements:
-            remove_public_statement(client, functionname, statement, list(statement['Principal']))
+            print(statement)
+            remove_public_statement(client, functionname, statement, statement['Principal'])
 
         client.get_policy(FunctionName=functionname)
 

--- a/source/test/__snapshots__/runbook_stack.test.ts.snap
+++ b/source/test/__snapshots__/runbook_stack.test.ts.snap
@@ -6077,6 +6077,12 @@ def print_policy_before(policy):
     print('Resource Policy to be deleted:')
     print(json.dumps(policy, indent=2, default=str))
 
+def public_s3_statement_check(statement, principal):
+    try:
+        return principal.get("Service", "") == "s3.amazonaws.com" and ("AWS:SourceAccount" not in statement["Condition"]["StringEquals"])
+    except KeyError:
+        pass
+
 def remove_resource_policy(functionname, sid, client):
     try:
         client.remove_permission(
@@ -6089,7 +6095,7 @@ def remove_resource_policy(functionname, sid, client):
 
 def remove_public_statement(client, functionname, statement, principal_source):
     for principal in list(principal_source):
-        if principal == "*" or (isinstance(principal, dict) and principal.get("AWS","") == "*"):
+        if principal == "*" or (isinstance(principal, dict) and principal.get("AWS","") == "*") or public_s3_statement_check(statement, principal):
             print_policy_before(statement)
             remove_resource_policy(functionname, statement['Sid'], client)
             break # there will only be one that matches

--- a/source/test/__snapshots__/runbook_stack.test.ts.snap
+++ b/source/test/__snapshots__/runbook_stack.test.ts.snap
@@ -6095,7 +6095,7 @@ def remove_resource_policy(functionname, sid, client):
 
 def remove_public_statement(client, functionname, statement, principal_source):
     for principal in list(principal_source):
-        if principal == "*" or (isinstance(principal, dict) and principal.get("AWS","") == "*") or public_s3_statement_check(statement, principal):
+        if principal == "*" or (isinstance(principal, dict) and principal.get("AWS","") == "*") or (isinstance(principal, dict) and public_s3_statement_check(statement, principal)):
             print_policy_before(statement)
             remove_resource_policy(functionname, statement['Sid'], client)
             break # there will only be one that matches

--- a/source/test/__snapshots__/runbook_stack.test.ts.snap
+++ b/source/test/__snapshots__/runbook_stack.test.ts.snap
@@ -6120,7 +6120,6 @@ def remove_lambda_public_access(event, context):
         print('Scanning for public resource policies in ' + functionname)
 
         for statement in statements:
-            print(statement)
             remove_public_statement(client, functionname, statement, statement['Principal'])
 
         client.get_policy(FunctionName=functionname)


### PR DESCRIPTION
*Description of changes:*

- Fixes bug with Lambda.1 Remediation not being able to remove a lambda resource policy pointed at S3 without a SourceAccount.
- Fixes bug with processing of Lambda resource policies that have dicts as principals.

Unit tests pass, new unit test case added, manually tested remediation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.