### PR TITLE
Added nested admin stacks to AppRegistry

### DIFF
--- a/source/Orchestrator/lib/common-orchestrator-construct.ts
+++ b/source/Orchestrator/lib/common-orchestrator-construct.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Stack, Duration, RemovalPolicy, CfnParameter, CfnStack, Fn } from 'aws-cdk-lib';
+import { Stack, Duration, RemovalPolicy, CfnParameter, CfnResource, Fn, NestedStack } from 'aws-cdk-lib';
 import { PolicyDocument, PolicyStatement, Role, Effect, ServicePrincipal, CfnRole } from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as sfn from 'aws-cdk-lib/aws-stepfunctions';
@@ -24,6 +24,7 @@ export interface ConstructProps {
 }
 
 export class OrchestratorConstruct extends Construct {
+  nestedStack: NestedStack;
   constructor(scope: Construct, id: string, props: ConstructProps) {
     super(scope, id);
 
@@ -39,6 +40,7 @@ export class OrchestratorConstruct extends Construct {
     });
 
     const nestedLogStack = this.createLogStack(props.kmsKeyParm);
+    this.nestedStack = nestedLogStack;
 
     const getDocStateFunc: lambda.IFunction = lambda.Function.fromFunctionAttributes(this, 'getDocStateFunc', {
       functionArn: props.ssmDocStateLambda,
@@ -490,7 +492,7 @@ export class OrchestratorConstruct extends Construct {
       IncludeExecutionData: true,
       Level: 'ALL',
     });
-    stateMachineConstruct.addDependency(nestedLogStack);
+    stateMachineConstruct.addDependency(nestedLogStack.nestedStackResource as CfnResource);
 
     // Remove the unnecessary Policy created by the L2 StateMachine construct
     const roleToModify = this.node.findChild('Role') as CfnRole;
@@ -504,7 +506,7 @@ export class OrchestratorConstruct extends Construct {
     ]);
   }
 
-  private createLogStack(kmsKeyParm: StringParameter): CfnStack {
+  private createLogStack(kmsKeyParm: StringParameter): NestedStack {
     const reuseOrchLogGroup = new CfnParameter(this, 'Reuse Log Group', {
       type: 'String',
       description: `Reuse existing Orchestrator Log Group? Choose "yes" if the log group already exists, else "no"`,
@@ -514,17 +516,23 @@ export class OrchestratorConstruct extends Construct {
 
     reuseOrchLogGroup.overrideLogicalId(`ReuseOrchestratorLogGroup`);
 
-    return new CfnStack(this, 'NestedLogStack', {
+    const logStack = new NestedStack(this, 'NestedLogStack', {
       parameters: {
         KmsKeyArn: kmsKeyParm.stringValue,
         ReuseOrchestratorLogGroup: reuseOrchLogGroup.valueAsString,
       },
-      templateUrl:
-        'https://' +
+    });
+    const cfnStack = logStack.nestedStackResource as CfnResource;
+
+    cfnStack.addPropertyOverride(
+      'TemplateURL',
+      'https://' +
         Fn.findInMap('SourceCode', 'General', 'S3Bucket') +
         '-reference.s3.amazonaws.com/' +
         Fn.findInMap('SourceCode', 'General', 'KeyPrefix') +
-        '/aws-sharr-orchestrator-log.template',
-    });
+        '/playbooks/' +
+        '/aws-sharr-orchestrator-log.template'
+    );
+    return logStack;
   }
 }

--- a/source/Orchestrator/lib/common-orchestrator-construct.ts
+++ b/source/Orchestrator/lib/common-orchestrator-construct.ts
@@ -530,7 +530,6 @@ export class OrchestratorConstruct extends Construct {
         Fn.findInMap('SourceCode', 'General', 'S3Bucket') +
         '-reference.s3.amazonaws.com/' +
         Fn.findInMap('SourceCode', 'General', 'KeyPrefix') +
-        '/playbooks/' +
         '/aws-sharr-orchestrator-log.template'
     );
     return logStack;

--- a/source/solution_deploy/bin/solution_deploy.ts
+++ b/source/solution_deploy/bin/solution_deploy.ts
@@ -96,4 +96,4 @@ const appregistry = new AppRegister({
 
 // Do not associate spoke stacks, we must allow other regions
 // Do not associate any nested stacks, this is a non-trivial change
-appregistry.applyAppRegistryToStacks(solStack, []);
+appregistry.applyAppRegistryToStacks(solStack, solStack.nestedStacks);

--- a/source/solution_deploy/bin/solution_deploy.ts
+++ b/source/solution_deploy/bin/solution_deploy.ts
@@ -95,5 +95,4 @@ const appregistry = new AppRegister({
 });
 
 // Do not associate spoke stacks, we must allow other regions
-// Do not associate any nested stacks, this is a non-trivial change
 appregistry.applyAppRegistryToStacks(solStack, solStack.nestedStacks);

--- a/source/solution_deploy/lib/appregistry/applyAppRegistry.ts
+++ b/source/solution_deploy/lib/appregistry/applyAppRegistry.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Aws, CfnMapping, Fn, Stack, NestedStack } from 'aws-cdk-lib';
+import { Aws, CfnMapping, CfnResource, Fn, Stack, NestedStack } from 'aws-cdk-lib';
 import { Application, AttributeGroup } from '@aws-cdk/aws-servicecatalogappregistry-alpha';
 import { applyTag } from '../tags/applyTag';
 import { CfnResourceAssociation } from 'aws-cdk-lib/aws-servicecatalogappregistry';
@@ -47,6 +47,7 @@ export class AppRegister {
         resource: nestedStack.stackId,
         resourceType: 'CFN_STACK',
       });
+      association.addDependency(application.node.defaultChild as CfnResource);
 
       // If the nested stack is conditional, the resource association must also be so on the same condition
       association.cfnOptions.condition = nestedStack.nestedStackResource?.cfnOptions.condition;

--- a/source/solution_deploy/lib/appregistry/applyAppRegistry.ts
+++ b/source/solution_deploy/lib/appregistry/applyAppRegistry.ts
@@ -35,7 +35,7 @@ export class AppRegister {
    * Do not create resource share, it is not needed if spoke accounts are not associated.
    * Do not create ApplicationInsights. This may sometimes fail.
    */
-  public applyAppRegistryToStacks(hubStack: Stack, nestedStacks: NestedStack[]) {
+  public applyAppRegistryToStacks(hubStack: Stack, nestedStacks: Stack[]) {
     const application = this.createAppRegistry(hubStack);
     // Do not create resource share
     // Do not associated spoke stacks, we must allow different regions
@@ -47,7 +47,6 @@ export class AppRegister {
         resource: nestedStack.stackId,
         resourceType: 'CFN_STACK',
       });
-      association.addDependency(application.node.defaultChild as CfnResource);
 
       // If the nested stack is conditional, the resource association must also be so on the same condition
       association.cfnOptions.condition = nestedStack.nestedStackResource?.cfnOptions.condition;

--- a/source/solution_deploy/lib/appregistry/applyAppRegistry.ts
+++ b/source/solution_deploy/lib/appregistry/applyAppRegistry.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Aws, CfnMapping, Fn, Stack } from 'aws-cdk-lib';
+import { Aws, CfnMapping, Fn, Stack, NestedStack } from 'aws-cdk-lib';
 import { Application, AttributeGroup } from '@aws-cdk/aws-servicecatalogappregistry-alpha';
 import { applyTag } from '../tags/applyTag';
 import { CfnResourceAssociation } from 'aws-cdk-lib/aws-servicecatalogappregistry';
@@ -35,7 +35,7 @@ export class AppRegister {
    * Do not create resource share, it is not needed if spoke accounts are not associated.
    * Do not create ApplicationInsights. This may sometimes fail.
    */
-  public applyAppRegistryToStacks(hubStack: Stack, nestedStacks: Stack[]) {
+  public applyAppRegistryToStacks(hubStack: Stack, nestedStacks: NestedStack[]) {
     const application = this.createAppRegistry(hubStack);
     // Do not create resource share
     // Do not associated spoke stacks, we must allow different regions

--- a/source/solution_deploy/lib/appregistry/applyAppRegistry.ts
+++ b/source/solution_deploy/lib/appregistry/applyAppRegistry.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Aws, CfnMapping, CfnResource, Fn, Stack, NestedStack } from 'aws-cdk-lib';
+import { Aws, CfnMapping, Fn, Stack } from 'aws-cdk-lib';
 import { Application, AttributeGroup } from '@aws-cdk/aws-servicecatalogappregistry-alpha';
 import { applyTag } from '../tags/applyTag';
 import { CfnResourceAssociation } from 'aws-cdk-lib/aws-servicecatalogappregistry';

--- a/source/solution_deploy/lib/solution_deploy-stack.ts
+++ b/source/solution_deploy/lib/solution_deploy-stack.ts
@@ -683,6 +683,8 @@ export class SolutionDeployStack extends cdk.Stack {
       kmsKeyParm: kmsKeyParm,
     });
 
+    this.nestedStacks.push(orchestrator.nestedStack as cdk.Stack);
+
     const orchStateMachine = orchestrator.node.findChild('StateMachine') as StateMachine;
     const stateMachineConstruct = orchStateMachine.node.defaultChild as CfnStateMachine;
     const orchArnParm = orchestrator.node.findChild('SHARR_Orchestrator_Arn') as StringParameter;

--- a/source/solution_deploy/lib/solution_deploy-stack.ts
+++ b/source/solution_deploy/lib/solution_deploy-stack.ts
@@ -739,8 +739,8 @@ export class SolutionDeployStack extends cdk.Stack {
           cfnStack.cfnOptions.condition = new cdk.CfnCondition(this, `load${file}Cond`, {
             expression: cdk.Fn.conditionEquals(adminStackOption, 'yes'),
           });
-          adminStack.node.addDependency(stateMachineConstruct);
-          adminStack.node.addDependency(orchestratorArn);
+          cfnStack.node.addDependency(stateMachineConstruct);
+          cfnStack.node.addDependency(orchestratorArn);
 
           this.nestedStacks.push(adminStack);
         }

--- a/source/solution_deploy/lib/solution_deploy-stack.ts
+++ b/source/solution_deploy/lib/solution_deploy-stack.ts
@@ -21,8 +21,6 @@ import {
 import { OrchestratorConstruct } from '../../Orchestrator/lib/common-orchestrator-construct';
 import { CfnStateMachine, StateMachine } from 'aws-cdk-lib/aws-stepfunctions';
 import { OneTrigger } from '../../lib/ssmplaybook';
-import { printDiffOrStringify } from 'jest-matcher-utils';
-import { CfnResource, CfnStack } from 'aws-cdk-lib';
 export interface SHARRStackProps extends cdk.StackProps {
   solutionId: string;
   solutionVersion: string;
@@ -726,7 +724,7 @@ export class SolutionDeployStack extends cdk.Stack {
         standardLogicalNames.push(`Load${parmname}AdminStack`);
 
         const adminStack = new cdk.NestedStack(this, `PlaybookAdminStack${file}`);
-        const cfnStack = adminStack.nestedStackResource as CfnResource;
+        const cfnStack = adminStack.nestedStackResource as cdk.CfnResource;
         cfnStack.addPropertyOverride(
           'TemplateURL',
           'https://' +

--- a/source/solution_deploy/lib/solution_deploy-stack.ts
+++ b/source/solution_deploy/lib/solution_deploy-stack.ts
@@ -33,6 +33,7 @@ export interface SHARRStackProps extends cdk.StackProps {
 
 export class SolutionDeployStack extends cdk.Stack {
   SEND_ANONYMOUS_DATA = 'Yes';
+  nestedStacks: cdk.Stack[] = [];
 
   constructor(scope: cdk.App, id: string, props: SHARRStackProps) {
     super(scope, id, props);
@@ -737,6 +738,7 @@ export class SolutionDeployStack extends cdk.Stack {
           adminStack.cfnOptions.condition = new cdk.CfnCondition(this, `load${file}Cond`, {
             expression: cdk.Fn.conditionEquals(adminStackOption, 'yes'),
           });
+          this.nestedStacks.push(cdk.Stack.of(adminStack));
         }
       });
     });

--- a/source/test/__snapshots__/orchestrator.test.ts.snap
+++ b/source/test/__snapshots__/orchestrator.test.ts.snap
@@ -148,7 +148,7 @@ exports[`test App Orchestrator Construct 1`] = `
                   "KeyPrefix",
                 ],
               },
-              "/playbooks//aws-sharr-orchestrator-log.template",
+              "/aws-sharr-orchestrator-log.template",
             ],
           ],
         },

--- a/source/test/__snapshots__/orchestrator.test.ts.snap
+++ b/source/test/__snapshots__/orchestrator.test.ts.snap
@@ -114,7 +114,8 @@ exports[`test App Orchestrator Construct 1`] = `
     },
   },
   "Resources": {
-    "OrchestratorNestedLogStack5F778DA0": {
+    "OrchestratorNestedLogStackNestedStackNestedLogStackNestedStackResource91223B3E": {
+      "DeletionPolicy": "Delete",
       "Properties": {
         "Parameters": {
           "KmsKeyArn": {
@@ -147,12 +148,13 @@ exports[`test App Orchestrator Construct 1`] = `
                   "KeyPrefix",
                 ],
               },
-              "/aws-sharr-orchestrator-log.template",
+              "/playbooks//aws-sharr-orchestrator-log.template",
             ],
           ],
         },
       },
       "Type": "AWS::CloudFormation::Stack",
+      "UpdateReplacePolicy": "Delete",
     },
     "OrchestratorRole9CF251DB": {
       "DeletionPolicy": "Retain",
@@ -288,7 +290,7 @@ exports[`test App Orchestrator Construct 1`] = `
     },
     "OrchestratorStateMachine1E795392": {
       "DependsOn": [
-        "OrchestratorNestedLogStack5F778DA0",
+        "OrchestratorNestedLogStackNestedStackNestedLogStackNestedStackResource91223B3E",
         "OrchestratorRole9CF251DB",
       ],
       "Metadata": {

--- a/source/test/__snapshots__/solution_deploy.test.ts.snap
+++ b/source/test/__snapshots__/solution_deploy.test.ts.snap
@@ -2,6 +2,48 @@
 
 exports[`Test if the Stack has all the resources. 1`] = `
 {
+  "Conditions": {
+    "loadAFSBPCond": {
+      "Fn::Equals": [
+        {
+          "Ref": "LoadAFSBPAdminStack",
+        },
+        "yes",
+      ],
+    },
+    "loadCIS120Cond": {
+      "Fn::Equals": [
+        {
+          "Ref": "LoadCIS120AdminStack",
+        },
+        "yes",
+      ],
+    },
+    "loadCIS140Cond": {
+      "Fn::Equals": [
+        {
+          "Ref": "LoadCIS140AdminStack",
+        },
+        "yes",
+      ],
+    },
+    "loadPCI321Cond": {
+      "Fn::Equals": [
+        {
+          "Ref": "LoadPCI321AdminStack",
+        },
+        "yes",
+      ],
+    },
+    "loadSCCond": {
+      "Fn::Equals": [
+        {
+          "Ref": "LoadSCAdminStack",
+        },
+        "yes",
+      ],
+    },
+  },
   "Mappings": {
     "SourceCode": {
       "General": {
@@ -22,12 +64,63 @@ exports[`Test if the Stack has all the resources. 1`] = `
           "Label": {
             "default": "Security Standard Playbooks",
           },
-          "Parameters": [],
+          "Parameters": [
+            "LoadAFSBPAdminStack",
+            "LoadCIS120AdminStack",
+            "LoadCIS140AdminStack",
+            "LoadPCI321AdminStack",
+            "LoadSCAdminStack",
+          ],
         },
       ],
     },
   },
   "Parameters": {
+    "LoadAFSBPAdminStack": {
+      "AllowedValues": [
+        "yes",
+        "no",
+      ],
+      "Default": "yes",
+      "Description": "Load CloudWatch Event Rules for AFSBP?",
+      "Type": "String",
+    },
+    "LoadCIS120AdminStack": {
+      "AllowedValues": [
+        "yes",
+        "no",
+      ],
+      "Default": "yes",
+      "Description": "Load CloudWatch Event Rules for CIS120?",
+      "Type": "String",
+    },
+    "LoadCIS140AdminStack": {
+      "AllowedValues": [
+        "yes",
+        "no",
+      ],
+      "Default": "yes",
+      "Description": "Load CloudWatch Event Rules for CIS140?",
+      "Type": "String",
+    },
+    "LoadPCI321AdminStack": {
+      "AllowedValues": [
+        "yes",
+        "no",
+      ],
+      "Default": "yes",
+      "Description": "Load CloudWatch Event Rules for PCI321?",
+      "Type": "String",
+    },
+    "LoadSCAdminStack": {
+      "AllowedValues": [
+        "yes",
+        "no",
+      ],
+      "Default": "yes",
+      "Description": "Load CloudWatch Event Rules for SC?",
+      "Type": "String",
+    },
     "ReuseOrchestratorLogGroup": {
       "AllowedValues": [
         "yes",
@@ -102,6 +195,186 @@ exports[`Test if the Stack has all the resources. 1`] = `
         "Timeout": 600,
       },
       "Type": "AWS::Lambda::Function",
+    },
+    "PlaybookAdminStackAFSBPNestedStackPlaybookAdminStackAFSBPNestedStackResource649D3317": {
+      "Condition": "loadAFSBPCond",
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "orchestratorSHARROrchestratorArn0ACC7B05",
+        "orchestratorStateMachine77C3F8FB",
+      ],
+      "Properties": {
+        "TemplateURL": {
+          "Fn::Join": [
+            "",
+            [
+              "https://",
+              {
+                "Fn::FindInMap": [
+                  "SourceCode",
+                  "General",
+                  "S3Bucket",
+                ],
+              },
+              "-reference.s3.amazonaws.com/",
+              {
+                "Fn::FindInMap": [
+                  "SourceCode",
+                  "General",
+                  "KeyPrefix",
+                ],
+              },
+              "/playbooks/AFSBPStack.template",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudFormation::Stack",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "PlaybookAdminStackCIS120NestedStackPlaybookAdminStackCIS120NestedStackResource21DCA876": {
+      "Condition": "loadCIS120Cond",
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "orchestratorSHARROrchestratorArn0ACC7B05",
+        "orchestratorStateMachine77C3F8FB",
+      ],
+      "Properties": {
+        "TemplateURL": {
+          "Fn::Join": [
+            "",
+            [
+              "https://",
+              {
+                "Fn::FindInMap": [
+                  "SourceCode",
+                  "General",
+                  "S3Bucket",
+                ],
+              },
+              "-reference.s3.amazonaws.com/",
+              {
+                "Fn::FindInMap": [
+                  "SourceCode",
+                  "General",
+                  "KeyPrefix",
+                ],
+              },
+              "/playbooks/CIS120Stack.template",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudFormation::Stack",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "PlaybookAdminStackCIS140NestedStackPlaybookAdminStackCIS140NestedStackResource54008C57": {
+      "Condition": "loadCIS140Cond",
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "orchestratorSHARROrchestratorArn0ACC7B05",
+        "orchestratorStateMachine77C3F8FB",
+      ],
+      "Properties": {
+        "TemplateURL": {
+          "Fn::Join": [
+            "",
+            [
+              "https://",
+              {
+                "Fn::FindInMap": [
+                  "SourceCode",
+                  "General",
+                  "S3Bucket",
+                ],
+              },
+              "-reference.s3.amazonaws.com/",
+              {
+                "Fn::FindInMap": [
+                  "SourceCode",
+                  "General",
+                  "KeyPrefix",
+                ],
+              },
+              "/playbooks/CIS140Stack.template",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudFormation::Stack",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "PlaybookAdminStackPCI321NestedStackPlaybookAdminStackPCI321NestedStackResourceB6A45DB0": {
+      "Condition": "loadPCI321Cond",
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "orchestratorSHARROrchestratorArn0ACC7B05",
+        "orchestratorStateMachine77C3F8FB",
+      ],
+      "Properties": {
+        "TemplateURL": {
+          "Fn::Join": [
+            "",
+            [
+              "https://",
+              {
+                "Fn::FindInMap": [
+                  "SourceCode",
+                  "General",
+                  "S3Bucket",
+                ],
+              },
+              "-reference.s3.amazonaws.com/",
+              {
+                "Fn::FindInMap": [
+                  "SourceCode",
+                  "General",
+                  "KeyPrefix",
+                ],
+              },
+              "/playbooks/PCI321Stack.template",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudFormation::Stack",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "PlaybookAdminStackSCNestedStackPlaybookAdminStackSCNestedStackResource269A112D": {
+      "Condition": "loadSCCond",
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "orchestratorSHARROrchestratorArn0ACC7B05",
+        "orchestratorStateMachine77C3F8FB",
+      ],
+      "Properties": {
+        "TemplateURL": {
+          "Fn::Join": [
+            "",
+            [
+              "https://",
+              {
+                "Fn::FindInMap": [
+                  "SourceCode",
+                  "General",
+                  "S3Bucket",
+                ],
+              },
+              "-reference.s3.amazonaws.com/",
+              {
+                "Fn::FindInMap": [
+                  "SourceCode",
+                  "General",
+                  "KeyPrefix",
+                ],
+              },
+              "/playbooks/SCStack.template",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudFormation::Stack",
+      "UpdateReplacePolicy": "Delete",
     },
     "RemediateWithSharrCustomActionABE4122A": {
       "DeletionPolicy": "Delete",

--- a/source/test/__snapshots__/solution_deploy.test.ts.snap
+++ b/source/test/__snapshots__/solution_deploy.test.ts.snap
@@ -45,6 +45,15 @@ exports[`Test if the Stack has all the resources. 1`] = `
     },
   },
   "Mappings": {
+    "Solution": {
+      "Data": {
+        "AppRegistryApplicationName": "automated-security-response-on-aws",
+        "ApplicationType": "AWS-Solutions",
+        "ID": "SO0111",
+        "SolutionName": "automated-security-response-on-aws",
+        "Version": "v1.0.0",
+      },
+    },
     "SourceCode": {
       "General": {
         "KeyPrefix": "aws-security-hub-automated-response-and-remediation/v1.0.0",
@@ -73,6 +82,39 @@ exports[`Test if the Stack has all the resources. 1`] = `
           ],
         },
       ],
+    },
+  },
+  "Outputs": {
+    "AppRegistryApplicationManagerUrl775D5C3D": {
+      "Description": "Application manager url for the application created.",
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "https://eu-west-1.console.aws.amazon.com/systems-manager/appmanager/application/AWS_AppRegistry_Application-",
+            {
+              "Fn::Join": [
+                "-",
+                [
+                  {
+                    "Fn::FindInMap": [
+                      "Solution",
+                      "Data",
+                      "AppRegistryApplicationName",
+                    ],
+                  },
+                  {
+                    "Ref": "AWS::Region",
+                  },
+                  {
+                    "Ref": "AWS::AccountId",
+                  },
+                ],
+              ],
+            },
+          ],
+        ],
+      },
     },
   },
   "Parameters": {
@@ -132,6 +174,207 @@ exports[`Test if the Stack has all the resources. 1`] = `
     },
   },
   "Resources": {
+    "AppRegistry968496A3": {
+      "Properties": {
+        "Description": "Service Catalog application to track and manage all your resources for the solution automated-security-response-on-aws",
+        "Name": {
+          "Fn::Join": [
+            "-",
+            [
+              {
+                "Fn::FindInMap": [
+                  "Solution",
+                  "Data",
+                  "AppRegistryApplicationName",
+                ],
+              },
+              {
+                "Ref": "AWS::Region",
+              },
+              {
+                "Ref": "AWS::AccountId",
+              },
+            ],
+          ],
+        },
+        "Tags": {
+          "Solutions:ApplicationType": {
+            "Fn::FindInMap": [
+              "Solution",
+              "Data",
+              "ApplicationType",
+            ],
+          },
+          "Solutions:SolutionID": {
+            "Fn::FindInMap": [
+              "Solution",
+              "Data",
+              "ID",
+            ],
+          },
+          "Solutions:SolutionName": {
+            "Fn::FindInMap": [
+              "Solution",
+              "Data",
+              "SolutionName",
+            ],
+          },
+          "Solutions:SolutionVersion": {
+            "Fn::FindInMap": [
+              "Solution",
+              "Data",
+              "Version",
+            ],
+          },
+        },
+      },
+      "Type": "AWS::ServiceCatalogAppRegistry::Application",
+    },
+    "AppRegistryAssociation": {
+      "Properties": {
+        "Application": {
+          "Fn::GetAtt": [
+            "AppRegistry968496A3",
+            "Id",
+          ],
+        },
+        "Resource": {
+          "Ref": "AWS::StackId",
+        },
+        "ResourceType": "CFN_STACK",
+      },
+      "Type": "AWS::ServiceCatalogAppRegistry::ResourceAssociation",
+    },
+    "AppRegistryAttributeGroupAssociation58e755b9eb72544DB135": {
+      "Properties": {
+        "Application": {
+          "Fn::GetAtt": [
+            "AppRegistry968496A3",
+            "Id",
+          ],
+        },
+        "AttributeGroup": {
+          "Fn::GetAtt": [
+            "DefaultApplicationAttributesFC1CC26B",
+            "Id",
+          ],
+        },
+      },
+      "Type": "AWS::ServiceCatalogAppRegistry::AttributeGroupAssociation",
+    },
+    "AppRegistryResourceAssociation142839FB0": {
+      "DependsOn": [
+        "orchestratorNestedLogStackNestedStackNestedLogStackNestedStackResourceE4E042A6",
+      ],
+      "Properties": {
+        "Application": {
+          "Fn::GetAtt": [
+            "AppRegistry968496A3",
+            "Id",
+          ],
+        },
+        "Resource": {
+          "Ref": "orchestratorNestedLogStackNestedStackNestedLogStackNestedStackResourceE4E042A6",
+        },
+        "ResourceType": "CFN_STACK",
+      },
+      "Type": "AWS::ServiceCatalogAppRegistry::ResourceAssociation",
+    },
+    "AppRegistryResourceAssociation2BB1A3300": {
+      "Condition": "loadAFSBPCond",
+      "DependsOn": [
+        "PlaybookAdminStackAFSBPNestedStackPlaybookAdminStackAFSBPNestedStackResource649D3317",
+      ],
+      "Properties": {
+        "Application": {
+          "Fn::GetAtt": [
+            "AppRegistry968496A3",
+            "Id",
+          ],
+        },
+        "Resource": {
+          "Ref": "PlaybookAdminStackAFSBPNestedStackPlaybookAdminStackAFSBPNestedStackResource649D3317",
+        },
+        "ResourceType": "CFN_STACK",
+      },
+      "Type": "AWS::ServiceCatalogAppRegistry::ResourceAssociation",
+    },
+    "AppRegistryResourceAssociation3BEAC7BB7": {
+      "Condition": "loadCIS120Cond",
+      "DependsOn": [
+        "PlaybookAdminStackCIS120NestedStackPlaybookAdminStackCIS120NestedStackResource21DCA876",
+      ],
+      "Properties": {
+        "Application": {
+          "Fn::GetAtt": [
+            "AppRegistry968496A3",
+            "Id",
+          ],
+        },
+        "Resource": {
+          "Ref": "PlaybookAdminStackCIS120NestedStackPlaybookAdminStackCIS120NestedStackResource21DCA876",
+        },
+        "ResourceType": "CFN_STACK",
+      },
+      "Type": "AWS::ServiceCatalogAppRegistry::ResourceAssociation",
+    },
+    "AppRegistryResourceAssociation46F7B9873": {
+      "Condition": "loadCIS140Cond",
+      "DependsOn": [
+        "PlaybookAdminStackCIS140NestedStackPlaybookAdminStackCIS140NestedStackResource54008C57",
+      ],
+      "Properties": {
+        "Application": {
+          "Fn::GetAtt": [
+            "AppRegistry968496A3",
+            "Id",
+          ],
+        },
+        "Resource": {
+          "Ref": "PlaybookAdminStackCIS140NestedStackPlaybookAdminStackCIS140NestedStackResource54008C57",
+        },
+        "ResourceType": "CFN_STACK",
+      },
+      "Type": "AWS::ServiceCatalogAppRegistry::ResourceAssociation",
+    },
+    "AppRegistryResourceAssociation5FAA30631": {
+      "Condition": "loadPCI321Cond",
+      "DependsOn": [
+        "PlaybookAdminStackPCI321NestedStackPlaybookAdminStackPCI321NestedStackResourceB6A45DB0",
+      ],
+      "Properties": {
+        "Application": {
+          "Fn::GetAtt": [
+            "AppRegistry968496A3",
+            "Id",
+          ],
+        },
+        "Resource": {
+          "Ref": "PlaybookAdminStackPCI321NestedStackPlaybookAdminStackPCI321NestedStackResourceB6A45DB0",
+        },
+        "ResourceType": "CFN_STACK",
+      },
+      "Type": "AWS::ServiceCatalogAppRegistry::ResourceAssociation",
+    },
+    "AppRegistryResourceAssociation62B582FF5": {
+      "Condition": "loadSCCond",
+      "DependsOn": [
+        "PlaybookAdminStackSCNestedStackPlaybookAdminStackSCNestedStackResource269A112D",
+      ],
+      "Properties": {
+        "Application": {
+          "Fn::GetAtt": [
+            "AppRegistry968496A3",
+            "Id",
+          ],
+        },
+        "Resource": {
+          "Ref": "PlaybookAdminStackSCNestedStackPlaybookAdminStackSCNestedStackResource269A112D",
+        },
+        "ResourceType": "CFN_STACK",
+      },
+      "Type": "AWS::ServiceCatalogAppRegistry::ResourceAssociation",
+    },
     "CreateCustomActionE7A973F5": {
       "DependsOn": [
         "createCustomActionRoleF0047414",
@@ -195,6 +438,45 @@ exports[`Test if the Stack has all the resources. 1`] = `
         "Timeout": 600,
       },
       "Type": "AWS::Lambda::Function",
+    },
+    "DefaultApplicationAttributesFC1CC26B": {
+      "Properties": {
+        "Attributes": {
+          "applicationType": {
+            "Fn::FindInMap": [
+              "Solution",
+              "Data",
+              "ApplicationType",
+            ],
+          },
+          "solutionID": {
+            "Fn::FindInMap": [
+              "Solution",
+              "Data",
+              "ID",
+            ],
+          },
+          "solutionName": {
+            "Fn::FindInMap": [
+              "Solution",
+              "Data",
+              "SolutionName",
+            ],
+          },
+          "version": {
+            "Fn::FindInMap": [
+              "Solution",
+              "Data",
+              "Version",
+            ],
+          },
+        },
+        "Description": "Attribute group for solution information",
+        "Name": {
+          "Ref": "AWS::StackName",
+        },
+      },
+      "Type": "AWS::ServiceCatalogAppRegistry::AttributeGroup",
     },
     "PlaybookAdminStackAFSBPNestedStackPlaybookAdminStackAFSBPNestedStackResource649D3317": {
       "Condition": "loadAFSBPCond",
@@ -1112,7 +1394,8 @@ exports[`Test if the Stack has all the resources. 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "orchestratorNestedLogStack4DD66790": {
+    "orchestratorNestedLogStackNestedStackNestedLogStackNestedStackResourceE4E042A6": {
+      "DeletionPolicy": "Delete",
       "Properties": {
         "Parameters": {
           "KmsKeyArn": {
@@ -1145,12 +1428,13 @@ exports[`Test if the Stack has all the resources. 1`] = `
                   "KeyPrefix",
                 ],
               },
-              "/aws-sharr-orchestrator-log.template",
+              "/playbooks//aws-sharr-orchestrator-log.template",
             ],
           ],
         },
       },
       "Type": "AWS::CloudFormation::Stack",
+      "UpdateReplacePolicy": "Delete",
     },
     "orchestratorPolicy8045810D": {
       "Metadata": {
@@ -1505,7 +1789,7 @@ exports[`Test if the Stack has all the resources. 1`] = `
     },
     "orchestratorStateMachine77C3F8FB": {
       "DependsOn": [
-        "orchestratorNestedLogStack4DD66790",
+        "orchestratorNestedLogStackNestedStackNestedLogStackNestedStackResourceE4E042A6",
         "orchestratorRole12B410FD",
       ],
       "Metadata": {

--- a/source/test/__snapshots__/solution_deploy.test.ts.snap
+++ b/source/test/__snapshots__/solution_deploy.test.ts.snap
@@ -1428,7 +1428,7 @@ exports[`Test if the Stack has all the resources. 1`] = `
                   "KeyPrefix",
                 ],
               },
-              "/playbooks//aws-sharr-orchestrator-log.template",
+              "/aws-sharr-orchestrator-log.template",
             ],
           ],
         },

--- a/source/test/solution_deploy.test.ts
+++ b/source/test/solution_deploy.test.ts
@@ -5,10 +5,19 @@ import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Template } from 'aws-cdk-lib/assertions';
 import { AwsSolutionsChecks } from 'cdk-nag';
 import { SolutionDeployStack } from '../solution_deploy/lib/solution_deploy-stack';
+import { AppRegister } from '../solution_deploy/lib/appregistry/applyAppRegistry';
 
 function getTestStack(): Stack {
   const envEU = { account: '111111111111', region: 'eu-west-1' };
   const app = new App();
+  const appName = 'automated-security-response-on-aws';
+  const appregistry = new AppRegister({
+    solutionId: 'SO0111',
+    solutionName: appName,
+    solutionVersion: 'v1.0.0',
+    appRegistryApplicationName: appName,
+    applicationType: 'AWS-Solutions',
+  });
   const stack = new SolutionDeployStack(app, 'stack', {
     synthesizer: new DefaultStackSynthesizer({ generateBootstrapVersionRule: false }),
     env: envEU,
@@ -20,6 +29,7 @@ function getTestStack(): Stack {
     runtimePython: Runtime.PYTHON_3_9,
     orchLogGroup: 'ORCH_LOG_GROUP',
   });
+  appregistry.applyAppRegistryToStacks(stack, stack.nestedStacks);
   Aspects.of(app).add(new AwsSolutionsChecks({ verbose: true }));
   return stack;
 }


### PR DESCRIPTION
*Description of changes:*
Changed the population of the nested stacks to be synchronous so it can get passed to our AppRegistry library.
Changed stacks to use NestedStack rather than the L1 construct.
      - The L1 construct is still used to populate some requirements for our stacks, but works the same as it did before.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.