### PR TITLE
Fixed creation issue with AppRegistry Association Group naming

### DIFF
--- a/source/solution_deploy/lib/__snapshots__/member-stack.test.ts.snap
+++ b/source/solution_deploy/lib/__snapshots__/member-stack.test.ts.snap
@@ -332,7 +332,15 @@ exports[`member stack snapshot matches 1`] = `
         },
         "Description": "Attribute group for solution information",
         "Name": {
-          "Ref": "AWS::StackName",
+          "Fn::Join": [
+            "",
+            [
+              "ASR",
+              {
+                "Ref": "AWS::StackName",
+              },
+            ],
+          ],
         },
       },
       "Type": "AWS::ServiceCatalogAppRegistry::AttributeGroup",

--- a/source/solution_deploy/lib/__snapshots__/member-stack.test.ts.snap
+++ b/source/solution_deploy/lib/__snapshots__/member-stack.test.ts.snap
@@ -335,7 +335,7 @@ exports[`member stack snapshot matches 1`] = `
           "Fn::Join": [
             "",
             [
-              "ASR",
+              "ASR-",
               {
                 "Ref": "AWS::StackName",
               },

--- a/source/solution_deploy/lib/appregistry/applyAppRegistry.ts
+++ b/source/solution_deploy/lib/appregistry/applyAppRegistry.ts
@@ -74,7 +74,7 @@ export class AppRegister {
     application.associateApplicationWithStack(stack);
 
     const attributeGroup = new AttributeGroup(stack, 'DefaultApplicationAttributes', {
-      attributeGroupName: 'ASR' + Aws.STACK_NAME,
+      attributeGroupName: 'ASR-' + Aws.STACK_NAME,
       description: 'Attribute group for solution information',
       attributes: {
         applicationType: map.findInMap('Data', 'ApplicationType'),

--- a/source/solution_deploy/lib/appregistry/applyAppRegistry.ts
+++ b/source/solution_deploy/lib/appregistry/applyAppRegistry.ts
@@ -74,7 +74,7 @@ export class AppRegister {
     application.associateApplicationWithStack(stack);
 
     const attributeGroup = new AttributeGroup(stack, 'DefaultApplicationAttributes', {
-      attributeGroupName: Aws.STACK_NAME,
+      attributeGroupName: 'ASR' + Aws.STACK_NAME,
       description: 'Attribute group for solution information',
       attributes: {
         applicationType: map.findInMap('Data', 'ApplicationType'),

--- a/source/test/__snapshots__/solution_deploy.test.ts.snap
+++ b/source/test/__snapshots__/solution_deploy.test.ts.snap
@@ -482,7 +482,7 @@ exports[`Test if the Stack has all the resources. 1`] = `
           "Fn::Join": [
             "",
             [
-              "ASR",
+              "ASR-",
               {
                 "Ref": "AWS::StackName",
               },

--- a/source/test/__snapshots__/solution_deploy.test.ts.snap
+++ b/source/test/__snapshots__/solution_deploy.test.ts.snap
@@ -479,7 +479,15 @@ exports[`Test if the Stack has all the resources. 1`] = `
         },
         "Description": "Attribute group for solution information",
         "Name": {
-          "Ref": "AWS::StackName",
+          "Fn::Join": [
+            "",
+            [
+              "ASR",
+              {
+                "Ref": "AWS::StackName",
+              },
+            ],
+          ],
         },
       },
       "Type": "AWS::ServiceCatalogAppRegistry::AttributeGroup",


### PR DESCRIPTION
*Description of changes:*
This change fixes the issue users were having spinning up the templates with a stack name starting with `aws`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.