### PR TITLE
WIP/POC add wait dependency chain between SSM documents, batched

### DIFF
--- a/deployment/build-s3-dist.sh
+++ b/deployment/build-s3-dist.sh
@@ -134,10 +134,12 @@ main() {
 
 	pushd "$temp_work_dir"/source/solution_deploy/source
 	zip ${build_dist_dir}/lambda/action_target_provider.zip action_target_provider.py cfnresponse.py
-	# Copy LambdaLayer modules in preparation for running tests
-	# These are not packaged with the Lambda
-	cp ../../LambdaLayers/*.py .
 	popd
+
+	header "[Pack] Wait Provider Lambda"
+
+	pushd "$temp_work_dir"/source/solution_deploy/source
+	zip ${build_dist_dir}/lambda/wait_provider.zip wait_provider.py cfnresponse.py
 
 	header "[Pack] Orchestrator Lambdas"
 
@@ -147,9 +149,6 @@ main() {
 			zip "$build_dist_dir"/lambda/"$file".zip "$file"
 		fi
 	done
-	# Copy LambdaLayer modules in preparation for running tests
-	# These are not packaged with the Lambda
-	cp ../LambdaLayers/*.py .
 	popd
 
 	header "[Create] Playbooks"

--- a/source/lib/sharrplaybook-construct.ts
+++ b/source/lib/sharrplaybook-construct.ts
@@ -12,7 +12,7 @@ import { Trigger } from './ssmplaybook';
 import AdminAccountParam from './admin-account-param';
 import { ControlRunbookFactory } from '../solution_deploy/lib/runbook_factory';
 import { Construct } from 'constructs';
-import { StackProps } from 'aws-cdk-lib';
+import { CfnParameter, StackProps } from 'aws-cdk-lib';
 
 export interface IControl {
   control: string;
@@ -120,7 +120,11 @@ export class PlaybookMemberStack extends cdk.Stack {
 
     new AdminAccountParam(this, 'AdminAccountParameter');
 
-    const runbookFactory = new ControlRunbookFactory(this, 'RunbookFactory');
+    const waitProviderServiceTokenParam = new CfnParameter(this, 'WaitProviderServiceToken');
+
+    const runbookFactory = new ControlRunbookFactory(this, 'RunbookFactory', {
+      waitProviderServiceToken: waitProviderServiceTokenParam.valueAsString,
+    });
 
     const processRemediation = function (controlSpec: IControl): void {
       // Create the ssm automation document only if this is not a remapped control

--- a/source/lib/sharrplaybook-construct.ts
+++ b/source/lib/sharrplaybook-construct.ts
@@ -10,7 +10,7 @@ import * as cdk from 'aws-cdk-lib';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import { Trigger } from './ssmplaybook';
 import AdminAccountParam from './admin-account-param';
-import { RunbookFactory } from '../solution_deploy/lib/runbook_factory';
+import { ControlRunbookFactory } from '../solution_deploy/lib/runbook_factory';
 import { Construct } from 'constructs';
 import { StackProps } from 'aws-cdk-lib';
 
@@ -120,7 +120,7 @@ export class PlaybookMemberStack extends cdk.Stack {
 
     new AdminAccountParam(this, 'AdminAccountParameter');
 
-    const runbookFactory = new RunbookFactory(this, 'RunbookFactory');
+    const runbookFactory = new ControlRunbookFactory(this, 'RunbookFactory');
 
     const processRemediation = function (controlSpec: IControl): void {
       // Create the ssm automation document only if this is not a remapped control

--- a/source/lib/sharrplaybook-construct.ts
+++ b/source/lib/sharrplaybook-construct.ts
@@ -120,10 +120,12 @@ export class PlaybookMemberStack extends cdk.Stack {
 
     new AdminAccountParam(this, 'AdminAccountParameter');
 
+    const runbookFactory = new RunbookFactory(this, 'RunbookFactory');
+
     const processRemediation = function (controlSpec: IControl): void {
       // Create the ssm automation document only if this is not a remapped control
       if (!(controlSpec.executes && controlSpec.control != controlSpec.executes)) {
-        RunbookFactory.createControlRunbook(stack, `${props.securityStandard} ${controlSpec.control}`, {
+        runbookFactory.createControlRunbook(stack, `${props.securityStandard} ${controlSpec.control}`, {
           securityStandard: props.securityStandard,
           securityStandardVersion: props.securityStandardVersion,
           controlId: controlSpec.control,

--- a/source/playbooks/AFSBP/test/__snapshots__/afsbp_stack.test.ts.snap
+++ b/source/playbooks/AFSBP/test/__snapshots__/afsbp_stack.test.ts.snap
@@ -62,10 +62,16 @@ exports[`Member Stack - AFSBP 1`] = `
       "Description": "Admin account number",
       "Type": "String",
     },
+    "WaitProviderServiceToken": {
+      "Type": "String",
+    },
   },
   "Resources": {
     "ControlAFSBPEC21": {
       "Condition": "EnableEC21Condition",
+      "DependsOn": [
+        "RunbookFactoryWaitAFSBPEC219EC604F5",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -383,6 +389,9 @@ def parse_event(event, context):
     },
     "ControlAFSBPLambda1": {
       "Condition": "EnableLambda1Condition",
+      "DependsOn": [
+        "RunbookFactoryWaitAFSBPLambda1D1E3CE83",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -720,6 +729,9 @@ def parse_event(event, context):
     },
     "ControlAFSBPRDS1": {
       "Condition": "EnableRDS1Condition",
+      "DependsOn": [
+        "RunbookFactoryWaitAFSBPRDS14E5989A9",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -1065,6 +1077,54 @@ def parse_event(event, context):
         "UpdateMethod": "NewVersion",
       },
       "Type": "AWS::SSM::Document",
+    },
+    "RunbookFactoryWaitAFSBPEC219EC604F5": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "a072269dc9c0e25a4cb7fb304b40ac5179ebee765518f9783a1dd74fa642c86e",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitAFSBPLambda1D1E3CE83": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitAFSBPRDS14E5989A9",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "dc3b76413ca4de4bde1dfbfc1c88505bf997b1ad6f83c44ecf7887a2a0012bcd",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitAFSBPRDS14E5989A9": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitAFSBPEC219EC604F5",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "a173fa97f4b37b0897a59f26fe36d757301ab042446738d60c150bab91dcfb01",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
     },
   },
 }

--- a/source/playbooks/AFSBP/test/__snapshots__/afsbp_stack.test.ts.snap
+++ b/source/playbooks/AFSBP/test/__snapshots__/afsbp_stack.test.ts.snap
@@ -390,7 +390,7 @@ def parse_event(event, context):
     "ControlAFSBPLambda1": {
       "Condition": "EnableLambda1Condition",
       "DependsOn": [
-        "RunbookFactoryWaitAFSBPLambda1D1E3CE83",
+        "RunbookFactoryWaitAFSBPEC219EC604F5",
       ],
       "Properties": {
         "Content": {
@@ -730,7 +730,7 @@ def parse_event(event, context):
     "ControlAFSBPRDS1": {
       "Condition": "EnableRDS1Condition",
       "DependsOn": [
-        "RunbookFactoryWaitAFSBPRDS14E5989A9",
+        "RunbookFactoryWaitAFSBPEC219EC604F5",
       ],
       "Properties": {
         "Content": {
@@ -1083,41 +1083,7 @@ def parse_event(event, context):
       "Properties": {
         "CreateIntervalSeconds": 1,
         "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "a072269dc9c0e25a4cb7fb304b40ac5179ebee765518f9783a1dd74fa642c86e",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitAFSBPLambda1D1E3CE83": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitAFSBPRDS14E5989A9",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "dc3b76413ca4de4bde1dfbfc1c88505bf997b1ad6f83c44ecf7887a2a0012bcd",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitAFSBPRDS14E5989A9": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitAFSBPEC219EC604F5",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "a173fa97f4b37b0897a59f26fe36d757301ab042446738d60c150bab91dcfb01",
+        "DocumentPropertiesHash": "473de65e6cd7ff453ca9fb70bad0f7074d4e639b4960739197292c8b3c1047a5",
         "ServiceToken": {
           "Ref": "WaitProviderServiceToken",
         },

--- a/source/playbooks/CIS120/test/__snapshots__/cis_stack.test.ts.snap
+++ b/source/playbooks/CIS120/test/__snapshots__/cis_stack.test.ts.snap
@@ -441,10 +441,16 @@ exports[`default stack 2`] = `
       "Description": "Admin account number",
       "Type": "String",
     },
+    "WaitProviderServiceToken": {
+      "Type": "String",
+    },
   },
   "Resources": {
     "ControlCIS13": {
       "Condition": "Enable13Condition",
+      "DependsOn": [
+        "RunbookFactoryWaitCIS1342939E39",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -764,6 +770,9 @@ def parse_event(event, context):
     },
     "ControlCIS15": {
       "Condition": "Enable15Condition",
+      "DependsOn": [
+        "RunbookFactoryWaitCIS152572AA0C",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -1095,6 +1104,9 @@ def parse_event(event, context):
     },
     "ControlCIS21": {
       "Condition": "Enable21Condition",
+      "DependsOn": [
+        "RunbookFactoryWaitCIS21A1B77688",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -1424,6 +1436,54 @@ def parse_event(event, context):
         "Value": "4.1",
       },
       "Type": "AWS::SSM::Parameter",
+    },
+    "RunbookFactoryWaitCIS1342939E39": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "114f0e66dd8ec933871c43328b2954be44640a438dae85fac059ab225634cb8c",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitCIS152572AA0C": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitCIS1342939E39",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "4b1d7aad8f9d5866e68ab1428f8c014a632fc239dbae9b59756722f777c03bbd",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitCIS21A1B77688": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitCIS152572AA0C",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "7adc5c8288d535bf80a40ef5ee2fe443dad25dff1c65e47e8f93948a4361738a",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
     },
   },
 }

--- a/source/playbooks/CIS120/test/__snapshots__/cis_stack.test.ts.snap
+++ b/source/playbooks/CIS120/test/__snapshots__/cis_stack.test.ts.snap
@@ -771,7 +771,7 @@ def parse_event(event, context):
     "ControlCIS15": {
       "Condition": "Enable15Condition",
       "DependsOn": [
-        "RunbookFactoryWaitCIS152572AA0C",
+        "RunbookFactoryWaitCIS1342939E39",
       ],
       "Properties": {
         "Content": {
@@ -1105,7 +1105,7 @@ def parse_event(event, context):
     "ControlCIS21": {
       "Condition": "Enable21Condition",
       "DependsOn": [
-        "RunbookFactoryWaitCIS21A1B77688",
+        "RunbookFactoryWaitCIS1342939E39",
       ],
       "Properties": {
         "Content": {
@@ -1442,41 +1442,7 @@ def parse_event(event, context):
       "Properties": {
         "CreateIntervalSeconds": 1,
         "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "114f0e66dd8ec933871c43328b2954be44640a438dae85fac059ab225634cb8c",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitCIS152572AA0C": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitCIS1342939E39",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "4b1d7aad8f9d5866e68ab1428f8c014a632fc239dbae9b59756722f777c03bbd",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitCIS21A1B77688": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitCIS152572AA0C",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "7adc5c8288d535bf80a40ef5ee2fe443dad25dff1c65e47e8f93948a4361738a",
+        "DocumentPropertiesHash": "421e08cfe3530735ac81379cc64a8a0d815110f399f64d789b583ad1f02e4250",
         "ServiceToken": {
           "Ref": "WaitProviderServiceToken",
         },

--- a/source/playbooks/CIS140/lib/cis140_playbook-construct.ts
+++ b/source/playbooks/CIS140/lib/cis140_playbook-construct.ts
@@ -1,9 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Stack, App, StackProps } from 'aws-cdk-lib';
+import { Stack, App, StackProps, CfnParameter } from 'aws-cdk-lib';
 import { ControlRunbooks } from './control_runbooks-construct';
 import AdminAccountParam from '../../../lib/admin-account-param';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import { SsmDocumentWaitProvider } from '../../../solution_deploy/lib/member/wait-provider';
 
 export interface IControl {
   control: string;
@@ -29,6 +30,12 @@ export class CIS140PlaybookMemberStack extends Stack {
     // Not used, but required by top-level member stack
     new AdminAccountParam(this, 'AdminAccountParameter');
 
+    const waitProviderServiceToken = new CfnParameter(this, 'WaitProviderServiceToken');
+
+    const waitProvider = new SsmDocumentWaitProvider(this, 'WaitProvider', {
+      serviceToken: waitProviderServiceToken.valueAsString,
+    });
+
     const controlRunbooks = new ControlRunbooks(this, 'ControlRunbooks', {
       standardShortName: props.securityStandard,
       standardLongName: props.securityStandardLongName,
@@ -37,6 +44,7 @@ export class CIS140PlaybookMemberStack extends Stack {
       solutionId: props.solutionId,
       solutionAcronym: 'ASR',
       solutionVersion: props.solutionVersion,
+      waitProvider,
     });
 
     // Make sure all known controls have runbooks

--- a/source/playbooks/CIS140/test/__snapshots__/cis_stack.test.ts.snap
+++ b/source/playbooks/CIS140/test/__snapshots__/cis_stack.test.ts.snap
@@ -771,7 +771,7 @@ def parse_event(event, context):
     "ControlCIS15": {
       "Condition": "Enable15Condition",
       "DependsOn": [
-        "RunbookFactoryWaitCIS152572AA0C",
+        "RunbookFactoryWaitCIS1342939E39",
       ],
       "Properties": {
         "Content": {
@@ -1105,7 +1105,7 @@ def parse_event(event, context):
     "ControlCIS21": {
       "Condition": "Enable21Condition",
       "DependsOn": [
-        "RunbookFactoryWaitCIS21A1B77688",
+        "RunbookFactoryWaitCIS1342939E39",
       ],
       "Properties": {
         "Content": {
@@ -1442,41 +1442,7 @@ def parse_event(event, context):
       "Properties": {
         "CreateIntervalSeconds": 1,
         "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "33c6936c2525babafd5c28f2b56acdd496e777d68f67e8a67c34bf069015556a",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitCIS152572AA0C": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitCIS1342939E39",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "78cabecb3617f556b1e16c8ff4d7a08a069a107e9ca3d2ef8ad55cffeaa7ffe3",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitCIS21A1B77688": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitCIS152572AA0C",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "7e36a728ad6cc73b656e09fd39b00d9cdb057455bfbcd2e3ff788e1747bab77b",
+        "DocumentPropertiesHash": "131d2736a38f8d8a0fd98d966e70dacb17db2495e0fdd6c0aa23c804f5f8eba4",
         "ServiceToken": {
           "Ref": "WaitProviderServiceToken",
         },

--- a/source/playbooks/CIS140/test/__snapshots__/cis_stack.test.ts.snap
+++ b/source/playbooks/CIS140/test/__snapshots__/cis_stack.test.ts.snap
@@ -441,10 +441,16 @@ exports[`default stack 2`] = `
       "Description": "Admin account number",
       "Type": "String",
     },
+    "WaitProviderServiceToken": {
+      "Type": "String",
+    },
   },
   "Resources": {
     "ControlCIS13": {
       "Condition": "Enable13Condition",
+      "DependsOn": [
+        "RunbookFactoryWaitCIS1342939E39",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -764,6 +770,9 @@ def parse_event(event, context):
     },
     "ControlCIS15": {
       "Condition": "Enable15Condition",
+      "DependsOn": [
+        "RunbookFactoryWaitCIS152572AA0C",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -1095,6 +1104,9 @@ def parse_event(event, context):
     },
     "ControlCIS21": {
       "Condition": "Enable21Condition",
+      "DependsOn": [
+        "RunbookFactoryWaitCIS21A1B77688",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -1424,6 +1436,54 @@ def parse_event(event, context):
         "Value": "4.1",
       },
       "Type": "AWS::SSM::Parameter",
+    },
+    "RunbookFactoryWaitCIS1342939E39": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "33c6936c2525babafd5c28f2b56acdd496e777d68f67e8a67c34bf069015556a",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitCIS152572AA0C": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitCIS1342939E39",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "78cabecb3617f556b1e16c8ff4d7a08a069a107e9ca3d2ef8ad55cffeaa7ffe3",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitCIS21A1B77688": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitCIS152572AA0C",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "7e36a728ad6cc73b656e09fd39b00d9cdb057455bfbcd2e3ff788e1747bab77b",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
     },
   },
 }

--- a/source/playbooks/NEWPLAYBOOK/test/__snapshots__/newplaybook_stack.test.ts.snap
+++ b/source/playbooks/NEWPLAYBOOK/test/__snapshots__/newplaybook_stack.test.ts.snap
@@ -374,10 +374,16 @@ exports[`member stack 1`] = `
       "Description": "Admin account number",
       "Type": "String",
     },
+    "WaitProviderServiceToken": {
+      "Type": "String",
+    },
   },
   "Resources": {
     "ControlNPBRDS6": {
       "Condition": "EnableRDS6Condition",
+      "DependsOn": [
+        "RunbookFactoryWaitNPBRDS6BBC073F6",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -733,6 +739,20 @@ def verify_remediation(event, context):
         "UpdateMethod": "NewVersion",
       },
       "Type": "AWS::SSM::Document",
+    },
+    "RunbookFactoryWaitNPBRDS6BBC073F6": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "4900a2c90d8700cdf3813530a248bcf245192d4bcbc40eabe549ebde81645649",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
     },
   },
 }

--- a/source/playbooks/PCI321/test/__snapshots__/pci321_stack.test.ts.snap
+++ b/source/playbooks/PCI321/test/__snapshots__/pci321_stack.test.ts.snap
@@ -761,7 +761,7 @@ def parse_event(event, context):
     "ControlPCIPCIEC26": {
       "Condition": "EnablePCIEC26Condition",
       "DependsOn": [
-        "RunbookFactoryWaitPCIPCIEC2614145FE2",
+        "RunbookFactoryWaitPCIPCIAutoScaling11EDF78C1",
       ],
       "Properties": {
         "Content": {
@@ -1104,7 +1104,7 @@ def parse_event(event, context):
     "ControlPCIPCIIAM8": {
       "Condition": "EnablePCIIAM8Condition",
       "DependsOn": [
-        "RunbookFactoryWaitPCIPCIIAM86AF66562",
+        "RunbookFactoryWaitPCIPCIAutoScaling11EDF78C1",
       ],
       "Properties": {
         "Content": {
@@ -1430,41 +1430,7 @@ def parse_event(event, context):
       "Properties": {
         "CreateIntervalSeconds": 1,
         "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "6db54a1a29c220236a827a2c0c79a6a6d9c8fa1710bffeedfde02cdbfab57f85",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitPCIPCIEC2614145FE2": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitPCIPCIAutoScaling11EDF78C1",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "acf20b72a9a15cff15cf1dccd97b4622aa7e4eaadb776388d6d30368927036f2",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitPCIPCIIAM86AF66562": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitPCIPCIEC2614145FE2",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "5b1af28b75f5bb3b3c86a15dbaa5721377f2192e41770a8b3e68224815e7a329",
+        "DocumentPropertiesHash": "3ac90e4bba3f9e11954482a6e4a89dfa7031bc2820a952481454d7f11cc52b03",
         "ServiceToken": {
           "Ref": "WaitProviderServiceToken",
         },

--- a/source/playbooks/PCI321/test/__snapshots__/pci321_stack.test.ts.snap
+++ b/source/playbooks/PCI321/test/__snapshots__/pci321_stack.test.ts.snap
@@ -408,10 +408,16 @@ exports[`default stack 2`] = `
       "Description": "Admin account number",
       "Type": "String",
     },
+    "WaitProviderServiceToken": {
+      "Type": "String",
+    },
   },
   "Resources": {
     "ControlPCIPCIAutoScaling1": {
       "Condition": "EnablePCIAutoScaling1Condition",
+      "DependsOn": [
+        "RunbookFactoryWaitPCIPCIAutoScaling11EDF78C1",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -754,6 +760,9 @@ def parse_event(event, context):
     },
     "ControlPCIPCIEC26": {
       "Condition": "EnablePCIEC26Condition",
+      "DependsOn": [
+        "RunbookFactoryWaitPCIPCIEC2614145FE2",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -1094,6 +1103,9 @@ def parse_event(event, context):
     },
     "ControlPCIPCIIAM8": {
       "Condition": "EnablePCIIAM8Condition",
+      "DependsOn": [
+        "RunbookFactoryWaitPCIPCIIAM86AF66562",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -1412,6 +1424,54 @@ def parse_event(event, context):
         "UpdateMethod": "NewVersion",
       },
       "Type": "AWS::SSM::Document",
+    },
+    "RunbookFactoryWaitPCIPCIAutoScaling11EDF78C1": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "6db54a1a29c220236a827a2c0c79a6a6d9c8fa1710bffeedfde02cdbfab57f85",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitPCIPCIEC2614145FE2": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitPCIPCIAutoScaling11EDF78C1",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "acf20b72a9a15cff15cf1dccd97b4622aa7e4eaadb776388d6d30368927036f2",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitPCIPCIIAM86AF66562": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitPCIPCIEC2614145FE2",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "5b1af28b75f5bb3b3c86a15dbaa5721377f2192e41770a8b3e68224815e7a329",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
     },
   },
 }

--- a/source/playbooks/SC/test/__snapshots__/security_controls_stack.test.ts.snap
+++ b/source/playbooks/SC/test/__snapshots__/security_controls_stack.test.ts.snap
@@ -1437,7 +1437,7 @@ def parse_event(event, context):
     "ControlRunbooksCloudFormation12CB945DB": {
       "Condition": "ControlRunbooksEnableCloudFormation1ConditionD8D32097",
       "DependsOn": [
-        "ControlRunbooksWaitCloudFormation146D9A34B",
+        "ControlRunbooksWaitAutoScaling10D4441AE",
       ],
       "Properties": {
         "Content": {
@@ -1784,7 +1784,7 @@ def parse_event(event, context):
     "ControlRunbooksCloudTrail1B15F1A13": {
       "Condition": "ControlRunbooksEnableCloudTrail1ConditionB7EBAA86",
       "DependsOn": [
-        "ControlRunbooksWaitCloudTrail1A25D32F1",
+        "ControlRunbooksWaitAutoScaling10D4441AE",
       ],
       "Properties": {
         "Content": {
@@ -2102,7 +2102,7 @@ def parse_event(event, context):
     "ControlRunbooksCloudTrail2979D0B5D": {
       "Condition": "ControlRunbooksEnableCloudTrail2ConditionC182A10F",
       "DependsOn": [
-        "ControlRunbooksWaitCloudTrail21F987E98",
+        "ControlRunbooksWaitAutoScaling10D4441AE",
       ],
       "Properties": {
         "Content": {
@@ -2432,7 +2432,7 @@ def parse_event(event, context):
     "ControlRunbooksCloudTrail4057F669F": {
       "Condition": "ControlRunbooksEnableCloudTrail4Condition587734A2",
       "DependsOn": [
-        "ControlRunbooksWaitCloudTrail458DE43DE",
+        "ControlRunbooksWaitAutoScaling10D4441AE",
       ],
       "Properties": {
         "Content": {
@@ -3128,7 +3128,7 @@ def parse_event(event, context):
     "ControlRunbooksCloudTrail6526C5643": {
       "Condition": "ControlRunbooksEnableCloudTrail6Condition486CC2C3",
       "DependsOn": [
-        "ControlRunbooksWaitCloudTrail67978D253",
+        "ControlRunbooksWaitCloudTrail5696BADE5",
       ],
       "Properties": {
         "Content": {
@@ -3458,7 +3458,7 @@ def parse_event(event, context):
     "ControlRunbooksCloudTrail7C6D85038": {
       "Condition": "ControlRunbooksEnableCloudTrail7ConditionA4FF88B2",
       "DependsOn": [
-        "ControlRunbooksWaitCloudTrail7EABB459B",
+        "ControlRunbooksWaitCloudTrail5696BADE5",
       ],
       "Properties": {
         "Content": {
@@ -3810,7 +3810,7 @@ def parse_event(event, context):
     "ControlRunbooksCloudWatch1A05F543A": {
       "Condition": "ControlRunbooksEnableCloudWatch1ConditionAB0DF2E5",
       "DependsOn": [
-        "ControlRunbooksWaitCloudWatch1153ADE37",
+        "ControlRunbooksWaitCloudTrail5696BADE5",
       ],
       "Properties": {
         "Content": {
@@ -4391,7 +4391,7 @@ def verify(event, context):
     "ControlRunbooksCodeBuild2A2751671": {
       "Condition": "ControlRunbooksEnableCodeBuild2ConditionB01F473D",
       "DependsOn": [
-        "ControlRunbooksWaitCodeBuild238275EA2",
+        "ControlRunbooksWaitCloudTrail5696BADE5",
       ],
       "Properties": {
         "Content": {
@@ -5406,7 +5406,7 @@ def parse_event(event, context):
     "ControlRunbooksEC214D3BB404": {
       "Condition": "ControlRunbooksEnableEC21ConditionD4F1277B",
       "DependsOn": [
-        "ControlRunbooksWaitEC2144340354",
+        "ControlRunbooksWaitConfig14A572694",
       ],
       "Properties": {
         "Content": {
@@ -5730,7 +5730,7 @@ def parse_event(event, context):
     "ControlRunbooksEC2153B43E7A8": {
       "Condition": "ControlRunbooksEnableEC215Condition52A7DE4B",
       "DependsOn": [
-        "ControlRunbooksWaitEC2157FB7B262",
+        "ControlRunbooksWaitEC21311511FED",
       ],
       "Properties": {
         "Content": {
@@ -6076,7 +6076,7 @@ def parse_event(event, context):
     "ControlRunbooksEC22ED852ADF": {
       "Condition": "ControlRunbooksEnableEC22ConditionB9E0D42E",
       "DependsOn": [
-        "ControlRunbooksWaitEC222CA02D05",
+        "ControlRunbooksWaitConfig14A572694",
       ],
       "Properties": {
         "Content": {
@@ -6424,7 +6424,7 @@ def parse_event(event, context):
     "ControlRunbooksEC267E3087AE": {
       "Condition": "ControlRunbooksEnableEC26ConditionF1F880B0",
       "DependsOn": [
-        "ControlRunbooksWaitEC269077B1CA",
+        "ControlRunbooksWaitConfig14A572694",
       ],
       "Properties": {
         "Content": {
@@ -6772,7 +6772,7 @@ def parse_event(event, context):
     "ControlRunbooksEC277719A4CD": {
       "Condition": "ControlRunbooksEnableEC27ConditionC77CF056",
       "DependsOn": [
-        "ControlRunbooksWaitEC274219617D",
+        "ControlRunbooksWaitConfig14A572694",
       ],
       "Properties": {
         "Content": {
@@ -7089,7 +7089,7 @@ def parse_event(event, context):
     "ControlRunbooksIAM3DC25477E": {
       "Condition": "ControlRunbooksEnableIAM3Condition3AA0E892",
       "DependsOn": [
-        "ControlRunbooksWaitIAM3131A4F99",
+        "ControlRunbooksWaitEC21311511FED",
       ],
       "Properties": {
         "Content": {
@@ -7427,7 +7427,7 @@ def parse_event(event, context):
     "ControlRunbooksIAM70A808F7C": {
       "Condition": "ControlRunbooksEnableIAM7ConditionDF8E776B",
       "DependsOn": [
-        "ControlRunbooksWaitIAM7211E71F4",
+        "ControlRunbooksWaitEC21311511FED",
       ],
       "Properties": {
         "Content": {
@@ -7765,7 +7765,7 @@ def parse_event(event, context):
     "ControlRunbooksIAM8632E03ED": {
       "Condition": "ControlRunbooksEnableIAM8Condition9CA5CB4B",
       "DependsOn": [
-        "ControlRunbooksWaitIAM8F6E89A05",
+        "ControlRunbooksWaitEC21311511FED",
       ],
       "Properties": {
         "Content": {
@@ -8441,7 +8441,7 @@ def parse_event(event, context):
     "ControlRunbooksLambda1F6ECACF8": {
       "Condition": "ControlRunbooksEnableLambda1Condition077CECAF",
       "DependsOn": [
-        "ControlRunbooksWaitLambda116719102",
+        "ControlRunbooksWaitKMS4C79B8335",
       ],
       "Properties": {
         "Content": {
@@ -8787,7 +8787,7 @@ def parse_event(event, context):
     "ControlRunbooksRDS13FCEA51BD": {
       "Condition": "ControlRunbooksEnableRDS13Condition0E8A44B3",
       "DependsOn": [
-        "ControlRunbooksWaitRDS13529AD058",
+        "ControlRunbooksWaitRDS5745B6BC7",
       ],
       "Properties": {
         "Content": {
@@ -9482,7 +9482,7 @@ def parse_event(event, context):
     "ControlRunbooksRDS1D73701E9": {
       "Condition": "ControlRunbooksEnableRDS1ConditionFAE5B7EA",
       "DependsOn": [
-        "ControlRunbooksWaitRDS1A1E35585",
+        "ControlRunbooksWaitKMS4C79B8335",
       ],
       "Properties": {
         "Content": {
@@ -9832,7 +9832,7 @@ def parse_event(event, context):
     "ControlRunbooksRDS2FBE04686": {
       "Condition": "ControlRunbooksEnableRDS2Condition4FD00FE6",
       "DependsOn": [
-        "ControlRunbooksWaitRDS29AE2B3A0",
+        "ControlRunbooksWaitKMS4C79B8335",
       ],
       "Properties": {
         "Content": {
@@ -10179,7 +10179,7 @@ def parse_event(event, context):
     "ControlRunbooksRDS4C82F2410": {
       "Condition": "ControlRunbooksEnableRDS4Condition2E89346E",
       "DependsOn": [
-        "ControlRunbooksWaitRDS4932DF75A",
+        "ControlRunbooksWaitKMS4C79B8335",
       ],
       "Properties": {
         "Content": {
@@ -10891,7 +10891,7 @@ def parse_event(event, context):
     "ControlRunbooksRDS6082B0D6B": {
       "Condition": "ControlRunbooksEnableRDS6Condition4A60A39B",
       "DependsOn": [
-        "ControlRunbooksWaitRDS6A575DF16",
+        "ControlRunbooksWaitRDS5745B6BC7",
       ],
       "Properties": {
         "Content": {
@@ -11256,7 +11256,7 @@ def parse_event(event, context):
     "ControlRunbooksRDS715C0A01A": {
       "Condition": "ControlRunbooksEnableRDS7ConditionE53509B0",
       "DependsOn": [
-        "ControlRunbooksWaitRDS7AC8C1011",
+        "ControlRunbooksWaitRDS5745B6BC7",
       ],
       "Properties": {
         "Content": {
@@ -11603,7 +11603,7 @@ def parse_event(event, context):
     "ControlRunbooksRDS89256480A": {
       "Condition": "ControlRunbooksEnableRDS8Condition8F460AB5",
       "DependsOn": [
-        "ControlRunbooksWaitRDS8885A190C",
+        "ControlRunbooksWaitRDS5745B6BC7",
       ],
       "Properties": {
         "Content": {
@@ -11949,7 +11949,7 @@ def parse_event(event, context):
     "ControlRunbooksRedshift1789871EB": {
       "Condition": "ControlRunbooksEnableRedshift1Condition3449D560",
       "DependsOn": [
-        "ControlRunbooksWaitRedshift15794DAD8",
+        "ControlRunbooksWaitRDS1677C2EBCA",
       ],
       "Properties": {
         "Content": {
@@ -12294,7 +12294,7 @@ def parse_event(event, context):
     "ControlRunbooksRedshift3106C10FF": {
       "Condition": "ControlRunbooksEnableRedshift3ConditionC65BAEF6",
       "DependsOn": [
-        "ControlRunbooksWaitRedshift340870EB6",
+        "ControlRunbooksWaitRDS1677C2EBCA",
       ],
       "Properties": {
         "Content": {
@@ -12674,7 +12674,7 @@ def event_handler(event, context):
     "ControlRunbooksRedshift475A78168": {
       "Condition": "ControlRunbooksEnableRedshift4Condition2377F6B5",
       "DependsOn": [
-        "ControlRunbooksWaitRedshift409BE659E",
+        "ControlRunbooksWaitRDS1677C2EBCA",
       ],
       "Properties": {
         "Content": {
@@ -13130,7 +13130,7 @@ def check_for_s3_bucket_name(event, context):
     "ControlRunbooksRedshift658631424": {
       "Condition": "ControlRunbooksEnableRedshift6Condition5A51FC97",
       "DependsOn": [
-        "ControlRunbooksWaitRedshift689426E75",
+        "ControlRunbooksWaitRDS1677C2EBCA",
       ],
       "Properties": {
         "Content": {
@@ -13835,7 +13835,7 @@ def parse_event(event, context):
     "ControlRunbooksS3260D6E897": {
       "Condition": "ControlRunbooksEnableS32ConditionD6F8CCE9",
       "DependsOn": [
-        "ControlRunbooksWaitS32C0E9E154",
+        "ControlRunbooksWaitS317DCF0083",
       ],
       "Properties": {
         "Content": {
@@ -14170,7 +14170,7 @@ def parse_event(event, context):
     "ControlRunbooksS34F82DA9F1": {
       "Condition": "ControlRunbooksEnableS34ConditionC23F6623",
       "DependsOn": [
-        "ControlRunbooksWaitS342E2C8B6C",
+        "ControlRunbooksWaitS317DCF0083",
       ],
       "Properties": {
         "Content": {
@@ -14504,7 +14504,7 @@ def parse_event(event, context):
     "ControlRunbooksS356959B795": {
       "Condition": "ControlRunbooksEnableS35ConditionD5E024B6",
       "DependsOn": [
-        "ControlRunbooksWaitS3595C584DE",
+        "ControlRunbooksWaitS317DCF0083",
       ],
       "Properties": {
         "Content": {
@@ -14831,7 +14831,7 @@ def parse_event(event, context):
     "ControlRunbooksS360762680A": {
       "Condition": "ControlRunbooksEnableS36ConditionD22273E2",
       "DependsOn": [
-        "ControlRunbooksWaitS36025111EA",
+        "ControlRunbooksWaitS317DCF0083",
       ],
       "Properties": {
         "Content": {
@@ -15196,7 +15196,7 @@ def runbook_handler(event, context):
     "ControlRunbooksSNS145784CBB": {
       "Condition": "ControlRunbooksEnableSNS1Condition7720D1CC",
       "DependsOn": [
-        "ControlRunbooksWaitSNS1F99C4DC8",
+        "ControlRunbooksWaitSQS1248958A6",
       ],
       "Properties": {
         "Content": {
@@ -15548,7 +15548,7 @@ def parse_event(event, context):
     "ControlRunbooksSNS2112179CC": {
       "Condition": "ControlRunbooksEnableSNS2Condition69621468",
       "DependsOn": [
-        "ControlRunbooksWaitSNS20DE22D54",
+        "ControlRunbooksWaitSQS1248958A6",
       ],
       "Properties": {
         "Content": {
@@ -16256,75 +16256,7 @@ def parse_event(event, context):
       "Properties": {
         "CreateIntervalSeconds": 1,
         "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "0a5cdc890539ee524d0c297b4a6343b65035470b77d297dd91acaf128db31f8b",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitCloudFormation146D9A34B": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitAutoScaling10D4441AE",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "5e2201d3748d25ec3d12c64e01533754930a86457b76138afc9d2413d57ee3f0",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitCloudTrail1A25D32F1": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitCloudFormation146D9A34B",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "8cf01c9cf5f3b65dc9b8c1a0e27e6f3fbb57e5246143ac56d7b0ee15f6738adb",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitCloudTrail21F987E98": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitCloudTrail1A25D32F1",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "846fa1246669ec63bc480920e0105777cbbe65e727116e4fec265d3016ed3101",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitCloudTrail458DE43DE": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitCloudTrail21F987E98",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "f9dcc13f00cd6bcd6690e9d0c291625e69c795711279b84df114ecee24499283",
+        "DocumentPropertiesHash": "11dc0ae816812ef227e9a7bd3a337d46b3b7c94d23b76ecdc435757c227797ff",
         "ServiceToken": {
           "Ref": "WaitProviderServiceToken",
         },
@@ -16336,80 +16268,12 @@ def parse_event(event, context):
     "ControlRunbooksWaitCloudTrail5696BADE5": {
       "DeletionPolicy": "Delete",
       "DependsOn": [
-        "ControlRunbooksWaitCloudTrail458DE43DE",
+        "ControlRunbooksWaitAutoScaling10D4441AE",
       ],
       "Properties": {
         "CreateIntervalSeconds": 1,
         "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "7c3b300b58d684a783f58c1b95634b6bf67fbfaa85767ab8b15c522f38e279da",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitCloudTrail67978D253": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitCloudTrail5696BADE5",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "d532794f5dc3302c1e096ec06d9a27e9a374348beed0b95e0c96fd4374299aa6",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitCloudTrail7EABB459B": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitCloudTrail67978D253",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "4a08db46d0f3aad52bda449f8bf3175e0bce6b9dd228223917a8ef4bb0498a8d",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitCloudWatch1153ADE37": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitCloudTrail7EABB459B",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "5c55b314ec285516f98ac951fef3bc4f21c6824554dc65327cb887cf0692d5bf",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitCodeBuild238275EA2": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitCloudWatch1153ADE37",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "41935a200230c1f2c2c2d1e742da29e5516949693f265edffcbf06adcf5dd03d",
+        "DocumentPropertiesHash": "53f801b967c642ca21ddb9491ddf4a80c610bd2342d34f42ac499e3ce5cc710b",
         "ServiceToken": {
           "Ref": "WaitProviderServiceToken",
         },
@@ -16421,12 +16285,12 @@ def parse_event(event, context):
     "ControlRunbooksWaitConfig14A572694": {
       "DeletionPolicy": "Delete",
       "DependsOn": [
-        "ControlRunbooksWaitCodeBuild238275EA2",
+        "ControlRunbooksWaitCloudTrail5696BADE5",
       ],
       "Properties": {
         "CreateIntervalSeconds": 1,
         "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "e1792fad7677fda98765e9b6696687df5d2953b154616ebc7daee827525ec714",
+        "DocumentPropertiesHash": "da23d6295b0210b134873b98ca2dd6ffd898bf5ed1f0ccc8bdeab41eedc8d8dd",
         "ServiceToken": {
           "Ref": "WaitProviderServiceToken",
         },
@@ -16438,148 +16302,12 @@ def parse_event(event, context):
     "ControlRunbooksWaitEC21311511FED": {
       "DeletionPolicy": "Delete",
       "DependsOn": [
-        "ControlRunbooksWaitEC274219617D",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "1e1fc671c3fbf7a860aee16b3f9bb29eb0b9e09b8c9d60cf76f18e3a5f1c6135",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitEC2144340354": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
         "ControlRunbooksWaitConfig14A572694",
       ],
       "Properties": {
         "CreateIntervalSeconds": 1,
         "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "5b734769a0449f194b275a57be67c588e453fbcf7dd48be5e02ba2f2567c0ddb",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitEC2157FB7B262": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitEC21311511FED",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "0ba5839b22a5728781720d3099ad094e8be8cda0de32ef14eb2a9b3675351798",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitEC222CA02D05": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitEC2144340354",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "413e16de20b9d5fd69b5ac61cd9162d12aeccaef51a64dea7640230e25e33b57",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitEC269077B1CA": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitEC222CA02D05",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "57206c372a4f6503ac294f22fd2b58d507fd133be43293484d0c0d5cfbf14b00",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitEC274219617D": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitEC269077B1CA",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "60fb93edd16ff7bffd79d7e572e4fc3167d49da79a84fd23cc715a3e4d218179",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitIAM3131A4F99": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitEC2157FB7B262",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "2cd79f19e73ebc8ea30e6490accdbe801d0fcdc47e2e43456406aebe29dbb757",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitIAM7211E71F4": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitIAM3131A4F99",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "a3c7d5926edb08bc363c8ba1b11a1e34037a8c23cc45fc775fd5b6ebba9ba959",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitIAM8F6E89A05": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitIAM7211E71F4",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "e9e11dc9bfc3a2b9688d2726cf066fc31cabc8c9c3f09ab2aead0c8afe8b7106",
+        "DocumentPropertiesHash": "ac944d9f5dc7f804a638b1f1918c19340da97d041d10594f767afd4031ae66ca",
         "ServiceToken": {
           "Ref": "WaitProviderServiceToken",
         },
@@ -16591,46 +16319,12 @@ def parse_event(event, context):
     "ControlRunbooksWaitKMS4C79B8335": {
       "DeletionPolicy": "Delete",
       "DependsOn": [
-        "ControlRunbooksWaitIAM8F6E89A05",
+        "ControlRunbooksWaitEC21311511FED",
       ],
       "Properties": {
         "CreateIntervalSeconds": 1,
         "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "558da743e6c51dba13e6491d7585dd854cb932e1a8d8d5ddbd51632f275f6710",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitLambda116719102": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitKMS4C79B8335",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "203af1f86e091cc6d6904dc172da92fbea3932bf692364d459b90087b54c5e74",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitRDS13529AD058": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitRDS8885A190C",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "f0110e41018452d82dea8340f257536ed956c6bb8c2833e8412a416f6bdd5e9b",
+        "DocumentPropertiesHash": "8f7c5f56862771c4548165a67ac47517f21777f5cf7ee23e9b7b0f5aa3a364a2",
         "ServiceToken": {
           "Ref": "WaitProviderServiceToken",
         },
@@ -16642,63 +16336,12 @@ def parse_event(event, context):
     "ControlRunbooksWaitRDS1677C2EBCA": {
       "DeletionPolicy": "Delete",
       "DependsOn": [
-        "ControlRunbooksWaitRDS13529AD058",
+        "ControlRunbooksWaitRDS5745B6BC7",
       ],
       "Properties": {
         "CreateIntervalSeconds": 1,
         "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "43a70213d6d0dae25136cd5e9bd39d6c965d8123793c9f8d875d52e6b34d1de4",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitRDS1A1E35585": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitLambda116719102",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "6346acdcd4b37ff6679bd8f4919bf4d799db8b9b64a327414b6f7ded6998e5cf",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitRDS29AE2B3A0": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitRDS1A1E35585",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "d625c1283fe12c0c7846fb58571a34ae45fd4234c0ae5e5c5c2490074563d7ee",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitRDS4932DF75A": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitRDS29AE2B3A0",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "f77799968e9f7d0163bcf40d726a151a37842770cf632c8192a34a5ed6b6e313",
+        "DocumentPropertiesHash": "b34df59968b49f9824c6b6560d6901e1666d1e75fb0ab85bc7b74e97838e11db",
         "ServiceToken": {
           "Ref": "WaitProviderServiceToken",
         },
@@ -16710,131 +16353,12 @@ def parse_event(event, context):
     "ControlRunbooksWaitRDS5745B6BC7": {
       "DeletionPolicy": "Delete",
       "DependsOn": [
-        "ControlRunbooksWaitRDS4932DF75A",
+        "ControlRunbooksWaitKMS4C79B8335",
       ],
       "Properties": {
         "CreateIntervalSeconds": 1,
         "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "1fe1863eef2752714b37f32fb68b592503f232905ef122566ebcd65ff32328c0",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitRDS6A575DF16": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitRDS5745B6BC7",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "e9e4a801949575cdc72a56dac4a6a03ca11ebbc6483f101cb8e09f7bd4167b80",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitRDS7AC8C1011": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitRDS6A575DF16",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "220a35b7ed8513d177fcf40b805470a52030d346d11ecb8a81ff21712c6eb938",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitRDS8885A190C": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitRDS7AC8C1011",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "a085ff1b619ba662c9250ed0b1943e1e04a375d1565d0af44aa0c636ec012909",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitRedshift15794DAD8": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitRDS1677C2EBCA",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "5edb4b13b12c4147ebbed09cc6759e4efc3fe6359297a675e1ebedf3ab58af0c",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitRedshift340870EB6": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitRedshift15794DAD8",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "2a9c6197df64a95c1b7c862e624392a4562332bbf375566de1636d83e2d3a60e",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitRedshift409BE659E": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitRedshift340870EB6",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "d0fd25a3394aef8f9c149f30e54d97ac2bac56063b755e91400ea76f9d6cd44a",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitRedshift689426E75": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitRedshift409BE659E",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "12029c7aff63e5ede4dc97259fcbc46136a732036c7ca078a948db2f0e565d3c",
+        "DocumentPropertiesHash": "e77fa52a0ca342dbfb86409abea49d2243ca46740d79b615ea9dc0618da3ad6e",
         "ServiceToken": {
           "Ref": "WaitProviderServiceToken",
         },
@@ -16846,114 +16370,12 @@ def parse_event(event, context):
     "ControlRunbooksWaitS317DCF0083": {
       "DeletionPolicy": "Delete",
       "DependsOn": [
-        "ControlRunbooksWaitRedshift689426E75",
+        "ControlRunbooksWaitRDS1677C2EBCA",
       ],
       "Properties": {
         "CreateIntervalSeconds": 1,
         "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "e123b5d4c56f5219121e7fae5258a36dbba0b04467c4fdd19f1b4097d9aaa5a8",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitS32C0E9E154": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitS317DCF0083",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "a4d581c01c9fd56d40b248c26fb1611e6414d2c82022a7bd7eb7ded92f4bf1fa",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitS342E2C8B6C": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitS32C0E9E154",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "1fe4fe2014f43bd011b7ca6ca374f35ef9084ce7bfd6bf86d9030ee9131cd3b4",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitS3595C584DE": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitS342E2C8B6C",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "2c55e32ec50a624c93529691ab04dd50781329ac87ab920c9d22213585c89609",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitS36025111EA": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitS3595C584DE",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "76ea55ea7fb6fe4916127c36a5c7fcc09d7f929d6ba60e1b9429b788be14dcc8",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitSNS1F99C4DC8": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitSQS1248958A6",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "6bddd4f41609e7375b1d09bd3edcee6a0ec6a4193e1248868d2eee9d3922f445",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ControlRunbooksWaitSNS20DE22D54": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "ControlRunbooksWaitSNS1F99C4DC8",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "14815b47d30e1729ab55e6cdf31519ab194f5f98a40ac9f877a7a0d808b81c7e",
+        "DocumentPropertiesHash": "5e53fc7abb1c81c81ab08e6a78360e7fdbca399b31fa2f4647bb43cf568ecfa9",
         "ServiceToken": {
           "Ref": "WaitProviderServiceToken",
         },
@@ -16965,12 +16387,12 @@ def parse_event(event, context):
     "ControlRunbooksWaitSQS1248958A6": {
       "DeletionPolicy": "Delete",
       "DependsOn": [
-        "ControlRunbooksWaitS36025111EA",
+        "ControlRunbooksWaitS317DCF0083",
       ],
       "Properties": {
         "CreateIntervalSeconds": 1,
         "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "aeb66dc2fe36dca5f1ac7fcdc95fb300e9d897127ef76012a710dbbf056bcf58",
+        "DocumentPropertiesHash": "1ddaa66543b6d561222bf40a61c1131852c184293363c6e11181a2f4ae6afb21",
         "ServiceToken": {
           "Ref": "WaitProviderServiceToken",
         },

--- a/source/playbooks/SC/test/__snapshots__/security_controls_stack.test.ts.snap
+++ b/source/playbooks/SC/test/__snapshots__/security_controls_stack.test.ts.snap
@@ -1080,10 +1080,16 @@ exports[`member stack 1`] = `
       "Description": "Admin account number",
       "Type": "String",
     },
+    "WaitProviderServiceToken": {
+      "Type": "String",
+    },
   },
   "Resources": {
     "ControlRunbooksAutoScaling1BA109277": {
       "Condition": "ControlRunbooksEnableAutoScaling1ConditionD5DF4981",
+      "DependsOn": [
+        "ControlRunbooksWaitAutoScaling10D4441AE",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -1430,6 +1436,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksCloudFormation12CB945DB": {
       "Condition": "ControlRunbooksEnableCloudFormation1ConditionD8D32097",
+      "DependsOn": [
+        "ControlRunbooksWaitCloudFormation146D9A34B",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -1774,6 +1783,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksCloudTrail1B15F1A13": {
       "Condition": "ControlRunbooksEnableCloudTrail1ConditionB7EBAA86",
+      "DependsOn": [
+        "ControlRunbooksWaitCloudTrail1A25D32F1",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -2089,6 +2101,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksCloudTrail2979D0B5D": {
       "Condition": "ControlRunbooksEnableCloudTrail2ConditionC182A10F",
+      "DependsOn": [
+        "ControlRunbooksWaitCloudTrail21F987E98",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -2416,6 +2431,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksCloudTrail4057F669F": {
       "Condition": "ControlRunbooksEnableCloudTrail4Condition587734A2",
+      "DependsOn": [
+        "ControlRunbooksWaitCloudTrail458DE43DE",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -2760,6 +2778,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksCloudTrail54F5ED8E4": {
       "Condition": "ControlRunbooksEnableCloudTrail5Condition17B6B536",
+      "DependsOn": [
+        "ControlRunbooksWaitCloudTrail5696BADE5",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -3106,6 +3127,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksCloudTrail6526C5643": {
       "Condition": "ControlRunbooksEnableCloudTrail6Condition486CC2C3",
+      "DependsOn": [
+        "ControlRunbooksWaitCloudTrail67978D253",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -3433,6 +3457,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksCloudTrail7C6D85038": {
       "Condition": "ControlRunbooksEnableCloudTrail7ConditionA4FF88B2",
+      "DependsOn": [
+        "ControlRunbooksWaitCloudTrail7EABB459B",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -3782,6 +3809,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksCloudWatch1A05F543A": {
       "Condition": "ControlRunbooksEnableCloudWatch1ConditionAB0DF2E5",
+      "DependsOn": [
+        "ControlRunbooksWaitCloudWatch1153ADE37",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -4360,6 +4390,9 @@ def verify(event, context):
     },
     "ControlRunbooksCodeBuild2A2751671": {
       "Condition": "ControlRunbooksEnableCodeBuild2ConditionB01F473D",
+      "DependsOn": [
+        "ControlRunbooksWaitCodeBuild238275EA2",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -4704,6 +4737,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksConfig1512B566F": {
       "Condition": "ControlRunbooksEnableConfig1Condition8CEB8627",
+      "DependsOn": [
+        "ControlRunbooksWaitConfig14A572694",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -5030,6 +5066,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksEC213D7C9C1EB": {
       "Condition": "ControlRunbooksEnableEC213Condition567EA275",
+      "DependsOn": [
+        "ControlRunbooksWaitEC21311511FED",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -5366,6 +5405,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksEC214D3BB404": {
       "Condition": "ControlRunbooksEnableEC21ConditionD4F1277B",
+      "DependsOn": [
+        "ControlRunbooksWaitEC2144340354",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -5687,6 +5729,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksEC2153B43E7A8": {
       "Condition": "ControlRunbooksEnableEC215Condition52A7DE4B",
+      "DependsOn": [
+        "ControlRunbooksWaitEC2157FB7B262",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -6030,6 +6075,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksEC22ED852ADF": {
       "Condition": "ControlRunbooksEnableEC22ConditionB9E0D42E",
+      "DependsOn": [
+        "ControlRunbooksWaitEC222CA02D05",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -6375,6 +6423,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksEC267E3087AE": {
       "Condition": "ControlRunbooksEnableEC26ConditionF1F880B0",
+      "DependsOn": [
+        "ControlRunbooksWaitEC269077B1CA",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -6720,6 +6771,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksEC277719A4CD": {
       "Condition": "ControlRunbooksEnableEC27ConditionC77CF056",
+      "DependsOn": [
+        "ControlRunbooksWaitEC274219617D",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -7034,6 +7088,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksIAM3DC25477E": {
       "Condition": "ControlRunbooksEnableIAM3Condition3AA0E892",
+      "DependsOn": [
+        "ControlRunbooksWaitIAM3131A4F99",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -7369,6 +7426,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksIAM70A808F7C": {
       "Condition": "ControlRunbooksEnableIAM7ConditionDF8E776B",
+      "DependsOn": [
+        "ControlRunbooksWaitIAM7211E71F4",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -7704,6 +7764,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksIAM8632E03ED": {
       "Condition": "ControlRunbooksEnableIAM8Condition9CA5CB4B",
+      "DependsOn": [
+        "ControlRunbooksWaitIAM8F6E89A05",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -8029,6 +8092,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksKMS41A22BB8D": {
       "Condition": "ControlRunbooksEnableKMS4Condition710C0C5C",
+      "DependsOn": [
+        "ControlRunbooksWaitKMS4C79B8335",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -8374,6 +8440,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksLambda1F6ECACF8": {
       "Condition": "ControlRunbooksEnableLambda1Condition077CECAF",
+      "DependsOn": [
+        "ControlRunbooksWaitLambda116719102",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -8717,6 +8786,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksRDS13FCEA51BD": {
       "Condition": "ControlRunbooksEnableRDS13Condition0E8A44B3",
+      "DependsOn": [
+        "ControlRunbooksWaitRDS13529AD058",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -9061,6 +9133,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksRDS16EB04DCBF": {
       "Condition": "ControlRunbooksEnableRDS16ConditionCB5C3E8F",
+      "DependsOn": [
+        "ControlRunbooksWaitRDS1677C2EBCA",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -9406,6 +9481,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksRDS1D73701E9": {
       "Condition": "ControlRunbooksEnableRDS1ConditionFAE5B7EA",
+      "DependsOn": [
+        "ControlRunbooksWaitRDS1A1E35585",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -9753,6 +9831,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksRDS2FBE04686": {
       "Condition": "ControlRunbooksEnableRDS2Condition4FD00FE6",
+      "DependsOn": [
+        "ControlRunbooksWaitRDS29AE2B3A0",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -10097,6 +10178,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksRDS4C82F2410": {
       "Condition": "ControlRunbooksEnableRDS4Condition2E89346E",
+      "DependsOn": [
+        "ControlRunbooksWaitRDS4932DF75A",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -10460,6 +10544,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksRDS5CECD9314": {
       "Condition": "ControlRunbooksEnableRDS5ConditionEC2574C3",
+      "DependsOn": [
+        "ControlRunbooksWaitRDS5745B6BC7",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -10803,6 +10890,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksRDS6082B0D6B": {
       "Condition": "ControlRunbooksEnableRDS6Condition4A60A39B",
+      "DependsOn": [
+        "ControlRunbooksWaitRDS6A575DF16",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -11165,6 +11255,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksRDS715C0A01A": {
       "Condition": "ControlRunbooksEnableRDS7ConditionE53509B0",
+      "DependsOn": [
+        "ControlRunbooksWaitRDS7AC8C1011",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -11509,6 +11602,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksRDS89256480A": {
       "Condition": "ControlRunbooksEnableRDS8Condition8F460AB5",
+      "DependsOn": [
+        "ControlRunbooksWaitRDS8885A190C",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -11852,6 +11948,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksRedshift1789871EB": {
       "Condition": "ControlRunbooksEnableRedshift1Condition3449D560",
+      "DependsOn": [
+        "ControlRunbooksWaitRedshift15794DAD8",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -12194,6 +12293,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksRedshift3106C10FF": {
       "Condition": "ControlRunbooksEnableRedshift3ConditionC65BAEF6",
+      "DependsOn": [
+        "ControlRunbooksWaitRedshift340870EB6",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -12571,6 +12673,9 @@ def event_handler(event, context):
     },
     "ControlRunbooksRedshift475A78168": {
       "Condition": "ControlRunbooksEnableRedshift4Condition2377F6B5",
+      "DependsOn": [
+        "ControlRunbooksWaitRedshift409BE659E",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -13024,6 +13129,9 @@ def check_for_s3_bucket_name(event, context):
     },
     "ControlRunbooksRedshift658631424": {
       "Condition": "ControlRunbooksEnableRedshift6Condition5A51FC97",
+      "DependsOn": [
+        "ControlRunbooksWaitRedshift689426E75",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -13401,6 +13509,9 @@ def event_handler(event, context):
     },
     "ControlRunbooksS311C5AAD45": {
       "Condition": "ControlRunbooksEnableS31Condition25C33B3F",
+      "DependsOn": [
+        "ControlRunbooksWaitS317DCF0083",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -13723,6 +13834,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksS3260D6E897": {
       "Condition": "ControlRunbooksEnableS32ConditionD6F8CCE9",
+      "DependsOn": [
+        "ControlRunbooksWaitS32C0E9E154",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -14055,6 +14169,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksS34F82DA9F1": {
       "Condition": "ControlRunbooksEnableS34ConditionC23F6623",
+      "DependsOn": [
+        "ControlRunbooksWaitS342E2C8B6C",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -14386,6 +14503,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksS356959B795": {
       "Condition": "ControlRunbooksEnableS35ConditionD5E024B6",
+      "DependsOn": [
+        "ControlRunbooksWaitS3595C584DE",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -14710,6 +14830,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksS360762680A": {
       "Condition": "ControlRunbooksEnableS36ConditionD22273E2",
+      "DependsOn": [
+        "ControlRunbooksWaitS36025111EA",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -15072,6 +15195,9 @@ def runbook_handler(event, context):
     },
     "ControlRunbooksSNS145784CBB": {
       "Condition": "ControlRunbooksEnableSNS1Condition7720D1CC",
+      "DependsOn": [
+        "ControlRunbooksWaitSNS1F99C4DC8",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -15421,6 +15547,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksSNS2112179CC": {
       "Condition": "ControlRunbooksEnableSNS2Condition69621468",
+      "DependsOn": [
+        "ControlRunbooksWaitSNS20DE22D54",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -15770,6 +15899,9 @@ def parse_event(event, context):
     },
     "ControlRunbooksSQS173AA7C81": {
       "Condition": "ControlRunbooksEnableSQS1Condition3065B4F2",
+      "DependsOn": [
+        "ControlRunbooksWaitSQS1248958A6",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -16118,6 +16250,734 @@ def parse_event(event, context):
         "UpdateMethod": "NewVersion",
       },
       "Type": "AWS::SSM::Document",
+    },
+    "ControlRunbooksWaitAutoScaling10D4441AE": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "0a5cdc890539ee524d0c297b4a6343b65035470b77d297dd91acaf128db31f8b",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitCloudFormation146D9A34B": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitAutoScaling10D4441AE",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "5e2201d3748d25ec3d12c64e01533754930a86457b76138afc9d2413d57ee3f0",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitCloudTrail1A25D32F1": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitCloudFormation146D9A34B",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "8cf01c9cf5f3b65dc9b8c1a0e27e6f3fbb57e5246143ac56d7b0ee15f6738adb",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitCloudTrail21F987E98": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitCloudTrail1A25D32F1",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "846fa1246669ec63bc480920e0105777cbbe65e727116e4fec265d3016ed3101",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitCloudTrail458DE43DE": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitCloudTrail21F987E98",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "f9dcc13f00cd6bcd6690e9d0c291625e69c795711279b84df114ecee24499283",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitCloudTrail5696BADE5": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitCloudTrail458DE43DE",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "7c3b300b58d684a783f58c1b95634b6bf67fbfaa85767ab8b15c522f38e279da",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitCloudTrail67978D253": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitCloudTrail5696BADE5",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "d532794f5dc3302c1e096ec06d9a27e9a374348beed0b95e0c96fd4374299aa6",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitCloudTrail7EABB459B": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitCloudTrail67978D253",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "4a08db46d0f3aad52bda449f8bf3175e0bce6b9dd228223917a8ef4bb0498a8d",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitCloudWatch1153ADE37": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitCloudTrail7EABB459B",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "5c55b314ec285516f98ac951fef3bc4f21c6824554dc65327cb887cf0692d5bf",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitCodeBuild238275EA2": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitCloudWatch1153ADE37",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "41935a200230c1f2c2c2d1e742da29e5516949693f265edffcbf06adcf5dd03d",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitConfig14A572694": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitCodeBuild238275EA2",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "e1792fad7677fda98765e9b6696687df5d2953b154616ebc7daee827525ec714",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitEC21311511FED": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitEC274219617D",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "1e1fc671c3fbf7a860aee16b3f9bb29eb0b9e09b8c9d60cf76f18e3a5f1c6135",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitEC2144340354": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitConfig14A572694",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "5b734769a0449f194b275a57be67c588e453fbcf7dd48be5e02ba2f2567c0ddb",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitEC2157FB7B262": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitEC21311511FED",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "0ba5839b22a5728781720d3099ad094e8be8cda0de32ef14eb2a9b3675351798",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitEC222CA02D05": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitEC2144340354",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "413e16de20b9d5fd69b5ac61cd9162d12aeccaef51a64dea7640230e25e33b57",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitEC269077B1CA": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitEC222CA02D05",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "57206c372a4f6503ac294f22fd2b58d507fd133be43293484d0c0d5cfbf14b00",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitEC274219617D": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitEC269077B1CA",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "60fb93edd16ff7bffd79d7e572e4fc3167d49da79a84fd23cc715a3e4d218179",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitIAM3131A4F99": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitEC2157FB7B262",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "2cd79f19e73ebc8ea30e6490accdbe801d0fcdc47e2e43456406aebe29dbb757",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitIAM7211E71F4": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitIAM3131A4F99",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "a3c7d5926edb08bc363c8ba1b11a1e34037a8c23cc45fc775fd5b6ebba9ba959",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitIAM8F6E89A05": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitIAM7211E71F4",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "e9e11dc9bfc3a2b9688d2726cf066fc31cabc8c9c3f09ab2aead0c8afe8b7106",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitKMS4C79B8335": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitIAM8F6E89A05",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "558da743e6c51dba13e6491d7585dd854cb932e1a8d8d5ddbd51632f275f6710",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitLambda116719102": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitKMS4C79B8335",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "203af1f86e091cc6d6904dc172da92fbea3932bf692364d459b90087b54c5e74",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitRDS13529AD058": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitRDS8885A190C",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "f0110e41018452d82dea8340f257536ed956c6bb8c2833e8412a416f6bdd5e9b",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitRDS1677C2EBCA": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitRDS13529AD058",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "43a70213d6d0dae25136cd5e9bd39d6c965d8123793c9f8d875d52e6b34d1de4",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitRDS1A1E35585": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitLambda116719102",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "6346acdcd4b37ff6679bd8f4919bf4d799db8b9b64a327414b6f7ded6998e5cf",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitRDS29AE2B3A0": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitRDS1A1E35585",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "d625c1283fe12c0c7846fb58571a34ae45fd4234c0ae5e5c5c2490074563d7ee",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitRDS4932DF75A": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitRDS29AE2B3A0",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "f77799968e9f7d0163bcf40d726a151a37842770cf632c8192a34a5ed6b6e313",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitRDS5745B6BC7": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitRDS4932DF75A",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "1fe1863eef2752714b37f32fb68b592503f232905ef122566ebcd65ff32328c0",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitRDS6A575DF16": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitRDS5745B6BC7",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "e9e4a801949575cdc72a56dac4a6a03ca11ebbc6483f101cb8e09f7bd4167b80",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitRDS7AC8C1011": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitRDS6A575DF16",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "220a35b7ed8513d177fcf40b805470a52030d346d11ecb8a81ff21712c6eb938",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitRDS8885A190C": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitRDS7AC8C1011",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "a085ff1b619ba662c9250ed0b1943e1e04a375d1565d0af44aa0c636ec012909",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitRedshift15794DAD8": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitRDS1677C2EBCA",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "5edb4b13b12c4147ebbed09cc6759e4efc3fe6359297a675e1ebedf3ab58af0c",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitRedshift340870EB6": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitRedshift15794DAD8",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "2a9c6197df64a95c1b7c862e624392a4562332bbf375566de1636d83e2d3a60e",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitRedshift409BE659E": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitRedshift340870EB6",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "d0fd25a3394aef8f9c149f30e54d97ac2bac56063b755e91400ea76f9d6cd44a",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitRedshift689426E75": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitRedshift409BE659E",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "12029c7aff63e5ede4dc97259fcbc46136a732036c7ca078a948db2f0e565d3c",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitS317DCF0083": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitRedshift689426E75",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "e123b5d4c56f5219121e7fae5258a36dbba0b04467c4fdd19f1b4097d9aaa5a8",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitS32C0E9E154": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitS317DCF0083",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "a4d581c01c9fd56d40b248c26fb1611e6414d2c82022a7bd7eb7ded92f4bf1fa",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitS342E2C8B6C": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitS32C0E9E154",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "1fe4fe2014f43bd011b7ca6ca374f35ef9084ce7bfd6bf86d9030ee9131cd3b4",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitS3595C584DE": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitS342E2C8B6C",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "2c55e32ec50a624c93529691ab04dd50781329ac87ab920c9d22213585c89609",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitS36025111EA": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitS3595C584DE",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "76ea55ea7fb6fe4916127c36a5c7fcc09d7f929d6ba60e1b9429b788be14dcc8",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitSNS1F99C4DC8": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitSQS1248958A6",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "6bddd4f41609e7375b1d09bd3edcee6a0ec6a4193e1248868d2eee9d3922f445",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitSNS20DE22D54": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitSNS1F99C4DC8",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "14815b47d30e1729ab55e6cdf31519ab194f5f98a40ac9f877a7a0d808b81c7e",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ControlRunbooksWaitSQS1248958A6": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ControlRunbooksWaitS36025111EA",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "aeb66dc2fe36dca5f1ac7fcdc95fb300e9d897127ef76012a710dbbf056bcf58",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
     },
   },
 }

--- a/source/solution_deploy/lib/__snapshots__/member-stack.test.ts.snap
+++ b/source/solution_deploy/lib/__snapshots__/member-stack.test.ts.snap
@@ -278,6 +278,12 @@ exports[`member stack snapshot matches 1`] = `
           "SecHubAdminAccount": {
             "Ref": "SecHubAdminAccount",
           },
+          "WaitProviderServiceToken": {
+            "Fn::GetAtt": [
+              "WaitProviderFunctionC30591AB",
+              "Arn",
+            ],
+          },
         },
         "TemplateURL": {
           "Fn::Join": [
@@ -316,6 +322,12 @@ exports[`member stack snapshot matches 1`] = `
         "Parameters": {
           "SecHubAdminAccount": {
             "Ref": "SecHubAdminAccount",
+          },
+          "WaitProviderServiceToken": {
+            "Fn::GetAtt": [
+              "WaitProviderFunctionC30591AB",
+              "Arn",
+            ],
           },
         },
         "TemplateURL": {
@@ -356,6 +368,12 @@ exports[`member stack snapshot matches 1`] = `
           "SecHubAdminAccount": {
             "Ref": "SecHubAdminAccount",
           },
+          "WaitProviderServiceToken": {
+            "Fn::GetAtt": [
+              "WaitProviderFunctionC30591AB",
+              "Arn",
+            ],
+          },
         },
         "TemplateURL": {
           "Fn::Join": [
@@ -394,6 +412,12 @@ exports[`member stack snapshot matches 1`] = `
         "Parameters": {
           "SecHubAdminAccount": {
             "Ref": "SecHubAdminAccount",
+          },
+          "WaitProviderServiceToken": {
+            "Fn::GetAtt": [
+              "WaitProviderFunctionC30591AB",
+              "Arn",
+            ],
           },
         },
         "TemplateURL": {
@@ -434,6 +458,12 @@ exports[`member stack snapshot matches 1`] = `
           "SecHubAdminAccount": {
             "Ref": "SecHubAdminAccount",
           },
+          "WaitProviderServiceToken": {
+            "Fn::GetAtt": [
+              "WaitProviderFunctionC30591AB",
+              "Arn",
+            ],
+          },
         },
         "TemplateURL": {
           "Fn::Join": [
@@ -464,6 +494,14 @@ exports[`member stack snapshot matches 1`] = `
     },
     "RunbookStackNoRoles": {
       "Properties": {
+        "Parameters": {
+          "WaitProviderServiceToken": {
+            "Fn::GetAtt": [
+              "WaitProviderFunctionC30591AB",
+              "Arn",
+            ],
+          },
+        },
         "TemplateURL": {
           "Fn::Join": [
             "",
@@ -778,6 +816,93 @@ exports[`member stack snapshot matches 1`] = `
         },
       },
       "Type": "AWS::SSM::Parameter",
+    },
+    "WaitProviderFunctionC30591AB": {
+      "DependsOn": [
+        "WaitProviderRole11F5230A",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Fn::Join": [
+              "",
+              [
+                "sharrbukkit-",
+                {
+                  "Ref": "AWS::Region",
+                },
+              ],
+            ],
+          },
+          "S3Key": "my-solution-tmn/v9.9.9/lambda/wait_provider.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "LOG_LEVEL": "WARNING",
+          },
+        },
+        "Handler": "wait_provider.lambda_handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "WaitProviderRole11F5230A",
+            "Arn",
+          ],
+        },
+        "Runtime": "python3.9",
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "WaitProviderRole11F5230A": {
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Resource * is needed for CloudWatch Logs policies used on Lambda functions.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "cloudwatch:PutMetricData",
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+                {
+                  "Action": [
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "LambdaPolicy",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
     },
   },
 }

--- a/source/solution_deploy/lib/member/wait-provider.ts
+++ b/source/solution_deploy/lib/member/wait-provider.ts
@@ -1,0 +1,96 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { createHash } from 'crypto';
+import { CustomResource, Duration, Stack } from 'aws-cdk-lib';
+import { Code, Function, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { Bucket } from 'aws-cdk-lib/aws-s3';
+import { CfnDocument } from 'aws-cdk-lib/aws-ssm';
+import { Construct } from 'constructs';
+import { PolicyDocument, PolicyStatement, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { NagSuppressions } from 'cdk-nag';
+
+export interface SsmDocumentWaitProviderProps {
+  readonly solutionDistBucket?: string;
+  readonly solutionVersion?: string;
+  readonly solutionTMN?: string;
+  readonly runtimePython?: Runtime;
+  readonly serviceToken?: string;
+}
+
+export interface SsmDocumentWaitResourceProps {
+  readonly document: CfnDocument;
+}
+
+export class SsmDocumentWaitProvider extends Construct {
+  public readonly serviceToken: string;
+
+  constructor(scope: Construct, id: string, props: SsmDocumentWaitProviderProps) {
+    super(scope, id);
+
+    if (!props.serviceToken) {
+      if (!props.solutionDistBucket || !props.solutionVersion || !props.solutionTMN || !props.runtimePython) {
+        throw new Error('If not specifying service token, you must specify all required properties');
+      }
+
+      const policyDocument = new PolicyDocument({
+        statements: [
+          new PolicyStatement({ actions: ['cloudwatch:PutMetricData'], resources: ['*'] }),
+          new PolicyStatement({
+            actions: ['logs:CreateLogGroup', 'logs:CreateLogStream', 'logs:PutLogEvents'],
+            resources: ['*'],
+          }),
+        ],
+      });
+
+      const role = new Role(this, 'Role', {
+        assumedBy: new ServicePrincipal('lambda.amazonaws.com'),
+        inlinePolicies: { LambdaPolicy: policyDocument },
+      });
+
+      NagSuppressions.addResourceSuppressions(role, [
+        {
+          id: 'AwsSolutions-IAM5',
+          reason: 'Resource * is needed for CloudWatch Logs policies used on Lambda functions.',
+        },
+      ]);
+
+      const lambdaFunction = new Function(this, 'Function', {
+        role,
+        runtime: props.runtimePython,
+        code: Code.fromBucket(
+          Bucket.fromBucketName(this, 'Bucket', `${props.solutionDistBucket}-${Stack.of(this).region}`),
+          props.solutionTMN + '/' + props.solutionVersion + '/lambda/wait_provider.zip'
+        ),
+        handler: 'wait_provider.lambda_handler',
+        environment: { LOG_LEVEL: 'WARNING' },
+        timeout: Duration.minutes(15),
+      });
+
+      this.serviceToken = lambdaFunction.functionArn;
+    } else {
+      this.serviceToken = props.serviceToken;
+    }
+  }
+
+  createWaitResource(scope: Construct, id: string, props: SsmDocumentWaitResourceProps): CustomResource {
+    const relevantProperties: string[] = [
+      props.document.name,
+      props.document.documentFormat,
+      props.document.documentType,
+      props.document.content,
+      props.document.updateMethod,
+    ];
+    // no need for cryptographic security, we just need a property that indicates when the underlying document changes
+    const propertiesHash = createHash('sha256').update(JSON.stringify(relevantProperties)).digest('hex');
+    return new CustomResource(scope, id, {
+      serviceToken: this.serviceToken,
+      properties: {
+        CreateIntervalSeconds: 1,
+        UpdateIntervalSeconds: 1,
+        DeleteIntervalSeconds: 0.5,
+        DocumentPropertiesHash: propertiesHash,
+      },
+      resourceType: 'Custom::Wait',
+    });
+  }
+}

--- a/source/solution_deploy/lib/member/wait-provider.ts
+++ b/source/solution_deploy/lib/member/wait-provider.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { createHash } from 'crypto';
-import { CustomResource, Duration, Stack } from 'aws-cdk-lib';
+import { createHash, Hash } from 'crypto';
+import { CfnCustomResource, CustomResource, Duration, Stack } from 'aws-cdk-lib';
 import { Code, Function, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
 import { CfnDocument } from 'aws-cdk-lib/aws-ssm';
@@ -72,7 +72,53 @@ export class SsmDocumentWaitProvider extends Construct {
     }
   }
 
+  private currentWaitResource: CustomResource | undefined;
+  private hash: Hash | undefined;
+  private readonly maxBatchedDocuments = 5;
+  private batchedDocuments = 0;
+
   createWaitResource(scope: Construct, id: string, props: SsmDocumentWaitResourceProps): CustomResource {
+    if (!this.currentWaitResource || !this.hash) {
+      // no need for cryptographic security, we just need a property that indicates when the underlying document changes
+      this.hash = createHash('sha256');
+      this.currentWaitResource = new CustomResource(scope, id, {
+        serviceToken: this.serviceToken,
+        properties: {
+          CreateIntervalSeconds: 1,
+          UpdateIntervalSeconds: 1,
+          DeleteIntervalSeconds: 0.5,
+        },
+        resourceType: 'Custom::Wait',
+      });
+    }
+
+    const relevantProperties: string[] = [
+      props.document.name,
+      props.document.documentFormat,
+      props.document.documentType,
+      props.document.content,
+      props.document.updateMethod,
+    ];
+    this.hash.update(JSON.stringify(relevantProperties));
+
+    const waitResource = this.currentWaitResource;
+
+    (waitResource.node.defaultChild as CfnCustomResource).addPropertyOverride(
+      'DocumentPropertiesHash',
+      this.hash.copy().digest('hex') // multiple calls to digest not allowed, copy to create rolling hash
+    );
+
+    ++this.batchedDocuments;
+
+    if (this.batchedDocuments >= this.maxBatchedDocuments) {
+      this.batchedDocuments = 0;
+      this.currentWaitResource = undefined;
+    }
+
+    return waitResource;
+  }
+
+  createWaitResourceOld(scope: Construct, id: string, props: SsmDocumentWaitResourceProps): CustomResource {
     const relevantProperties: string[] = [
       props.document.name,
       props.document.documentFormat,

--- a/source/solution_deploy/lib/remediation_runbook-stack.ts
+++ b/source/solution_deploy/lib/remediation_runbook-stack.ts
@@ -23,6 +23,7 @@ import { RemediationRunbookFactory } from './runbook_factory';
 import { SNS2DeliveryStatusLoggingRole } from '../../remediation_runbooks/sns2-remediation-resources';
 import { SsmRole } from '../../lib/ssmplaybook';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
+import { CfnParameter } from 'aws-cdk-lib';
 
 export interface MemberRoleStackProps extends cdk.StackProps {
   readonly solutionId: string;
@@ -76,7 +77,11 @@ export class RemediationRunbookStack extends cdk.Stack {
     const RESOURCE_PREFIX = props.solutionId.replace(/^DEV-/, ''); // prefix on every resource name
     const remediationRoleNameBase = `${RESOURCE_PREFIX}-`;
 
-    const runbookFactory = new RemediationRunbookFactory(this, 'RunbookFactory');
+    const waitProviderServiceTokenParam = new CfnParameter(this, 'WaitProviderServiceToken');
+
+    const runbookFactory = new RemediationRunbookFactory(this, 'RunbookFactory', {
+      waitProviderServiceToken: waitProviderServiceTokenParam.valueAsString,
+    });
 
     //-----------------------
     // CreateCloudTrailMultiRegionTrail

--- a/source/solution_deploy/lib/remediation_runbook-stack.ts
+++ b/source/solution_deploy/lib/remediation_runbook-stack.ts
@@ -19,7 +19,7 @@ import {
 import { OrchestratorMemberRole } from '../../lib/orchestrator_roles-construct';
 import AdminAccountParam from '../../lib/admin-account-param';
 import { Rds6EnhancedMonitoringRole } from '../../remediation_runbooks/rds6-remediation-resources';
-import { RunbookFactory } from './runbook_factory';
+import { RemediationRunbookFactory } from './runbook_factory';
 import { SNS2DeliveryStatusLoggingRole } from '../../remediation_runbooks/sns2-remediation-resources';
 import { SsmRole } from '../../lib/ssmplaybook';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
@@ -76,7 +76,7 @@ export class RemediationRunbookStack extends cdk.Stack {
     const RESOURCE_PREFIX = props.solutionId.replace(/^DEV-/, ''); // prefix on every resource name
     const remediationRoleNameBase = `${RESOURCE_PREFIX}-`;
 
-    const runbookFactory = new RunbookFactory(this, 'RunbookFactory');
+    const runbookFactory = new RemediationRunbookFactory(this, 'RunbookFactory');
 
     //-----------------------
     // CreateCloudTrailMultiRegionTrail

--- a/source/solution_deploy/lib/remediation_runbook-stack.ts
+++ b/source/solution_deploy/lib/remediation_runbook-stack.ts
@@ -76,6 +76,8 @@ export class RemediationRunbookStack extends cdk.Stack {
     const RESOURCE_PREFIX = props.solutionId.replace(/^DEV-/, ''); // prefix on every resource name
     const remediationRoleNameBase = `${RESOURCE_PREFIX}-`;
 
+    const runbookFactory = new RunbookFactory(this, 'RunbookFactory');
+
     //-----------------------
     // CreateCloudTrailMultiRegionTrail
     //
@@ -108,7 +110,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -166,7 +168,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -195,7 +197,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -285,7 +287,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -380,7 +382,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -427,7 +429,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -476,7 +478,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -595,7 +597,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -638,7 +640,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -680,7 +682,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -725,7 +727,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -771,7 +773,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -827,7 +829,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -884,7 +886,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         },
       };
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -935,7 +937,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -977,7 +979,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -1027,7 +1029,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -1070,7 +1072,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -1116,7 +1118,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -1159,7 +1161,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -1202,7 +1204,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -1253,7 +1255,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -1302,7 +1304,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -1351,7 +1353,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -1480,7 +1482,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -1522,7 +1524,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -1563,7 +1565,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -1593,7 +1595,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -1648,7 +1650,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -1696,7 +1698,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -1753,7 +1755,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -1811,7 +1813,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -1856,7 +1858,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -1898,7 +1900,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -1952,7 +1954,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -2010,7 +2012,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -2058,7 +2060,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -2100,7 +2102,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -2147,7 +2149,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -2189,7 +2191,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -2247,7 +2249,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,
@@ -2289,7 +2291,7 @@ export class RemediationRunbookStack extends cdk.Stack {
         remediationRoleName: `${remediationRoleNameBase}${remediationName}`,
       });
 
-      RunbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
+      runbookFactory.createRemediationRunbook(this, 'ASR ' + remediationName, {
         ssmDocName: remediationName,
         ssmDocPath: ssmdocs,
         ssmDocFileName: `${remediationName}.yaml`,

--- a/source/solution_deploy/lib/runbook_factory.ts
+++ b/source/solution_deploy/lib/runbook_factory.ts
@@ -39,7 +39,7 @@ export class RunbookFactory extends Construct {
     super(scope, id);
   }
 
-  static createControlRunbook(scope: Construct, id: string, props: IssmPlaybookProps): CfnDocument {
+  createControlRunbook(scope: Construct, id: string, props: IssmPlaybookProps): CfnDocument {
     let scriptPath = '';
     if (props.scriptPath == undefined) {
       scriptPath = `${props.ssmDocPath}/scripts`;
@@ -106,7 +106,7 @@ export class RunbookFactory extends Construct {
     return ssmDoc;
   }
 
-  static createRemediationRunbook(scope: Construct, id: string, props: RemediationRunbookProps) {
+  createRemediationRunbook(scope: Construct, id: string, props: RemediationRunbookProps) {
     const ssmDocName = `ASR-${props.ssmDocName}`;
     let scriptPath = '';
     if (props.scriptPath == undefined) {

--- a/source/solution_deploy/lib/runbook_factory.ts
+++ b/source/solution_deploy/lib/runbook_factory.ts
@@ -34,7 +34,7 @@ export interface RemediationRunbookProps {
   scriptPath?: string;
 }
 
-export class RunbookFactory extends Construct {
+export class ControlRunbookFactory extends Construct {
   createControlRunbook(scope: Construct, id: string, props: IssmPlaybookProps): CfnDocument {
     let scriptPath = '';
     if (props.scriptPath == undefined) {
@@ -101,7 +101,9 @@ export class RunbookFactory extends Construct {
 
     return ssmDoc;
   }
+}
 
+export class RemediationRunbookFactory extends Construct {
   createRemediationRunbook(scope: Construct, id: string, props: RemediationRunbookProps) {
     const ssmDocName = `ASR-${props.ssmDocName}`;
     let scriptPath = '';

--- a/source/solution_deploy/lib/runbook_factory.ts
+++ b/source/solution_deploy/lib/runbook_factory.ts
@@ -35,10 +35,6 @@ export interface RemediationRunbookProps {
 }
 
 export class RunbookFactory extends Construct {
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
-  }
-
   createControlRunbook(scope: Construct, id: string, props: IssmPlaybookProps): CfnDocument {
     let scriptPath = '';
     if (props.scriptPath == undefined) {

--- a/source/solution_deploy/source/test/test_wait_provider.py
+++ b/source/solution_deploy/source/test/test_wait_provider.py
@@ -1,0 +1,51 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Test the custom resource provider for arbitrary wait"""
+
+from unittest.mock import ANY, patch
+from wait_provider import lambda_handler
+from cfnresponse import SUCCESS
+
+
+def get_event(create, update, delete, request_type):
+    return {
+        "ResourceProperties": {
+            "CreateIntervalSeconds": str(create),
+            "UpdateIntervalSeconds": str(update),
+            "DeleteIntervalSeconds": str(delete),
+        },
+        "RequestType": request_type,
+    }
+
+
+@patch("cfnresponse.send")
+@patch("wait_provider.wait_seconds")
+def test_wait_create(mock_wait, mock_cfnresponse):
+    """Create request waits for the correct amount of time"""
+    create = 1.0
+    event = get_event(create, 2.0, 3.0, "Create")
+    lambda_handler(event, {})
+    mock_wait.assert_called_once_with(create)
+    mock_cfnresponse.assert_called_once_with(event, {}, SUCCESS, ANY)
+
+
+@patch("cfnresponse.send")
+@patch("wait_provider.wait_seconds")
+def test_wait_update(mock_wait, mock_cfnresponse):
+    """Update request waits for the correct amount of time"""
+    update = 2.0
+    event = get_event(1.0, update, 3.0, "Update")
+    lambda_handler(event, {})
+    mock_wait.assert_called_once_with(update)
+    mock_cfnresponse.assert_called_once_with(event, {}, SUCCESS, ANY)
+
+
+@patch("cfnresponse.send")
+@patch("wait_provider.wait_seconds")
+def test_wait_delete(mock_wait, mock_cfnresponse):
+    """Delete request waits for the correct amount of time"""
+    delete = 3.0
+    event = get_event(1.0, 2.0, delete, "Delete")
+    lambda_handler(event, {})
+    mock_wait.assert_called_once_with(delete)
+    mock_cfnresponse.assert_called_once_with(event, {}, SUCCESS, ANY)

--- a/source/solution_deploy/source/wait_provider.py
+++ b/source/solution_deploy/source/wait_provider.py
@@ -1,0 +1,59 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Custom resource provider that waits for a specified time, then returns success"""
+
+from os import getenv
+import json
+from logging import basicConfig, getLevelName, getLogger
+from time import sleep
+import cfnresponse
+
+basicConfig(level=getLevelName(getenv("LOG_LEVEL", "WARNING")))
+logger = getLogger(__name__)
+
+
+class InvalidRequest(Exception):
+    """Invalid wait request"""
+
+
+def wait_seconds(wait: float):
+    """Wait for `wait` seconds"""
+    sleep(wait)
+
+
+def lambda_handler(event, context):
+    """Handle the Lambda request for a wait"""
+    response_data = {}
+
+    try:
+        properties = event.get("ResourceProperties", {})
+        logger.info(json.dumps(properties))
+
+        wait_create = float(properties["CreateIntervalSeconds"])
+        wait_update = float(properties["UpdateIntervalSeconds"])
+        wait_delete = float(properties["DeleteIntervalSeconds"])
+
+        request_type = event["RequestType"]
+        if request_type == "Create":
+            logger.info("Create, waiting %f seconds", wait_create)
+            wait_seconds(wait_create)
+        elif request_type == "Update":
+            logger.info("Update, waiting %f seconds", wait_update)
+            wait_seconds(wait_update)
+        elif request_type == "Delete":
+            logger.info("Delete, waiting %f seconds", wait_delete)
+            wait_seconds(wait_delete)
+        else:
+            raise InvalidRequest(f"Invalid request type {request_type}")
+        logger.info("Success")
+
+        cfnresponse.send(event, context, cfnresponse.SUCCESS, response_data)
+    except Exception as exc:
+        logger.exception(exc)
+        cfnresponse.send(
+            event,
+            context,
+            cfnresponse.FAILED,
+            response_data,
+            reason=str(exc),
+        )

--- a/source/test/__snapshots__/runbook_stack.test.ts.snap
+++ b/source/test/__snapshots__/runbook_stack.test.ts.snap
@@ -235,7 +235,7 @@ exports[`Regional Documents 1`] = `
   "Resources": {
     "ASRConfigureS3BucketPublicAccessBlock": {
       "DependsOn": [
-        "RunbookFactoryWaitASRConfigureS3BucketPublicAccessBlock08BBA9CD",
+        "RunbookFactoryWaitASREnableAutomaticSnapshotsOnRedshiftCluster6D809FEA",
       ],
       "Properties": {
         "Content": {
@@ -579,7 +579,7 @@ def handler(event, context):
     },
     "ASRConfigureSNSTopicForStack": {
       "DependsOn": [
-        "RunbookFactoryWaitASRConfigureSNSTopicForStackC9EAB91D",
+        "RunbookFactoryWaitASREnableAutomaticSnapshotsOnRedshiftCluster6D809FEA",
       ],
       "Properties": {
         "Content": {
@@ -749,7 +749,7 @@ class StackConfigurationFailedException(Exception):
     },
     "ASRCreateAccessLoggingBucket": {
       "DependsOn": [
-        "RunbookFactoryWaitASRCreateAccessLoggingBucketC3EB77DA",
+        "RunbookFactoryWaitASREnableCloudTrailEncryption27956D34",
       ],
       "Properties": {
         "Content": {
@@ -1356,7 +1356,7 @@ def process_results(event, context):
     },
     "ASRCreateIAMSupportRole": {
       "DependsOn": [
-        "RunbookFactoryWaitASRCreateIAMSupportRole9F5D1244",
+        "RunbookFactoryWaitASREnableAutomaticSnapshotsOnRedshiftCluster6D809FEA",
       ],
       "Properties": {
         "Content": {
@@ -1505,7 +1505,7 @@ def does_role_exist(iam, role_name):
     },
     "ASRCreateLogMetricFilterAndAlarm": {
       "DependsOn": [
-        "RunbookFactoryWaitASRCreateLogMetricFilterAndAlarmD0985F81",
+        "RunbookFactoryWaitASRCreateCloudTrailMultiRegionTrail59648D64",
       ],
       "Properties": {
         "Content": {
@@ -1855,7 +1855,7 @@ def verify(event, context):
     },
     "ASRDisablePublicAccessToRDSInstance": {
       "DependsOn": [
-        "RunbookFactoryWaitASRDisablePublicAccessToRDSInstance44100ADC",
+        "RunbookFactoryWaitASRRevokeUnusedIAMUserCredentials8F820D02",
       ],
       "Properties": {
         "Content": {
@@ -2031,7 +2031,7 @@ Confirms public accessibility is disabled on the DB instance.
     },
     "ASRDisablePublicAccessToRedshiftCluster": {
       "DependsOn": [
-        "RunbookFactoryWaitASRDisablePublicAccessToRedshiftCluster825A0721",
+        "RunbookFactoryWaitASRS3BlockDenylistC5124331",
       ],
       "Properties": {
         "Content": {
@@ -2137,7 +2137,7 @@ Confirms the public accessibility setting is disabled on the cluster.
     },
     "ASRDisablePublicIPAutoAssign": {
       "DependsOn": [
-        "RunbookFactoryWaitASRDisablePublicIPAutoAssign4F120289",
+        "RunbookFactoryWaitASREnableDeliveryStatusLoggingForSNSTopic6B2897FC",
       ],
       "Properties": {
         "Content": {
@@ -2270,7 +2270,7 @@ def describe_subnet(subnet_id):
     },
     "ASREnableAWSConfig": {
       "DependsOn": [
-        "RunbookFactoryWaitASREnableAWSConfig3525A3F3",
+        "RunbookFactoryWaitASRCreateCloudTrailMultiRegionTrail59648D64",
       ],
       "Properties": {
         "Content": {
@@ -2783,7 +2783,7 @@ def process_results(event, context):
     },
     "ASREnableAutoScalingGroupELBHealthCheck": {
       "DependsOn": [
-        "RunbookFactoryWaitASREnableAutoScalingGroupELBHealthCheck83273238",
+        "RunbookFactoryWaitASRCreateCloudTrailMultiRegionTrail59648D64",
       ],
       "Properties": {
         "Content": {
@@ -3106,7 +3106,7 @@ The runbook enables automatic snapshots on a Redshift cluster.
     },
     "ASREnableAutomaticVersionUpgradeOnRedshiftCluster": {
       "DependsOn": [
-        "RunbookFactoryWaitASREnableAutomaticVersionUpgradeOnRedshiftCluster21E48D7F",
+        "RunbookFactoryWaitASRS3BlockDenylistC5124331",
       ],
       "Properties": {
         "Content": {
@@ -3345,7 +3345,7 @@ def enable_trail_encryption(event, context):
     },
     "ASREnableCloudTrailLogFileValidation": {
       "DependsOn": [
-        "RunbookFactoryWaitASREnableCloudTrailLogFileValidationBC3F7A62",
+        "RunbookFactoryWaitASRConfigureS3PublicAccessBlock3D512CE9",
       ],
       "Properties": {
         "Content": {
@@ -3434,7 +3434,7 @@ Verifies log file validation is enabled for your trail.
     },
     "ASREnableCloudTrailToCloudWatchLogging": {
       "DependsOn": [
-        "RunbookFactoryWaitASREnableCloudTrailToCloudWatchLoggingBE7665D9",
+        "RunbookFactoryWaitASRCreateCloudTrailMultiRegionTrail59648D64",
       ],
       "Properties": {
         "Content": {
@@ -3582,7 +3582,7 @@ def wait_for_loggroup(event, _):
     },
     "ASREnableCopyTagsToSnapshotOnRDSCluster": {
       "DependsOn": [
-        "RunbookFactoryWaitASREnableCopyTagsToSnapshotOnRDSCluster912111BA",
+        "RunbookFactoryWaitASREnableRDSClusterDeletionProtection33056C9E",
       ],
       "Properties": {
         "Content": {
@@ -3721,7 +3721,7 @@ Verifies that \`CopyTagsToSnapshot\` has been enabled on the target resource.
     },
     "ASREnableDefaultEncryptionS3": {
       "DependsOn": [
-        "RunbookFactoryWaitASREnableDefaultEncryptionS3708084A1",
+        "RunbookFactoryWaitASREnableCloudTrailEncryption27956D34",
       ],
       "Properties": {
         "Content": {
@@ -4008,7 +4008,7 @@ def reset_to_recognized_state(topic_arn):
     },
     "ASREnableEbsEncryptionByDefault": {
       "DependsOn": [
-        "RunbookFactoryWaitASREnableEbsEncryptionByDefaultEE5086CF",
+        "RunbookFactoryWaitASRConfigureS3PublicAccessBlock3D512CE9",
       ],
       "Properties": {
         "Content": {
@@ -4086,7 +4086,7 @@ Checks if EbsEncryptionByDefault is enabled correctly from the previous step.
     },
     "ASREnableEncryptionForSNSTopic": {
       "DependsOn": [
-        "RunbookFactoryWaitASREnableEncryptionForSNSTopicA80819D8",
+        "RunbookFactoryWaitASRRevokeUnusedIAMUserCredentials8F820D02",
       ],
       "Properties": {
         "Content": {
@@ -4185,7 +4185,7 @@ Verifies the given Amazon SNS Topic is encrypted with AWS KMS Key ARN.
     },
     "ASREnableEncryptionForSQSQueue": {
       "DependsOn": [
-        "RunbookFactoryWaitASREnableEncryptionForSQSQueueB09B4FC9",
+        "RunbookFactoryWaitASREnableAutomaticSnapshotsOnRedshiftCluster6D809FEA",
       ],
       "Properties": {
         "Content": {
@@ -4294,7 +4294,7 @@ Based on your data policy, Amazon SQS queues should be encrypted with different 
     },
     "ASREnableEnhancedMonitoringOnRDSInstance": {
       "DependsOn": [
-        "RunbookFactoryWaitASREnableEnhancedMonitoringOnRDSInstanceDD1C1BF3",
+        "RunbookFactoryWaitASRConfigureS3PublicAccessBlock3D512CE9",
       ],
       "Properties": {
         "Content": {
@@ -4492,7 +4492,7 @@ def handler(event, context):
     },
     "ASREnableKeyRotation": {
       "DependsOn": [
-        "RunbookFactoryWaitASREnableKeyRotation8051B8D2",
+        "RunbookFactoryWaitASRConfigureS3PublicAccessBlock3D512CE9",
       ],
       "Properties": {
         "Content": {
@@ -4578,7 +4578,7 @@ Verifies that the KeyRotationEnabled is set to true for the given AWS KMS CMK.
     },
     "ASREnableMinorVersionUpgradeOnRDSDBInstance": {
       "DependsOn": [
-        "RunbookFactoryWaitASREnableMinorVersionUpgradeOnRDSDBInstanceAB104E4F",
+        "RunbookFactoryWaitASRRevokeUnusedIAMUserCredentials8F820D02",
       ],
       "Properties": {
         "Content": {
@@ -4760,7 +4760,7 @@ def verify_instance_changes(instanceID):
     },
     "ASREnableMultiAZOnRDSInstance": {
       "DependsOn": [
-        "RunbookFactoryWaitASREnableMultiAZOnRDSInstance0E221168",
+        "RunbookFactoryWaitASREnableRDSClusterDeletionProtection33056C9E",
       ],
       "Properties": {
         "Content": {
@@ -5060,7 +5060,7 @@ Verifies that deletion protection has been enabled for the given Amazon RDS data
     },
     "ASREnableRDSInstanceDeletionProtection": {
       "DependsOn": [
-        "RunbookFactoryWaitASREnableRDSInstanceDeletionProtectionC279E7E4",
+        "RunbookFactoryWaitASREnableRDSClusterDeletionProtection33056C9E",
       ],
       "Properties": {
         "Content": {
@@ -5186,7 +5186,7 @@ Checks whether deletion protection is enabled on Amazon RDS Instance.
     },
     "ASREnableRedshiftClusterAuditLogging": {
       "DependsOn": [
-        "RunbookFactoryWaitASREnableRedshiftClusterAuditLogging774EA430",
+        "RunbookFactoryWaitASRS3BlockDenylistC5124331",
       ],
       "Properties": {
         "Content": {
@@ -5359,7 +5359,7 @@ Checks whether the value of the "BucketName" parameter is used for the audit log
     },
     "ASREnableVPCFlowLogs": {
       "DependsOn": [
-        "RunbookFactoryWaitASREnableVPCFlowLogs3E9F26B7",
+        "RunbookFactoryWaitASREnableCloudTrailEncryption27956D34",
       ],
       "Properties": {
         "Content": {
@@ -5588,7 +5588,7 @@ def enable_flow_logs(event, context):
     },
     "ASREncryptRDSSnapshot": {
       "DependsOn": [
-        "RunbookFactoryWaitASREncryptRDSSnapshot49845014",
+        "RunbookFactoryWaitASRS3BlockDenylistC5124331",
       ],
       "Properties": {
         "Content": {
@@ -5796,7 +5796,7 @@ If KmsKeyId is a Customer-Managed Key (CMK), then AutomationAssumeRole must have
     },
     "ASRMakeEBSSnapshotsPrivate": {
       "DependsOn": [
-        "RunbookFactoryWaitASRMakeEBSSnapshotsPrivateB36DA424",
+        "RunbookFactoryWaitASREnableCloudTrailEncryption27956D34",
       ],
       "Properties": {
         "Content": {
@@ -6132,7 +6132,7 @@ def make_snapshot_private(event, context):
     },
     "ASRRemoveLambdaPublicAccess": {
       "DependsOn": [
-        "RunbookFactoryWaitASRRemoveLambdaPublicAccessC79BEAD8",
+        "RunbookFactoryWaitASRMakeRDSSnapshotPrivate68A32264",
       ],
       "Properties": {
         "Content": {
@@ -6298,7 +6298,7 @@ def verify(function_name_to_check):
     },
     "ASRRemoveVPCDefaultSecurityGroupRules": {
       "DependsOn": [
-        "RunbookFactoryWaitASRRemoveVPCDefaultSecurityGroupRulesC388ED7D",
+        "RunbookFactoryWaitASREnableRDSClusterDeletionProtection33056C9E",
       ],
       "Properties": {
         "Content": {
@@ -6423,7 +6423,7 @@ def handler(event, context):
     },
     "ASRReplaceCodeBuildClearTextCredentials": {
       "DependsOn": [
-        "RunbookFactoryWaitASRReplaceCodeBuildClearTextCredentials20FDDBB7",
+        "RunbookFactoryWaitASRMakeRDSSnapshotPrivate68A32264",
       ],
       "Properties": {
         "Content": {
@@ -6724,7 +6724,7 @@ Changes the settings of a build project.
     },
     "ASRRevokeUnrotatedKeys": {
       "DependsOn": [
-        "RunbookFactoryWaitASRRevokeUnrotatedKeys729E7B55",
+        "RunbookFactoryWaitASRMakeRDSSnapshotPrivate68A32264",
       ],
       "Properties": {
         "Content": {
@@ -7277,7 +7277,7 @@ def update_bucket_policy(event, context):
     },
     "ASRSetIAMPasswordPolicy": {
       "DependsOn": [
-        "RunbookFactoryWaitASRSetIAMPasswordPolicy44AAC428",
+        "RunbookFactoryWaitASRRevokeUnusedIAMUserCredentials8F820D02",
       ],
       "Properties": {
         "Content": {
@@ -7450,7 +7450,7 @@ def update_and_verify_iam_user_password_policy(event, context):
     },
     "ASRSetSSLBucketPolicy": {
       "DependsOn": [
-        "RunbookFactoryWaitASRSetSSLBucketPolicyCD1142F2",
+        "RunbookFactoryWaitASRMakeRDSSnapshotPrivate68A32264",
       ],
       "Properties": {
         "Content": {
@@ -7605,66 +7605,15 @@ def add_ssl_bucket_policy(event, context):
       },
       "Type": "AWS::SSM::Document",
     },
-    "RunbookFactoryWaitASRConfigureS3BucketPublicAccessBlock08BBA9CD": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASRConfigureSNSTopicForStackC9EAB91D",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "d46d826df4763585df74f4757224460b4c64d192501cecfbd2d4eef6684f26c2",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
     "RunbookFactoryWaitASRConfigureS3PublicAccessBlock3D512CE9": {
       "DeletionPolicy": "Delete",
       "DependsOn": [
-        "RunbookFactoryWaitASRConfigureS3BucketPublicAccessBlock08BBA9CD",
+        "RunbookFactoryWaitASREnableAutomaticSnapshotsOnRedshiftCluster6D809FEA",
       ],
       "Properties": {
         "CreateIntervalSeconds": 1,
         "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "44666e1e9a133fef5249a420cf6b1827d9ab2cf7b8a9be556a8c1a5e317965ed",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASRConfigureSNSTopicForStackC9EAB91D": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASREnableEncryptionForSQSQueueB09B4FC9",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "5b9ee7b3553d436edee47a28ec1ccd32903adea745414788c0d2ef2572acab9e",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASRCreateAccessLoggingBucketC3EB77DA": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASREnableVPCFlowLogs3E9F26B7",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "d3e78b1577d20b4b4f44c39a1682cb123a26562fce5abb96e6b9298647dbc068",
+        "DocumentPropertiesHash": "6beab64cd1e1e29ec0dfac301f88b9a6eb2cf699bf743fbecf0fb88eca6f4f5c",
         "ServiceToken": {
           "Ref": "WaitProviderServiceToken",
         },
@@ -7678,126 +7627,7 @@ def add_ssl_bucket_policy(event, context):
       "Properties": {
         "CreateIntervalSeconds": 1,
         "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "0baa7af8a6bd1bbca980bdac18034185a2f37173eac857848d74c2ba84e78c31",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASRCreateIAMSupportRole9F5D1244": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASREnableAutomaticSnapshotsOnRedshiftCluster6D809FEA",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "27388acdf839747c3aeeec6c1a245abb3e52ac8eb23598250975857f21c49bcb",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASRCreateLogMetricFilterAndAlarmD0985F81": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASRCreateCloudTrailMultiRegionTrail59648D64",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "69e43c5adafad414c7a37d8320cc8b67d6ec70bed84c16afdfdb08785697af99",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASRDisablePublicAccessToRDSInstance44100ADC": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASRSetIAMPasswordPolicy44AAC428",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "a361bc190c84d8446b90e97d4467597efd5588eadfdbadad47b91bdb765dc339",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASRDisablePublicAccessToRedshiftCluster825A0721": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASREncryptRDSSnapshot49845014",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "22d54ac22a0a9ff09b419ffaaa8f6adff5092ed6f3913b154173b4eb58f027ef",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASRDisablePublicIPAutoAssign4F120289": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASREnableDeliveryStatusLoggingForSNSTopic6B2897FC",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "ceff3ebcbeb12c839b36e2b0ed60c184742ffdeeeda7f82933965fd23a2228f4",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASREnableAWSConfig3525A3F3": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASREnableAutoScalingGroupELBHealthCheck83273238",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "2ff4a98d0fdd571a26bf6341c77cf602de124e8fa97f6843466a5f4efd58685a",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASREnableAutoScalingGroupELBHealthCheck83273238": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASRCreateLogMetricFilterAndAlarmD0985F81",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "26d30f51cccd0807f1ff5fc0ef28a87accada59a9e952ac0235bec97b3e99e0f",
+        "DocumentPropertiesHash": "ebe1f593f68bac17d211fa3bc5587a7db937c450d8f77ad73285baab8faaad98",
         "ServiceToken": {
           "Ref": "WaitProviderServiceToken",
         },
@@ -7809,29 +7639,12 @@ def add_ssl_bucket_policy(event, context):
     "RunbookFactoryWaitASREnableAutomaticSnapshotsOnRedshiftCluster6D809FEA": {
       "DeletionPolicy": "Delete",
       "DependsOn": [
-        "RunbookFactoryWaitASREnableAutomaticVersionUpgradeOnRedshiftCluster21E48D7F",
+        "RunbookFactoryWaitASRS3BlockDenylistC5124331",
       ],
       "Properties": {
         "CreateIntervalSeconds": 1,
         "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "ace1e70a18c1a2ea3772f5c4f9910fb761ea193e432859d655fe9f6ec837ce21",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASREnableAutomaticVersionUpgradeOnRedshiftCluster21E48D7F": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASREnableRedshiftClusterAuditLogging774EA430",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "ea5377434f76e0ebc4bb2aedd6022895232c5681dd4721fbf46e5f02ff4821d9",
+        "DocumentPropertiesHash": "cbb21589711741582f016da0204b949e6bb393744d53b01dcc5383669d106dea",
         "ServiceToken": {
           "Ref": "WaitProviderServiceToken",
         },
@@ -7843,80 +7656,12 @@ def add_ssl_bucket_policy(event, context):
     "RunbookFactoryWaitASREnableCloudTrailEncryption27956D34": {
       "DeletionPolicy": "Delete",
       "DependsOn": [
-        "RunbookFactoryWaitASREnableCloudTrailToCloudWatchLoggingBE7665D9",
+        "RunbookFactoryWaitASRCreateCloudTrailMultiRegionTrail59648D64",
       ],
       "Properties": {
         "CreateIntervalSeconds": 1,
         "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "003a1a49236fcdfc739dfb3f8042f826cf9f4032510b676af46ba99b629b5b7c",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASREnableCloudTrailLogFileValidationBC3F7A62": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASRConfigureS3PublicAccessBlock3D512CE9",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "caa227863c2b5c5dc94a90b1f1e1cf927127f30fae916c0bbb6e1b9607c171a4",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASREnableCloudTrailToCloudWatchLoggingBE7665D9": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASREnableAWSConfig3525A3F3",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "3e5913fa7336a8b260d11bef407566fa7d080105f7e9e493132e4417be2520eb",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASREnableCopyTagsToSnapshotOnRDSCluster912111BA": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASREnableRDSClusterDeletionProtection33056C9E",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "36ac21b01db1e3d59bd46592a516c953d48703d5a1c7229ef6440d675b304dac",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASREnableDefaultEncryptionS3708084A1": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASREnableCloudTrailEncryption27956D34",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "cce3695a00c635a07ef072f1c9acf6756e10e4e98c6bfb4480342492cd7c3a80",
+        "DocumentPropertiesHash": "0374bc4c927868c772cfefafebaaa108b323922d891f0b86d28e4a2638a5f353",
         "ServiceToken": {
           "Ref": "WaitProviderServiceToken",
         },
@@ -7928,131 +7673,12 @@ def add_ssl_bucket_policy(event, context):
     "RunbookFactoryWaitASREnableDeliveryStatusLoggingForSNSTopic6B2897FC": {
       "DeletionPolicy": "Delete",
       "DependsOn": [
-        "RunbookFactoryWaitASREnableEncryptionForSNSTopicA80819D8",
+        "RunbookFactoryWaitASRRevokeUnusedIAMUserCredentials8F820D02",
       ],
       "Properties": {
         "CreateIntervalSeconds": 1,
         "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "60b1425ab885c47215f2e2515543c019bd9a5146d4ba5e1f02e68ac11ad27260",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASREnableEbsEncryptionByDefaultEE5086CF": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASREnableCloudTrailLogFileValidationBC3F7A62",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "822be5661b27c1f14e4acb849bf83016d4af595609d257612867ebceb328ef22",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASREnableEncryptionForSNSTopicA80819D8": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASREnableMinorVersionUpgradeOnRDSDBInstanceAB104E4F",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "61a59380b46a46a69f1fa979d945fc00e1c06d5d6d51e73a761ec91bb12149e0",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASREnableEncryptionForSQSQueueB09B4FC9": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASRCreateIAMSupportRole9F5D1244",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "72c82f29b4d94028d9e82f27973045b6a1f16de44526c3394eb33e6fdb15a839",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASREnableEnhancedMonitoringOnRDSInstanceDD1C1BF3": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASREnableEbsEncryptionByDefaultEE5086CF",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "c97afb9ac8b8a2583eea4448c40943ebe59240159ba7c436f9b811b45fbd2700",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASREnableKeyRotation8051B8D2": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASREnableEnhancedMonitoringOnRDSInstanceDD1C1BF3",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "054f29d349a639373862975a095d56c02e019070f9a76ac3c169c890d64390ea",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASREnableMinorVersionUpgradeOnRDSDBInstanceAB104E4F": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASRDisablePublicAccessToRDSInstance44100ADC",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "4792d658f4870a505c0374cfd5a0241dafc742bccd72b83ee5588d33e51c5c47",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASREnableMultiAZOnRDSInstance0E221168": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASREnableRDSInstanceDeletionProtectionC279E7E4",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "ab6c691b77016bae8de4def05dd335cf0392f6ec239c9dd38ec0d4b7ca75af1b",
+        "DocumentPropertiesHash": "48149a5b1d9c9f805b246117d5ba0490ff5e0fab9d08d34ca79054672035709b",
         "ServiceToken": {
           "Ref": "WaitProviderServiceToken",
         },
@@ -8064,97 +7690,12 @@ def add_ssl_bucket_policy(event, context):
     "RunbookFactoryWaitASREnableRDSClusterDeletionProtection33056C9E": {
       "DeletionPolicy": "Delete",
       "DependsOn": [
-        "RunbookFactoryWaitASREnableKeyRotation8051B8D2",
+        "RunbookFactoryWaitASRConfigureS3PublicAccessBlock3D512CE9",
       ],
       "Properties": {
         "CreateIntervalSeconds": 1,
         "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "b7e86a11f40a8e1ef5d6a5eeda0b2c327604d36982b1cfe1c193aff19c1c2545",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASREnableRDSInstanceDeletionProtectionC279E7E4": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASREnableCopyTagsToSnapshotOnRDSCluster912111BA",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "05fa3511e4100593c8f6a99306fda5e1f19de81f15ff5dc2c248964b57025d55",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASREnableRedshiftClusterAuditLogging774EA430": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASRDisablePublicAccessToRedshiftCluster825A0721",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "fcb2fd960230ba090b9ea7d2bad8f8ddb88b13d088dd2c38e00731011e50f134",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASREnableVPCFlowLogs3E9F26B7": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASREnableDefaultEncryptionS3708084A1",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "df417f4120e2607e6701a9fa4905e1096fb7972c10769a7474779820e4bfe65a",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASREncryptRDSSnapshot49845014": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASRS3BlockDenylistC5124331",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "dcfbd22506a98b94170a97c9b1a59d6eb69b5c4d0e8ea9d7ac7b1ad8579f01eb",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASRMakeEBSSnapshotsPrivateB36DA424": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASRCreateAccessLoggingBucketC3EB77DA",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "3d0ce35a17c1b5dc226ac9ea9aa8d4cc5322757987265f32cfc14b9b8937bf29",
+        "DocumentPropertiesHash": "76ac9234ed21512ab7274d9f95c6a1ef847748fa697d122f7c3e1d7a1d74f010",
         "ServiceToken": {
           "Ref": "WaitProviderServiceToken",
         },
@@ -8166,80 +7707,12 @@ def add_ssl_bucket_policy(event, context):
     "RunbookFactoryWaitASRMakeRDSSnapshotPrivate68A32264": {
       "DeletionPolicy": "Delete",
       "DependsOn": [
-        "RunbookFactoryWaitASRMakeEBSSnapshotsPrivateB36DA424",
+        "RunbookFactoryWaitASREnableCloudTrailEncryption27956D34",
       ],
       "Properties": {
         "CreateIntervalSeconds": 1,
         "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "a29d272e168f1c033c32f2019ca8445d9769b10020832919afd83f09fd200065",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASRRemoveLambdaPublicAccessC79BEAD8": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASRMakeRDSSnapshotPrivate68A32264",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "0f331e1290baab19ce1516c2650ca1f5463b96e071f5ccb6cfcab75193c3c377",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASRRemoveVPCDefaultSecurityGroupRulesC388ED7D": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASREnableMultiAZOnRDSInstance0E221168",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "218f33de9a1b921482b9ed5f1114f9979b136d1e9fe892f57c362092f41aecf3",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASRReplaceCodeBuildClearTextCredentials20FDDBB7": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASRSetSSLBucketPolicyCD1142F2",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "9beba37c425b4546c50c73cc2f879265ad3a423a21a8f10fafb75dce1de05244",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASRRevokeUnrotatedKeys729E7B55": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASRRemoveLambdaPublicAccessC79BEAD8",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "16e4a7791e8708195eef4fb48490a9fca825530b69905edb4f0bcac12e6f4e0a",
+        "DocumentPropertiesHash": "083c4ea6c7a0c6910ca69f9302c059742061110bc8dec336c7d978536d91f001",
         "ServiceToken": {
           "Ref": "WaitProviderServiceToken",
         },
@@ -8251,12 +7724,12 @@ def add_ssl_bucket_policy(event, context):
     "RunbookFactoryWaitASRRevokeUnusedIAMUserCredentials8F820D02": {
       "DeletionPolicy": "Delete",
       "DependsOn": [
-        "RunbookFactoryWaitASRRemoveVPCDefaultSecurityGroupRulesC388ED7D",
+        "RunbookFactoryWaitASREnableRDSClusterDeletionProtection33056C9E",
       ],
       "Properties": {
         "CreateIntervalSeconds": 1,
         "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "363b35c818cadb6621d4ff7da58e3300d9f301df90a02dd3b98a818ce1062b61",
+        "DocumentPropertiesHash": "160a5fcbd69cdf8cbcfc14188cc87476510aab26e5a76e68a14d9338c0bc5f44",
         "ServiceToken": {
           "Ref": "WaitProviderServiceToken",
         },
@@ -8268,46 +7741,12 @@ def add_ssl_bucket_policy(event, context):
     "RunbookFactoryWaitASRS3BlockDenylistC5124331": {
       "DeletionPolicy": "Delete",
       "DependsOn": [
-        "RunbookFactoryWaitASRReplaceCodeBuildClearTextCredentials20FDDBB7",
+        "RunbookFactoryWaitASRMakeRDSSnapshotPrivate68A32264",
       ],
       "Properties": {
         "CreateIntervalSeconds": 1,
         "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "c5d99304fae4d91393ad856a73a41e5288ff913bc9cb39f9195d6ace2af9e37d",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASRSetIAMPasswordPolicy44AAC428": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASRRevokeUnusedIAMUserCredentials8F820D02",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "08ace87cffc04a975d1c846626fb506af9facbf45eba124ab3cba4b3999992b5",
-        "ServiceToken": {
-          "Ref": "WaitProviderServiceToken",
-        },
-        "UpdateIntervalSeconds": 1,
-      },
-      "Type": "Custom::Wait",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "RunbookFactoryWaitASRSetSSLBucketPolicyCD1142F2": {
-      "DeletionPolicy": "Delete",
-      "DependsOn": [
-        "RunbookFactoryWaitASRRevokeUnrotatedKeys729E7B55",
-      ],
-      "Properties": {
-        "CreateIntervalSeconds": 1,
-        "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "8ffadb58b190d8ce243a25724f6178a959810a240cb2c843fee22378f7bf95bc",
+        "DocumentPropertiesHash": "7f6a725f52d98dbb022cfb5576d75b8985772fe26791fbbc6f23dcbb6d4e6709",
         "ServiceToken": {
           "Ref": "WaitProviderServiceToken",
         },

--- a/source/test/__snapshots__/runbook_stack.test.ts.snap
+++ b/source/test/__snapshots__/runbook_stack.test.ts.snap
@@ -227,8 +227,16 @@ exports[`Global Roles Stack 1`] = `
 exports[`Regional Documents 1`] = `
 {
   "Description": "test;",
+  "Parameters": {
+    "WaitProviderServiceToken": {
+      "Type": "String",
+    },
+  },
   "Resources": {
     "ASRConfigureS3BucketPublicAccessBlock": {
+      "DependsOn": [
+        "RunbookFactoryWaitASRConfigureS3BucketPublicAccessBlock08BBA9CD",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -402,6 +410,9 @@ def validate_s3_bucket_publicaccessblock(event, context):
       "Type": "AWS::SSM::Document",
     },
     "ASRConfigureS3PublicAccessBlock": {
+      "DependsOn": [
+        "RunbookFactoryWaitASRConfigureS3PublicAccessBlock3D512CE9",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -567,6 +578,9 @@ def handler(event, context):
       "Type": "AWS::SSM::Document",
     },
     "ASRConfigureSNSTopicForStack": {
+      "DependsOn": [
+        "RunbookFactoryWaitASRConfigureSNSTopicForStackC9EAB91D",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -734,6 +748,9 @@ class StackConfigurationFailedException(Exception):
       "Type": "AWS::SSM::Document",
     },
     "ASRCreateAccessLoggingBucket": {
+      "DependsOn": [
+        "RunbookFactoryWaitASRCreateAccessLoggingBucketC3EB77DA",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -853,6 +870,9 @@ def create_logging_bucket(event, context):
       "Type": "AWS::SSM::Document",
     },
     "ASRCreateCloudTrailMultiRegionTrail": {
+      "DependsOn": [
+        "RunbookFactoryWaitASRCreateCloudTrailMultiRegionTrail59648D64",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -1335,6 +1355,9 @@ def process_results(event, context):
       "Type": "AWS::SSM::Document",
     },
     "ASRCreateIAMSupportRole": {
+      "DependsOn": [
+        "RunbookFactoryWaitASRCreateIAMSupportRole9F5D1244",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -1481,6 +1504,9 @@ def does_role_exist(iam, role_name):
       "Type": "AWS::SSM::Document",
     },
     "ASRCreateLogMetricFilterAndAlarm": {
+      "DependsOn": [
+        "RunbookFactoryWaitASRCreateLogMetricFilterAndAlarmD0985F81",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -1828,6 +1854,9 @@ def verify(event, context):
       "Type": "AWS::SSM::Document",
     },
     "ASRDisablePublicAccessToRDSInstance": {
+      "DependsOn": [
+        "RunbookFactoryWaitASRDisablePublicAccessToRDSInstance44100ADC",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -2001,6 +2030,9 @@ Confirms public accessibility is disabled on the DB instance.
       "Type": "AWS::SSM::Document",
     },
     "ASRDisablePublicAccessToRedshiftCluster": {
+      "DependsOn": [
+        "RunbookFactoryWaitASRDisablePublicAccessToRedshiftCluster825A0721",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -2104,6 +2136,9 @@ Confirms the public accessibility setting is disabled on the cluster.
       "Type": "AWS::SSM::Document",
     },
     "ASRDisablePublicIPAutoAssign": {
+      "DependsOn": [
+        "RunbookFactoryWaitASRDisablePublicIPAutoAssign4F120289",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -2234,6 +2269,9 @@ def describe_subnet(subnet_id):
       "Type": "AWS::SSM::Document",
     },
     "ASREnableAWSConfig": {
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableAWSConfig3525A3F3",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -2744,6 +2782,9 @@ def process_results(event, context):
       "Type": "AWS::SSM::Document",
     },
     "ASREnableAutoScalingGroupELBHealthCheck": {
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableAutoScalingGroupELBHealthCheck83273238",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -2880,6 +2921,9 @@ def verify(event, context):
       "Type": "AWS::SSM::Document",
     },
     "ASREnableAutomaticSnapshotsOnRedshiftCluster": {
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableAutomaticSnapshotsOnRedshiftCluster6D809FEA",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{AutomationAssumeRole}}",
@@ -3061,6 +3105,9 @@ The runbook enables automatic snapshots on a Redshift cluster.
       "Type": "AWS::SSM::Document",
     },
     "ASREnableAutomaticVersionUpgradeOnRedshiftCluster": {
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableAutomaticVersionUpgradeOnRedshiftCluster21E48D7F",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{AutomationAssumeRole}}",
@@ -3175,6 +3222,9 @@ The runbook enables automatic version upgrade on a Redshift cluster.
       "Type": "AWS::SSM::Document",
     },
     "ASREnableCloudTrailEncryption": {
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableCloudTrailEncryption27956D34",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -3294,6 +3344,9 @@ def enable_trail_encryption(event, context):
       "Type": "AWS::SSM::Document",
     },
     "ASREnableCloudTrailLogFileValidation": {
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableCloudTrailLogFileValidationBC3F7A62",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -3380,6 +3433,9 @@ Verifies log file validation is enabled for your trail.
       "Type": "AWS::SSM::Document",
     },
     "ASREnableCloudTrailToCloudWatchLogging": {
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableCloudTrailToCloudWatchLoggingBE7665D9",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -3525,6 +3581,9 @@ def wait_for_loggroup(event, _):
       "Type": "AWS::SSM::Document",
     },
     "ASREnableCopyTagsToSnapshotOnRDSCluster": {
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableCopyTagsToSnapshotOnRDSCluster912111BA",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -3661,6 +3720,9 @@ Verifies that \`CopyTagsToSnapshot\` has been enabled on the target resource.
       "Type": "AWS::SSM::Document",
     },
     "ASREnableDefaultEncryptionS3": {
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableDefaultEncryptionS3708084A1",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -3775,6 +3837,9 @@ This document configures default encryption for an Amazon S3 Bucket.
       "Type": "AWS::SSM::Document",
     },
     "ASREnableDeliveryStatusLoggingForSNSTopic": {
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableDeliveryStatusLoggingForSNSTopic6B2897FC",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -3942,6 +4007,9 @@ def reset_to_recognized_state(topic_arn):
       "Type": "AWS::SSM::Document",
     },
     "ASREnableEbsEncryptionByDefault": {
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableEbsEncryptionByDefaultEE5086CF",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -4017,6 +4085,9 @@ Checks if EbsEncryptionByDefault is enabled correctly from the previous step.
       "Type": "AWS::SSM::Document",
     },
     "ASREnableEncryptionForSNSTopic": {
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableEncryptionForSNSTopicA80819D8",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -4113,6 +4184,9 @@ Verifies the given Amazon SNS Topic is encrypted with AWS KMS Key ARN.
       "Type": "AWS::SSM::Document",
     },
     "ASREnableEncryptionForSQSQueue": {
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableEncryptionForSQSQueueB09B4FC9",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -4219,6 +4293,9 @@ Based on your data policy, Amazon SQS queues should be encrypted with different 
       "Type": "AWS::SSM::Document",
     },
     "ASREnableEnhancedMonitoringOnRDSInstance": {
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableEnhancedMonitoringOnRDSInstanceDD1C1BF3",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -4414,6 +4491,9 @@ def handler(event, context):
       "Type": "AWS::SSM::Document",
     },
     "ASREnableKeyRotation": {
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableKeyRotation8051B8D2",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -4497,6 +4577,9 @@ Verifies that the KeyRotationEnabled is set to true for the given AWS KMS CMK.
       "Type": "AWS::SSM::Document",
     },
     "ASREnableMinorVersionUpgradeOnRDSDBInstance": {
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableMinorVersionUpgradeOnRDSDBInstanceAB104E4F",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -4676,6 +4759,9 @@ def verify_instance_changes(instanceID):
       "Type": "AWS::SSM::Document",
     },
     "ASREnableMultiAZOnRDSInstance": {
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableMultiAZOnRDSInstance0E221168",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -4842,6 +4928,9 @@ Verifies that the RDS Instance's \`PendingModifiedValues.MultiAZ\` value is \`Tr
       "Type": "AWS::SSM::Document",
     },
     "ASREnableRDSClusterDeletionProtection": {
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableRDSClusterDeletionProtection33056C9E",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -4970,6 +5059,9 @@ Verifies that deletion protection has been enabled for the given Amazon RDS data
       "Type": "AWS::SSM::Document",
     },
     "ASREnableRDSInstanceDeletionProtection": {
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableRDSInstanceDeletionProtectionC279E7E4",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -5093,6 +5185,9 @@ Checks whether deletion protection is enabled on Amazon RDS Instance.
       "Type": "AWS::SSM::Document",
     },
     "ASREnableRedshiftClusterAuditLogging": {
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableRedshiftClusterAuditLogging774EA430",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -5263,6 +5358,9 @@ Checks whether the value of the "BucketName" parameter is used for the audit log
       "Type": "AWS::SSM::Document",
     },
     "ASREnableVPCFlowLogs": {
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableVPCFlowLogs3E9F26B7",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -5489,6 +5587,9 @@ def enable_flow_logs(event, context):
       "Type": "AWS::SSM::Document",
     },
     "ASREncryptRDSSnapshot": {
+      "DependsOn": [
+        "RunbookFactoryWaitASREncryptRDSSnapshot49845014",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{AutomationAssumeRole}}",
@@ -5694,6 +5795,9 @@ If KmsKeyId is a Customer-Managed Key (CMK), then AutomationAssumeRole must have
       "Type": "AWS::SSM::Document",
     },
     "ASRMakeEBSSnapshotsPrivate": {
+      "DependsOn": [
+        "RunbookFactoryWaitASRMakeEBSSnapshotsPrivateB36DA424",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -5905,6 +6009,9 @@ def make_snapshots_private(event, context):
       "Type": "AWS::SSM::Document",
     },
     "ASRMakeRDSSnapshotPrivate": {
+      "DependsOn": [
+        "RunbookFactoryWaitASRMakeRDSSnapshotPrivate68A32264",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -6024,6 +6131,9 @@ def make_snapshot_private(event, context):
       "Type": "AWS::SSM::Document",
     },
     "ASRRemoveLambdaPublicAccess": {
+      "DependsOn": [
+        "RunbookFactoryWaitASRRemoveLambdaPublicAccessC79BEAD8",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -6187,6 +6297,9 @@ def verify(function_name_to_check):
       "Type": "AWS::SSM::Document",
     },
     "ASRRemoveVPCDefaultSecurityGroupRules": {
+      "DependsOn": [
+        "RunbookFactoryWaitASRRemoveVPCDefaultSecurityGroupRulesC388ED7D",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -6309,6 +6422,9 @@ def handler(event, context):
       "Type": "AWS::SSM::Document",
     },
     "ASRReplaceCodeBuildClearTextCredentials": {
+      "DependsOn": [
+        "RunbookFactoryWaitASRReplaceCodeBuildClearTextCredentials20FDDBB7",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -6607,6 +6723,9 @@ Changes the settings of a build project.
       "Type": "AWS::SSM::Document",
     },
     "ASRRevokeUnrotatedKeys": {
+      "DependsOn": [
+        "RunbookFactoryWaitASRRevokeUnrotatedKeys729E7B55",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -6767,6 +6886,9 @@ def unrotated_key_handler(event, context):
       "Type": "AWS::SSM::Document",
     },
     "ASRRevokeUnusedIAMUserCredentials": {
+      "DependsOn": [
+        "RunbookFactoryWaitASRRevokeUnusedIAMUserCredentials8F820D02",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -6930,6 +7052,9 @@ def unused_iam_credentials_handler(event, context):
       "Type": "AWS::SSM::Document",
     },
     "ASRS3BlockDenylist": {
+      "DependsOn": [
+        "RunbookFactoryWaitASRS3BlockDenylistC5124331",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -7151,6 +7276,9 @@ def update_bucket_policy(event, context):
       "Type": "AWS::SSM::Document",
     },
     "ASRSetIAMPasswordPolicy": {
+      "DependsOn": [
+        "RunbookFactoryWaitASRSetIAMPasswordPolicy44AAC428",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -7321,6 +7449,9 @@ def update_and_verify_iam_user_password_policy(event, context):
       "Type": "AWS::SSM::Document",
     },
     "ASRSetSSLBucketPolicy": {
+      "DependsOn": [
+        "RunbookFactoryWaitASRSetSSLBucketPolicyCD1142F2",
+      ],
       "Properties": {
         "Content": {
           "assumeRole": "{{ AutomationAssumeRole }}",
@@ -7473,6 +7604,717 @@ def add_ssl_bucket_policy(event, context):
         "UpdateMethod": "NewVersion",
       },
       "Type": "AWS::SSM::Document",
+    },
+    "RunbookFactoryWaitASRConfigureS3BucketPublicAccessBlock08BBA9CD": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASRConfigureSNSTopicForStackC9EAB91D",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "d46d826df4763585df74f4757224460b4c64d192501cecfbd2d4eef6684f26c2",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASRConfigureS3PublicAccessBlock3D512CE9": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASRConfigureS3BucketPublicAccessBlock08BBA9CD",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "44666e1e9a133fef5249a420cf6b1827d9ab2cf7b8a9be556a8c1a5e317965ed",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASRConfigureSNSTopicForStackC9EAB91D": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableEncryptionForSQSQueueB09B4FC9",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "5b9ee7b3553d436edee47a28ec1ccd32903adea745414788c0d2ef2572acab9e",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASRCreateAccessLoggingBucketC3EB77DA": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableVPCFlowLogs3E9F26B7",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "d3e78b1577d20b4b4f44c39a1682cb123a26562fce5abb96e6b9298647dbc068",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASRCreateCloudTrailMultiRegionTrail59648D64": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "0baa7af8a6bd1bbca980bdac18034185a2f37173eac857848d74c2ba84e78c31",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASRCreateIAMSupportRole9F5D1244": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableAutomaticSnapshotsOnRedshiftCluster6D809FEA",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "27388acdf839747c3aeeec6c1a245abb3e52ac8eb23598250975857f21c49bcb",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASRCreateLogMetricFilterAndAlarmD0985F81": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASRCreateCloudTrailMultiRegionTrail59648D64",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "69e43c5adafad414c7a37d8320cc8b67d6ec70bed84c16afdfdb08785697af99",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASRDisablePublicAccessToRDSInstance44100ADC": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASRSetIAMPasswordPolicy44AAC428",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "a361bc190c84d8446b90e97d4467597efd5588eadfdbadad47b91bdb765dc339",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASRDisablePublicAccessToRedshiftCluster825A0721": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASREncryptRDSSnapshot49845014",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "22d54ac22a0a9ff09b419ffaaa8f6adff5092ed6f3913b154173b4eb58f027ef",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASRDisablePublicIPAutoAssign4F120289": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableDeliveryStatusLoggingForSNSTopic6B2897FC",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "ceff3ebcbeb12c839b36e2b0ed60c184742ffdeeeda7f82933965fd23a2228f4",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASREnableAWSConfig3525A3F3": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableAutoScalingGroupELBHealthCheck83273238",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "2ff4a98d0fdd571a26bf6341c77cf602de124e8fa97f6843466a5f4efd58685a",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASREnableAutoScalingGroupELBHealthCheck83273238": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASRCreateLogMetricFilterAndAlarmD0985F81",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "26d30f51cccd0807f1ff5fc0ef28a87accada59a9e952ac0235bec97b3e99e0f",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASREnableAutomaticSnapshotsOnRedshiftCluster6D809FEA": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableAutomaticVersionUpgradeOnRedshiftCluster21E48D7F",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "ace1e70a18c1a2ea3772f5c4f9910fb761ea193e432859d655fe9f6ec837ce21",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASREnableAutomaticVersionUpgradeOnRedshiftCluster21E48D7F": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableRedshiftClusterAuditLogging774EA430",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "ea5377434f76e0ebc4bb2aedd6022895232c5681dd4721fbf46e5f02ff4821d9",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASREnableCloudTrailEncryption27956D34": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableCloudTrailToCloudWatchLoggingBE7665D9",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "003a1a49236fcdfc739dfb3f8042f826cf9f4032510b676af46ba99b629b5b7c",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASREnableCloudTrailLogFileValidationBC3F7A62": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASRConfigureS3PublicAccessBlock3D512CE9",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "caa227863c2b5c5dc94a90b1f1e1cf927127f30fae916c0bbb6e1b9607c171a4",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASREnableCloudTrailToCloudWatchLoggingBE7665D9": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableAWSConfig3525A3F3",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "3e5913fa7336a8b260d11bef407566fa7d080105f7e9e493132e4417be2520eb",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASREnableCopyTagsToSnapshotOnRDSCluster912111BA": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableRDSClusterDeletionProtection33056C9E",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "36ac21b01db1e3d59bd46592a516c953d48703d5a1c7229ef6440d675b304dac",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASREnableDefaultEncryptionS3708084A1": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableCloudTrailEncryption27956D34",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "cce3695a00c635a07ef072f1c9acf6756e10e4e98c6bfb4480342492cd7c3a80",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASREnableDeliveryStatusLoggingForSNSTopic6B2897FC": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableEncryptionForSNSTopicA80819D8",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "60b1425ab885c47215f2e2515543c019bd9a5146d4ba5e1f02e68ac11ad27260",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASREnableEbsEncryptionByDefaultEE5086CF": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableCloudTrailLogFileValidationBC3F7A62",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "822be5661b27c1f14e4acb849bf83016d4af595609d257612867ebceb328ef22",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASREnableEncryptionForSNSTopicA80819D8": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableMinorVersionUpgradeOnRDSDBInstanceAB104E4F",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "61a59380b46a46a69f1fa979d945fc00e1c06d5d6d51e73a761ec91bb12149e0",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASREnableEncryptionForSQSQueueB09B4FC9": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASRCreateIAMSupportRole9F5D1244",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "72c82f29b4d94028d9e82f27973045b6a1f16de44526c3394eb33e6fdb15a839",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASREnableEnhancedMonitoringOnRDSInstanceDD1C1BF3": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableEbsEncryptionByDefaultEE5086CF",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "c97afb9ac8b8a2583eea4448c40943ebe59240159ba7c436f9b811b45fbd2700",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASREnableKeyRotation8051B8D2": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableEnhancedMonitoringOnRDSInstanceDD1C1BF3",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "054f29d349a639373862975a095d56c02e019070f9a76ac3c169c890d64390ea",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASREnableMinorVersionUpgradeOnRDSDBInstanceAB104E4F": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASRDisablePublicAccessToRDSInstance44100ADC",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "4792d658f4870a505c0374cfd5a0241dafc742bccd72b83ee5588d33e51c5c47",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASREnableMultiAZOnRDSInstance0E221168": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableRDSInstanceDeletionProtectionC279E7E4",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "ab6c691b77016bae8de4def05dd335cf0392f6ec239c9dd38ec0d4b7ca75af1b",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASREnableRDSClusterDeletionProtection33056C9E": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableKeyRotation8051B8D2",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "b7e86a11f40a8e1ef5d6a5eeda0b2c327604d36982b1cfe1c193aff19c1c2545",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASREnableRDSInstanceDeletionProtectionC279E7E4": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableCopyTagsToSnapshotOnRDSCluster912111BA",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "05fa3511e4100593c8f6a99306fda5e1f19de81f15ff5dc2c248964b57025d55",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASREnableRedshiftClusterAuditLogging774EA430": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASRDisablePublicAccessToRedshiftCluster825A0721",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "fcb2fd960230ba090b9ea7d2bad8f8ddb88b13d088dd2c38e00731011e50f134",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASREnableVPCFlowLogs3E9F26B7": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableDefaultEncryptionS3708084A1",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "df417f4120e2607e6701a9fa4905e1096fb7972c10769a7474779820e4bfe65a",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASREncryptRDSSnapshot49845014": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASRS3BlockDenylistC5124331",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "dcfbd22506a98b94170a97c9b1a59d6eb69b5c4d0e8ea9d7ac7b1ad8579f01eb",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASRMakeEBSSnapshotsPrivateB36DA424": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASRCreateAccessLoggingBucketC3EB77DA",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "3d0ce35a17c1b5dc226ac9ea9aa8d4cc5322757987265f32cfc14b9b8937bf29",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASRMakeRDSSnapshotPrivate68A32264": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASRMakeEBSSnapshotsPrivateB36DA424",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "a29d272e168f1c033c32f2019ca8445d9769b10020832919afd83f09fd200065",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASRRemoveLambdaPublicAccessC79BEAD8": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASRMakeRDSSnapshotPrivate68A32264",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "0f331e1290baab19ce1516c2650ca1f5463b96e071f5ccb6cfcab75193c3c377",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASRRemoveVPCDefaultSecurityGroupRulesC388ED7D": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASREnableMultiAZOnRDSInstance0E221168",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "218f33de9a1b921482b9ed5f1114f9979b136d1e9fe892f57c362092f41aecf3",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASRReplaceCodeBuildClearTextCredentials20FDDBB7": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASRSetSSLBucketPolicyCD1142F2",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "9beba37c425b4546c50c73cc2f879265ad3a423a21a8f10fafb75dce1de05244",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASRRevokeUnrotatedKeys729E7B55": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASRRemoveLambdaPublicAccessC79BEAD8",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "16e4a7791e8708195eef4fb48490a9fca825530b69905edb4f0bcac12e6f4e0a",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASRRevokeUnusedIAMUserCredentials8F820D02": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASRRemoveVPCDefaultSecurityGroupRulesC388ED7D",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "363b35c818cadb6621d4ff7da58e3300d9f301df90a02dd3b98a818ce1062b61",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASRS3BlockDenylistC5124331": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASRReplaceCodeBuildClearTextCredentials20FDDBB7",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "c5d99304fae4d91393ad856a73a41e5288ff913bc9cb39f9195d6ace2af9e37d",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASRSetIAMPasswordPolicy44AAC428": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASRRevokeUnusedIAMUserCredentials8F820D02",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "08ace87cffc04a975d1c846626fb506af9facbf45eba124ab3cba4b3999992b5",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "RunbookFactoryWaitASRSetSSLBucketPolicyCD1142F2": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "RunbookFactoryWaitASRRevokeUnrotatedKeys729E7B55",
+      ],
+      "Properties": {
+        "CreateIntervalSeconds": 1,
+        "DeleteIntervalSeconds": 0.5,
+        "DocumentPropertiesHash": "8ffadb58b190d8ce243a25724f6178a959810a240cb2c843fee22378f7bf95bc",
+        "ServiceToken": {
+          "Ref": "WaitProviderServiceToken",
+        },
+        "UpdateIntervalSeconds": 1,
+      },
+      "Type": "Custom::Wait",
+      "UpdateReplacePolicy": "Delete",
     },
   },
 }

--- a/source/test/ssmplaybook.test.ts
+++ b/source/test/ssmplaybook.test.ts
@@ -5,7 +5,7 @@ import { Policy, PolicyStatement, Effect } from 'aws-cdk-lib/aws-iam';
 import { Template } from 'aws-cdk-lib/assertions';
 import { AwsSolutionsChecks } from 'cdk-nag';
 import { SsmRole } from '../lib/ssmplaybook';
-import { RunbookFactory } from '../solution_deploy/lib/runbook_factory';
+import { ControlRunbookFactory, RemediationRunbookFactory } from '../solution_deploy/lib/runbook_factory';
 import { MemberRoleStack } from '../solution_deploy/lib/remediation_runbook-stack';
 
 function getSsmPlaybook(): Stack {
@@ -13,7 +13,7 @@ function getSsmPlaybook(): Stack {
   const stack = new Stack(app, 'MyTestStack', {
     stackName: 'testStack',
   });
-  const runbookFactory = new RunbookFactory(stack, 'RunbookFactory');
+  const runbookFactory = new ControlRunbookFactory(stack, 'RunbookFactory');
   runbookFactory.createControlRunbook(stack, 'Playbook', {
     securityStandard: 'SECTEST',
     securityStandardVersion: '1.2.3',
@@ -68,7 +68,7 @@ function getSsmRemediationRunbook(): Stack {
     solutionVersion: 'v1.1.1',
     solutionDistBucket: 'sharrbukkit',
   });
-  const runbookFactory = new RunbookFactory(stack, 'RunbookFactory');
+  const runbookFactory = new RemediationRunbookFactory(stack, 'RunbookFactory');
   runbookFactory.createRemediationRunbook(stack, 'Playbook', {
     ssmDocName: 'blahblahblah',
     ssmDocPath: 'test/test_data/',

--- a/source/test/ssmplaybook.test.ts
+++ b/source/test/ssmplaybook.test.ts
@@ -13,7 +13,9 @@ function getSsmPlaybook(): Stack {
   const stack = new Stack(app, 'MyTestStack', {
     stackName: 'testStack',
   });
-  const runbookFactory = new ControlRunbookFactory(stack, 'RunbookFactory');
+  const runbookFactory = new ControlRunbookFactory(stack, 'RunbookFactory', {
+    waitProviderServiceToken: 'fake',
+  });
   runbookFactory.createControlRunbook(stack, 'Playbook', {
     securityStandard: 'SECTEST',
     securityStandardVersion: '1.2.3',
@@ -68,7 +70,9 @@ function getSsmRemediationRunbook(): Stack {
     solutionVersion: 'v1.1.1',
     solutionDistBucket: 'sharrbukkit',
   });
-  const runbookFactory = new RemediationRunbookFactory(stack, 'RunbookFactory');
+  const runbookFactory = new RemediationRunbookFactory(stack, 'RunbookFactory', {
+    waitProviderServiceToken: 'fake',
+  });
   runbookFactory.createRemediationRunbook(stack, 'Playbook', {
     ssmDocName: 'blahblahblah',
     ssmDocPath: 'test/test_data/',

--- a/source/test/ssmplaybook.test.ts
+++ b/source/test/ssmplaybook.test.ts
@@ -13,8 +13,8 @@ function getSsmPlaybook(): Stack {
   const stack = new Stack(app, 'MyTestStack', {
     stackName: 'testStack',
   });
-  new RunbookFactory(stack, 'RunbookFactory');
-  RunbookFactory.createControlRunbook(stack, 'Playbook', {
+  const runbookFactory = new RunbookFactory(stack, 'RunbookFactory');
+  runbookFactory.createControlRunbook(stack, 'Playbook', {
     securityStandard: 'SECTEST',
     securityStandardVersion: '1.2.3',
     controlId: 'TEST.1',
@@ -68,8 +68,8 @@ function getSsmRemediationRunbook(): Stack {
     solutionVersion: 'v1.1.1',
     solutionDistBucket: 'sharrbukkit',
   });
-  new RunbookFactory(stack, 'RunbookFactory');
-  RunbookFactory.createRemediationRunbook(stack, 'Playbook', {
+  const runbookFactory = new RunbookFactory(stack, 'RunbookFactory');
+  runbookFactory.createRemediationRunbook(stack, 'Playbook', {
     ssmDocName: 'blahblahblah',
     ssmDocPath: 'test/test_data/',
     ssmDocFileName: 'tstest-cis29.yaml',


### PR DESCRIPTION
This PR is of a WIP/POC branch and I don't consider it ready for production.

- to mitigate throttling exceptions/rate limit exceeded when creating SSM 
- add a wait custom resource
- make all SSM documents dependent on a sequence of wait custom resources
- batch documents in groups of 5 - this is approximately how long it takes for each gate to deploy

To handle updates correctly, we need to make sure each gate gets the same documents on each build. This is a maintainability nightmare, and it gives a lower confidence that deploy will succeed. But it's probably the simplest way.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.