### PR TITLE
Changed ControlRunbookDocument names to reduce code smells

### DIFF
--- a/source/playbooks/CIS140/ssmdocs/CIS140_1.12.ts
+++ b/source/playbooks/CIS140/ssmdocs/CIS140_1.12.ts
@@ -3,8 +3,8 @@
 import { Construct } from 'constructs';
 import { PlaybookProps } from '../../SC/lib/control_runbooks-construct';
 import { ControlRunbookDocument } from '../../SC/ssmdocs/control_runbook';
-import { IAM_8_ControlRunbookDocument } from '../../SC/ssmdocs/SC_IAM.8';
+import { RevokeUnusedIAMUserCredentialsDocument } from '../../SC/ssmdocs/SC_IAM.8';
 
 export function createControlRunbook(stage: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new IAM_8_ControlRunbookDocument(stage, id, { ...props, controlId: '1.12' });
+  return new RevokeUnusedIAMUserCredentialsDocument(stage, id, { ...props, controlId: '1.12' });
 }

--- a/source/playbooks/CIS140/ssmdocs/CIS140_1.14.ts
+++ b/source/playbooks/CIS140/ssmdocs/CIS140_1.14.ts
@@ -3,8 +3,8 @@
 import { Construct } from 'constructs';
 import { PlaybookProps } from '../../SC/lib/control_runbooks-construct';
 import { ControlRunbookDocument } from '../../SC/ssmdocs/control_runbook';
-import { IAM_3_ControlRunbookDocument } from '../../SC/ssmdocs/SC_IAM.3';
+import { RevokeUnrotatedKeysDocument } from '../../SC/ssmdocs/SC_IAM.3';
 
 export function createControlRunbook(stage: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new IAM_3_ControlRunbookDocument(stage, id, { ...props, controlId: '1.14' });
+  return new RevokeUnrotatedKeysDocument(stage, id, { ...props, controlId: '1.14' });
 }

--- a/source/playbooks/CIS140/ssmdocs/CIS140_1.8.ts
+++ b/source/playbooks/CIS140/ssmdocs/CIS140_1.8.ts
@@ -3,8 +3,8 @@
 import { Construct } from 'constructs';
 import { PlaybookProps } from '../../SC/lib/control_runbooks-construct';
 import { ControlRunbookDocument } from '../../SC/ssmdocs/control_runbook';
-import { IAM_7_ControlRunbookDocument } from '../../SC/ssmdocs/SC_IAM.7';
+import { SetIAMPasswordPolicyDocument } from '../../SC/ssmdocs/SC_IAM.7';
 
 export function createControlRunbook(stage: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new IAM_7_ControlRunbookDocument(stage, id, { ...props, controlId: '1.8', otherControlIds: ['1.9'] });
+  return new SetIAMPasswordPolicyDocument(stage, id, { ...props, controlId: '1.8', otherControlIds: ['1.9'] });
 }

--- a/source/playbooks/CIS140/ssmdocs/CIS140_2.1.1.ts
+++ b/source/playbooks/CIS140/ssmdocs/CIS140_2.1.1.ts
@@ -3,8 +3,8 @@
 import { Construct } from 'constructs';
 import { PlaybookProps } from '../../SC/lib/control_runbooks-construct';
 import { ControlRunbookDocument } from '../../SC/ssmdocs/control_runbook';
-import { S3_4_ControlRunbookDocument } from '../../SC/ssmdocs/SC_S3.4';
+import { EnableDefaultEncryptionS3Document } from '../../SC/ssmdocs/SC_S3.4';
 
 export function createControlRunbook(stage: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new S3_4_ControlRunbookDocument(stage, id, { ...props, controlId: '2.1.1' });
+  return new EnableDefaultEncryptionS3Document(stage, id, { ...props, controlId: '2.1.1' });
 }

--- a/source/playbooks/CIS140/ssmdocs/CIS140_2.1.2.ts
+++ b/source/playbooks/CIS140/ssmdocs/CIS140_2.1.2.ts
@@ -3,8 +3,8 @@
 import { Construct } from 'constructs';
 import { PlaybookProps } from '../../SC/lib/control_runbooks-construct';
 import { ControlRunbookDocument } from '../../SC/ssmdocs/control_runbook';
-import { S3_5_ControlRunbookDocument } from '../../SC/ssmdocs/SC_S3.5';
+import { SetSSLBucketPolicyDocument } from '../../SC/ssmdocs/SC_S3.5';
 
 export function createControlRunbook(stage: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new S3_5_ControlRunbookDocument(stage, id, { ...props, controlId: '2.1.2' });
+  return new SetSSLBucketPolicyDocument(stage, id, { ...props, controlId: '2.1.2' });
 }

--- a/source/playbooks/CIS140/ssmdocs/CIS140_2.1.5.ts
+++ b/source/playbooks/CIS140/ssmdocs/CIS140_2.1.5.ts
@@ -3,8 +3,8 @@
 import { Construct } from 'constructs';
 import { PlaybookProps } from '../../SC/lib/control_runbooks-construct';
 import { ControlRunbookDocument } from '../../SC/ssmdocs/control_runbook';
-import { S3_2_ControlRunbookDocument } from '../../SC/ssmdocs/SC_S3.2';
+import { ConfigureS3BucketPublicAccessBlockDocument } from '../../SC/ssmdocs/SC_S3.2';
 
 export function createControlRunbook(stage: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new S3_2_ControlRunbookDocument(stage, id, { ...props, controlId: '2.1.5' });
+  return new ConfigureS3BucketPublicAccessBlockDocument(stage, id, { ...props, controlId: '2.1.5' });
 }

--- a/source/playbooks/CIS140/ssmdocs/CIS140_3.1.ts
+++ b/source/playbooks/CIS140/ssmdocs/CIS140_3.1.ts
@@ -3,8 +3,8 @@
 import { Construct } from 'constructs';
 import { PlaybookProps } from '../../SC/lib/control_runbooks-construct';
 import { ControlRunbookDocument } from '../../SC/ssmdocs/control_runbook';
-import { CloudTrail_1_ControlRunbookDocument } from '../../SC/ssmdocs/SC_CloudTrail.1';
+import { CreateCloudTrailMultiRegionTrailDocument } from '../../SC/ssmdocs/SC_CloudTrail.1';
 
 export function createControlRunbook(stage: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new CloudTrail_1_ControlRunbookDocument(stage, id, { ...props, controlId: '3.1' });
+  return new CreateCloudTrailMultiRegionTrailDocument(stage, id, { ...props, controlId: '3.1' });
 }

--- a/source/playbooks/CIS140/ssmdocs/CIS140_3.2.ts
+++ b/source/playbooks/CIS140/ssmdocs/CIS140_3.2.ts
@@ -3,8 +3,8 @@
 import { Construct } from 'constructs';
 import { PlaybookProps } from '../../SC/lib/control_runbooks-construct';
 import { ControlRunbookDocument } from '../../SC/ssmdocs/control_runbook';
-import { CloudTrail_4_ControlRunbookDocument } from '../../SC/ssmdocs/SC_CloudTrail.4';
+import { EnableCloudTrailLogFileValidationDocument } from '../../SC/ssmdocs/SC_CloudTrail.4';
 
 export function createControlRunbook(stage: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new CloudTrail_4_ControlRunbookDocument(stage, id, { ...props, controlId: '3.2' });
+  return new EnableCloudTrailLogFileValidationDocument(stage, id, { ...props, controlId: '3.2' });
 }

--- a/source/playbooks/CIS140/ssmdocs/CIS140_3.3.ts
+++ b/source/playbooks/CIS140/ssmdocs/CIS140_3.3.ts
@@ -3,8 +3,8 @@
 import { Construct } from 'constructs';
 import { PlaybookProps } from '../../SC/lib/control_runbooks-construct';
 import { ControlRunbookDocument } from '../../SC/ssmdocs/control_runbook';
-import { CloudTrail_6_ControlRunbookDocument } from '../../SC/ssmdocs/SC_CloudTrail.6';
+import { ConfigureS3BucketPublicAccessBlockDocument } from '../../SC/ssmdocs/SC_CloudTrail.6';
 
 export function createControlRunbook(stage: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new CloudTrail_6_ControlRunbookDocument(stage, id, { ...props, controlId: '3.3' });
+  return new ConfigureS3BucketPublicAccessBlockDocument(stage, id, { ...props, controlId: '3.3' });
 }

--- a/source/playbooks/CIS140/ssmdocs/CIS140_3.4.ts
+++ b/source/playbooks/CIS140/ssmdocs/CIS140_3.4.ts
@@ -3,8 +3,8 @@
 import { Construct } from 'constructs';
 import { PlaybookProps } from '../../SC/lib/control_runbooks-construct';
 import { ControlRunbookDocument } from '../../SC/ssmdocs/control_runbook';
-import { CloudTrail_5_ControlRunbookDocument } from '../../SC/ssmdocs/SC_CloudTrail.5';
+import { EnableCloudTrailToCloudWatchLoggingDocument } from '../../SC/ssmdocs/SC_CloudTrail.5';
 
 export function createControlRunbook(stage: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new CloudTrail_5_ControlRunbookDocument(stage, id, { ...props, controlId: '3.4' });
+  return new EnableCloudTrailToCloudWatchLoggingDocument(stage, id, { ...props, controlId: '3.4' });
 }

--- a/source/playbooks/CIS140/ssmdocs/CIS140_3.5.ts
+++ b/source/playbooks/CIS140/ssmdocs/CIS140_3.5.ts
@@ -3,8 +3,8 @@
 import { Construct } from 'constructs';
 import { PlaybookProps } from '../../SC/lib/control_runbooks-construct';
 import { ControlRunbookDocument } from '../../SC/ssmdocs/control_runbook';
-import { Config_1_ControlRunbookDocument } from '../../SC/ssmdocs/SC_Config.1';
+import { EnableAWSConfigDocument } from '../../SC/ssmdocs/SC_Config.1';
 
 export function createControlRunbook(stage: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new Config_1_ControlRunbookDocument(stage, id, { ...props, controlId: '3.5' });
+  return new EnableAWSConfigDocument(stage, id, { ...props, controlId: '3.5' });
 }

--- a/source/playbooks/CIS140/ssmdocs/CIS140_3.6.ts
+++ b/source/playbooks/CIS140/ssmdocs/CIS140_3.6.ts
@@ -3,8 +3,8 @@
 import { Construct } from 'constructs';
 import { PlaybookProps } from '../../SC/lib/control_runbooks-construct';
 import { ControlRunbookDocument } from '../../SC/ssmdocs/control_runbook';
-import { CloudTrail_7_ControlRunbookDocument } from '../../SC/ssmdocs/SC_CloudTrail.7';
+import { ConfigureS3BucketLoggingDocument } from '../../SC/ssmdocs/SC_CloudTrail.7';
 
 export function createControlRunbook(stage: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new CloudTrail_7_ControlRunbookDocument(stage, id, { ...props, controlId: '3.6' });
+  return new ConfigureS3BucketLoggingDocument(stage, id, { ...props, controlId: '3.6' });
 }

--- a/source/playbooks/CIS140/ssmdocs/CIS140_3.7.ts
+++ b/source/playbooks/CIS140/ssmdocs/CIS140_3.7.ts
@@ -3,8 +3,8 @@
 import { Construct } from 'constructs';
 import { PlaybookProps } from '../../SC/lib/control_runbooks-construct';
 import { ControlRunbookDocument } from '../../SC/ssmdocs/control_runbook';
-import { CloudTrail_2_ControlRunbookDocument } from '../../SC/ssmdocs/SC_CloudTrail.2';
+import { EnableCloudTrailEncryptionDocument } from '../../SC/ssmdocs/SC_CloudTrail.2';
 
 export function createControlRunbook(stage: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new CloudTrail_2_ControlRunbookDocument(stage, id, { ...props, controlId: '3.7' });
+  return new EnableCloudTrailEncryptionDocument(stage, id, { ...props, controlId: '3.7' });
 }

--- a/source/playbooks/CIS140/ssmdocs/CIS140_3.8.ts
+++ b/source/playbooks/CIS140/ssmdocs/CIS140_3.8.ts
@@ -3,8 +3,8 @@
 import { Construct } from 'constructs';
 import { PlaybookProps } from '../../SC/lib/control_runbooks-construct';
 import { ControlRunbookDocument } from '../../SC/ssmdocs/control_runbook';
-import { KMS_4_ControlRunbookDocument } from '../../SC/ssmdocs/SC_KMS.4';
+import { EnableKeyRotationDocument } from '../../SC/ssmdocs/SC_KMS.4';
 
 export function createControlRunbook(stage: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new KMS_4_ControlRunbookDocument(stage, id, { ...props, controlId: '3.8' });
+  return new EnableKeyRotationDocument(stage, id, { ...props, controlId: '3.8' });
 }

--- a/source/playbooks/CIS140/ssmdocs/CIS140_3.9.ts
+++ b/source/playbooks/CIS140/ssmdocs/CIS140_3.9.ts
@@ -3,8 +3,8 @@
 import { Construct } from 'constructs';
 import { PlaybookProps } from '../../SC/lib/control_runbooks-construct';
 import { ControlRunbookDocument } from '../../SC/ssmdocs/control_runbook';
-import { EC2_6_ControlRunbookDocument } from '../../SC/ssmdocs/SC_EC2.6';
+import { EnableVPCFlowLogsDocument } from '../../SC/ssmdocs/SC_EC2.6';
 
 export function createControlRunbook(stage: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new EC2_6_ControlRunbookDocument(stage, id, { ...props, controlId: '3.9' });
+  return new EnableVPCFlowLogsDocument(stage, id, { ...props, controlId: '3.9' });
 }

--- a/source/playbooks/CIS140/ssmdocs/CIS140_4.1.ts
+++ b/source/playbooks/CIS140/ssmdocs/CIS140_4.1.ts
@@ -3,8 +3,8 @@
 import { Construct } from 'constructs';
 import { PlaybookProps } from '../../SC/lib/control_runbooks-construct';
 import { ControlRunbookDocument } from '../../SC/ssmdocs/control_runbook';
-import { CloudWatch_1_ControlRunbookDocument } from '../../SC/ssmdocs/SC_CloudWatch.1';
+import { CreateLogMetricFilterAndAlarmDocument } from '../../SC/ssmdocs/SC_CloudWatch.1';
 
 export function createControlRunbook(stage: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new CloudWatch_1_ControlRunbookDocument(stage, id, { ...props, controlId: '4.1' });
+  return new CreateLogMetricFilterAndAlarmDocument(stage, id, { ...props, controlId: '4.1' });
 }

--- a/source/playbooks/CIS140/ssmdocs/CIS140_5.3.ts
+++ b/source/playbooks/CIS140/ssmdocs/CIS140_5.3.ts
@@ -3,8 +3,8 @@
 import { Construct } from 'constructs';
 import { PlaybookProps } from '../../SC/lib/control_runbooks-construct';
 import { ControlRunbookDocument } from '../../SC/ssmdocs/control_runbook';
-import { EC2_2_ControlRunbookDocument } from '../../SC/ssmdocs/SC_EC2.2';
+import { RemoveVPCDefaultSecurityGroupRulesDocument } from '../../SC/ssmdocs/SC_EC2.2';
 
 export function createControlRunbook(stage: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new EC2_2_ControlRunbookDocument(stage, id, { ...props, controlId: '5.3' });
+  return new RemoveVPCDefaultSecurityGroupRulesDocument(stage, id, { ...props, controlId: '5.3' });
 }

--- a/source/playbooks/SC/ssmdocs/SC_AutoScaling.1.ts
+++ b/source/playbooks/SC/ssmdocs/SC_AutoScaling.1.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { HardCodedString } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new AutoScaling_1_ControlRunbookDocument(scope, id, { ...props, controlId: 'AutoScaling.1' });
+  return new EnableAutoScalingGroupELBHealthCheckDocument(scope, id, { ...props, controlId: 'AutoScaling.1' });
 }
 
-class AutoScaling_1_ControlRunbookDocument extends ControlRunbookDocument {
+class EnableAutoScalingGroupELBHealthCheckDocument extends ControlRunbookDocument {
   constructor(stage: Construct, id: string, props: ControlRunbookProps) {
     super(stage, id, {
       ...props,

--- a/source/playbooks/SC/ssmdocs/SC_CloudFormation.1.ts
+++ b/source/playbooks/SC/ssmdocs/SC_CloudFormation.1.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { HardCodedString } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new CloudFormation_1_ControlRunbookDocument(scope, id, { ...props, controlId: 'CloudFormation.1' });
+  return new ConfigureSNSTopicForStackDocument(scope, id, { ...props, controlId: 'CloudFormation.1' });
 }
 
-class CloudFormation_1_ControlRunbookDocument extends ControlRunbookDocument {
+class ConfigureSNSTopicForStackDocument extends ControlRunbookDocument {
   constructor(stage: Construct, id: string, props: ControlRunbookProps) {
     super(stage, id, {
       ...props,

--- a/source/playbooks/SC/ssmdocs/SC_CloudTrail.1.ts
+++ b/source/playbooks/SC/ssmdocs/SC_CloudTrail.1.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { HardCodedString, StringVariable } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new CloudTrail_1_ControlRunbookDocument(scope, id, { ...props, controlId: 'CloudTrail.1' });
+  return new CreateCloudTrailMultiRegionTrailDocument(scope, id, { ...props, controlId: 'CloudTrail.1' });
 }
 
-export class CloudTrail_1_ControlRunbookDocument extends ControlRunbookDocument {
+export class CreateCloudTrailMultiRegionTrailDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     super(scope, id, {
       ...props,

--- a/source/playbooks/SC/ssmdocs/SC_CloudTrail.2.ts
+++ b/source/playbooks/SC/ssmdocs/SC_CloudTrail.2.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { HardCodedString, Input, StringVariable } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new CloudTrail_2_ControlRunbookDocument(scope, id, { ...props, controlId: 'CloudTrail.2' });
+  return new EnableCloudTrailEncryptionDocument(scope, id, { ...props, controlId: 'CloudTrail.2' });
 }
 
-export class CloudTrail_2_ControlRunbookDocument extends ControlRunbookDocument {
+export class EnableCloudTrailEncryptionDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     const docInputs = [
       Input.ofTypeString('KMSKeyArn', {

--- a/source/playbooks/SC/ssmdocs/SC_CloudTrail.4.ts
+++ b/source/playbooks/SC/ssmdocs/SC_CloudTrail.4.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { HardCodedString } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new CloudTrail_4_ControlRunbookDocument(scope, id, { ...props, controlId: 'CloudTrail.4' });
+  return new EnableCloudTrailLogFileValidationDocument(scope, id, { ...props, controlId: 'CloudTrail.4' });
 }
 
-export class CloudTrail_4_ControlRunbookDocument extends ControlRunbookDocument {
+export class EnableCloudTrailLogFileValidationDocument extends ControlRunbookDocument {
   constructor(stage: Construct, id: string, props: ControlRunbookProps) {
     super(stage, id, {
       ...props,

--- a/source/playbooks/SC/ssmdocs/SC_CloudTrail.5.ts
+++ b/source/playbooks/SC/ssmdocs/SC_CloudTrail.5.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { StringFormat, StringVariable } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new CloudTrail_5_ControlRunbookDocument(scope, id, { ...props, controlId: 'CloudTrail.5' });
+  return new EnableCloudTrailToCloudWatchLoggingDocument(scope, id, { ...props, controlId: 'CloudTrail.5' });
 }
 
-export class CloudTrail_5_ControlRunbookDocument extends ControlRunbookDocument {
+export class EnableCloudTrailToCloudWatchLoggingDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     super(scope, id, {
       ...props,

--- a/source/playbooks/SC/ssmdocs/SC_CloudTrail.6.ts
+++ b/source/playbooks/SC/ssmdocs/SC_CloudTrail.6.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { HardCodedString } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new CloudTrail_6_ControlRunbookDocument(scope, id, { ...props, controlId: 'CloudTrail.6' });
+  return new ConfigureS3BucketPublicAccessBlockDocument(scope, id, { ...props, controlId: 'CloudTrail.6' });
 }
 
-export class CloudTrail_6_ControlRunbookDocument extends ControlRunbookDocument {
+export class ConfigureS3BucketPublicAccessBlockDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     super(scope, id, {
       ...props,

--- a/source/playbooks/SC/ssmdocs/SC_CloudTrail.7.ts
+++ b/source/playbooks/SC/ssmdocs/SC_CloudTrail.7.ts
@@ -14,10 +14,10 @@ import {
 } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new CloudTrail_7_ControlRunbookDocument(scope, id, { ...props, controlId: 'CloudTrail.7' });
+  return new ConfigureS3BucketLoggingDocument(scope, id, { ...props, controlId: 'CloudTrail.7' });
 }
 
-export class CloudTrail_7_ControlRunbookDocument extends ControlRunbookDocument {
+export class ConfigureS3BucketLoggingDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     const resourceIdName = 'BucketName';
 

--- a/source/playbooks/SC/ssmdocs/SC_CloudWatch.1.ts
+++ b/source/playbooks/SC/ssmdocs/SC_CloudWatch.1.ts
@@ -18,7 +18,7 @@ import {
 } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new CloudWatch_1_ControlRunbookDocument(scope, id, {
+  return new CreateLogMetricFilterAndAlarmDocument(scope, id, {
     ...props,
     controlId: 'CloudWatch.1',
     otherControlIds: [
@@ -39,7 +39,7 @@ export function createControlRunbook(scope: Construct, id: string, props: Playbo
   });
 }
 
-export class CloudWatch_1_ControlRunbookDocument extends ControlRunbookDocument {
+export class CreateLogMetricFilterAndAlarmDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     const allowAnyRegex = String.raw`.*`;
     const docInputs: Input[] = [

--- a/source/playbooks/SC/ssmdocs/SC_CodeBuild.2.ts
+++ b/source/playbooks/SC/ssmdocs/SC_CodeBuild.2.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { HardCodedString } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new CodeBuild_2_ControlRunbookDocument(scope, id, { ...props, controlId: 'CodeBuild.2' });
+  return new ReplaceCodeBuildClearTextCredentialsDocument(scope, id, { ...props, controlId: 'CodeBuild.2' });
 }
 
-class CodeBuild_2_ControlRunbookDocument extends ControlRunbookDocument {
+class ReplaceCodeBuildClearTextCredentialsDocument extends ControlRunbookDocument {
   constructor(stage: Construct, id: string, props: ControlRunbookProps) {
     super(stage, id, {
       ...props,

--- a/source/playbooks/SC/ssmdocs/SC_Config.1.ts
+++ b/source/playbooks/SC/ssmdocs/SC_Config.1.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { HardCodedString, Input, StringVariable } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new Config_1_ControlRunbookDocument(scope, id, { ...props, controlId: 'Config.1' });
+  return new EnableAWSConfigDocument(scope, id, { ...props, controlId: 'Config.1' });
 }
 
-export class Config_1_ControlRunbookDocument extends ControlRunbookDocument {
+export class EnableAWSConfigDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     const docInputs: Input[] = [
       Input.ofTypeString('KMSKeyArn', {

--- a/source/playbooks/SC/ssmdocs/SC_EC2.1.ts
+++ b/source/playbooks/SC/ssmdocs/SC_EC2.1.ts
@@ -14,10 +14,10 @@ import {
 } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new EC2_1_ControlRunbookDocument(scope, id, { ...props, controlId: 'EC2.1' });
+  return new MakeEBSSnapshotsPrivateDocument(scope, id, { ...props, controlId: 'EC2.1' });
 }
 
-class EC2_1_ControlRunbookDocument extends ControlRunbookDocument {
+class MakeEBSSnapshotsPrivateDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     super(scope, id, {
       ...props,

--- a/source/playbooks/SC/ssmdocs/SC_EC2.13.ts
+++ b/source/playbooks/SC/ssmdocs/SC_EC2.13.ts
@@ -13,14 +13,14 @@ import {
 } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new EC2_13_ControlRunbookDocument(scope, id, {
+  return new DisablePublicAccessForSecurityGroupDocument(scope, id, {
     ...props,
     controlId: 'EC2.13',
     otherControlIds: ['EC2.14'],
   });
 }
 
-class EC2_13_ControlRunbookDocument extends ControlRunbookDocument {
+class DisablePublicAccessForSecurityGroupDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     const resourceIdName = 'GroupId';
 

--- a/source/playbooks/SC/ssmdocs/SC_EC2.15.ts
+++ b/source/playbooks/SC/ssmdocs/SC_EC2.15.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { HardCodedString } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new EC2_15_ControlRunbookDocument(scope, id, { ...props, controlId: 'EC2.15' });
+  return new DisablePublicIPAutoAssignDocument(scope, id, { ...props, controlId: 'EC2.15' });
 }
 
-export class EC2_15_ControlRunbookDocument extends ControlRunbookDocument {
+export class DisablePublicIPAutoAssignDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     super(scope, id, {
       ...props,

--- a/source/playbooks/SC/ssmdocs/SC_EC2.2.ts
+++ b/source/playbooks/SC/ssmdocs/SC_EC2.2.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { HardCodedString } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new EC2_2_ControlRunbookDocument(scope, id, { ...props, controlId: 'EC2.2' });
+  return new RemoveVPCDefaultSecurityGroupRulesDocument(scope, id, { ...props, controlId: 'EC2.2' });
 }
 
-export class EC2_2_ControlRunbookDocument extends ControlRunbookDocument {
+export class RemoveVPCDefaultSecurityGroupRulesDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     super(scope, id, {
       ...props,

--- a/source/playbooks/SC/ssmdocs/SC_EC2.6.ts
+++ b/source/playbooks/SC/ssmdocs/SC_EC2.6.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { HardCodedString, StringFormat, StringVariable } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new EC2_6_ControlRunbookDocument(scope, id, { ...props, controlId: 'EC2.6' });
+  return new EnableVPCFlowLogsDocument(scope, id, { ...props, controlId: 'EC2.6' });
 }
 
-export class EC2_6_ControlRunbookDocument extends ControlRunbookDocument {
+export class EnableVPCFlowLogsDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     super(scope, id, {
       ...props,

--- a/source/playbooks/SC/ssmdocs/SC_EC2.7.ts
+++ b/source/playbooks/SC/ssmdocs/SC_EC2.7.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { HardCodedString } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new EC2_7_ControlRunbookDocument(scope, id, { ...props, controlId: 'EC2.7' });
+  return new EnableEbsEncryptionByDefaultDocument(scope, id, { ...props, controlId: 'EC2.7' });
 }
 
-class EC2_7_ControlRunbookDocument extends ControlRunbookDocument {
+class EnableEbsEncryptionByDefaultDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     super(scope, id, {
       ...props,

--- a/source/playbooks/SC/ssmdocs/SC_IAM.3.ts
+++ b/source/playbooks/SC/ssmdocs/SC_IAM.3.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { DataTypeEnum, Input, Output, StringFormat, StringVariable } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new IAM_3_ControlRunbookDocument(scope, id, { ...props, controlId: 'IAM.3' });
+  return new RevokeUnrotatedKeysDocument(scope, id, { ...props, controlId: 'IAM.3' });
 }
 
-export class IAM_3_ControlRunbookDocument extends ControlRunbookDocument {
+export class RevokeUnrotatedKeysDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     const docInputs: Input[] = [
       Input.ofTypeString('MaxCredentialUsageAge', {

--- a/source/playbooks/SC/ssmdocs/SC_IAM.7.ts
+++ b/source/playbooks/SC/ssmdocs/SC_IAM.7.ts
@@ -6,14 +6,14 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { HardCodedBoolean, HardCodedNumber, HardCodedString } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new IAM_7_ControlRunbookDocument(scope, id, {
+  return new SetIAMPasswordPolicyDocument(scope, id, {
     ...props,
     controlId: 'IAM.7',
     otherControlIds: ['IAM.11', 'IAM.12', 'IAM.13', 'IAM.14', 'IAM.15', 'IAM.16', 'IAM.17'],
   });
 }
 
-export class IAM_7_ControlRunbookDocument extends ControlRunbookDocument {
+export class SetIAMPasswordPolicyDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     const remediationName = 'SetIAMPasswordPolicy';
 

--- a/source/playbooks/SC/ssmdocs/SC_IAM.8.ts
+++ b/source/playbooks/SC/ssmdocs/SC_IAM.8.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { DataTypeEnum, HardCodedString, Output, StringVariable } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new IAM_8_ControlRunbookDocument(scope, id, { ...props, controlId: 'IAM.8' });
+  return new RevokeUnusedIAMUserCredentialsDocument(scope, id, { ...props, controlId: 'IAM.8' });
 }
 
-export class IAM_8_ControlRunbookDocument extends ControlRunbookDocument {
+export class RevokeUnusedIAMUserCredentialsDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     const remediationName = 'RevokeUnusedIAMUserCredentials';
 

--- a/source/playbooks/SC/ssmdocs/SC_KMS.4.ts
+++ b/source/playbooks/SC/ssmdocs/SC_KMS.4.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { StringFormat, StringVariable } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new KMS_4_ControlRunbookDocument(scope, id, { ...props, controlId: 'KMS.4' });
+  return new EnableKeyRotationDocument(scope, id, { ...props, controlId: 'KMS.4' });
 }
 
-export class KMS_4_ControlRunbookDocument extends ControlRunbookDocument {
+export class EnableKeyRotationDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     const resourceIdName = 'KeyId';
 

--- a/source/playbooks/SC/ssmdocs/SC_Lambda.1.ts
+++ b/source/playbooks/SC/ssmdocs/SC_Lambda.1.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { StringFormat, StringVariable } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new Lambda_1_ControlRunbookDocument(scope, id, { ...props, controlId: 'Lambda.1' });
+  return new RemoveLambdaPublicAccessDocument(scope, id, { ...props, controlId: 'Lambda.1' });
 }
 
-class Lambda_1_ControlRunbookDocument extends ControlRunbookDocument {
+class RemoveLambdaPublicAccessDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     const resourceIdName = 'FunctionName';
 

--- a/source/playbooks/SC/ssmdocs/SC_RDS.1.ts
+++ b/source/playbooks/SC/ssmdocs/SC_RDS.1.ts
@@ -13,10 +13,10 @@ import {
 } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new RDS_1_ControlRunbookDocument(scope, id, { ...props, controlId: 'RDS.1' });
+  return new MakeRDSSnapshotPrivateDocument(scope, id, { ...props, controlId: 'RDS.1' });
 }
 
-class RDS_1_ControlRunbookDocument extends ControlRunbookDocument {
+class MakeRDSSnapshotPrivateDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     super(scope, id, {
       ...props,

--- a/source/playbooks/SC/ssmdocs/SC_RDS.13.ts
+++ b/source/playbooks/SC/ssmdocs/SC_RDS.13.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { DataTypeEnum, HardCodedString, Output, StringVariable } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new RDS_13_ControlRunbookDocument(scope, id, { ...props, controlId: 'RDS.13' });
+  return new EnableMinorVersionUpgradeOnRDSDBInstanceDocument(scope, id, { ...props, controlId: 'RDS.13' });
 }
 
-class RDS_13_ControlRunbookDocument extends ControlRunbookDocument {
+class EnableMinorVersionUpgradeOnRDSDBInstanceDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     super(scope, id, {
       ...props,

--- a/source/playbooks/SC/ssmdocs/SC_RDS.16.ts
+++ b/source/playbooks/SC/ssmdocs/SC_RDS.16.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { DataTypeEnum, HardCodedBoolean, HardCodedString, Output, StringVariable } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new RDS_16_ControlRunbookDocument(scope, id, { ...props, controlId: 'RDS.16' });
+  return new EnableCopyTagsToSnapshotOnRDSClusterDocument(scope, id, { ...props, controlId: 'RDS.16' });
 }
 
-class RDS_16_ControlRunbookDocument extends ControlRunbookDocument {
+class EnableCopyTagsToSnapshotOnRDSClusterDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     super(scope, id, {
       ...props,

--- a/source/playbooks/SC/ssmdocs/SC_RDS.2.ts
+++ b/source/playbooks/SC/ssmdocs/SC_RDS.2.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { DataTypeEnum, HardCodedString, Output, StringVariable } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new RDS_2_ControlRunbookDocument(scope, id, { ...props, controlId: 'RDS.2' });
+  return new DisablePublicAccessToRDSInstanceDocument(scope, id, { ...props, controlId: 'RDS.2' });
 }
 
-class RDS_2_ControlRunbookDocument extends ControlRunbookDocument {
+class DisablePublicAccessToRDSInstanceDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     super(scope, id, {
       ...props,

--- a/source/playbooks/SC/ssmdocs/SC_RDS.4.ts
+++ b/source/playbooks/SC/ssmdocs/SC_RDS.4.ts
@@ -15,10 +15,10 @@ import {
 } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new RDS_4_ControlRunbookDocument(scope, id, { ...props, controlId: 'RDS.4' });
+  return new EncryptRDSSnapshotDocument(scope, id, { ...props, controlId: 'RDS.4' });
 }
 
-class RDS_4_ControlRunbookDocument extends ControlRunbookDocument {
+class EncryptRDSSnapshotDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     const docInputs: Input[] = [
       Input.ofTypeString('KMSKeyId', {

--- a/source/playbooks/SC/ssmdocs/SC_RDS.5.ts
+++ b/source/playbooks/SC/ssmdocs/SC_RDS.5.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { DataTypeEnum, HardCodedBoolean, HardCodedString, Output, StringVariable } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new RDS_5_ControlRunbookDocument(scope, id, { ...props, controlId: 'RDS.5' });
+  return new EnableMultiAZOnRDSInstanceDocument(scope, id, { ...props, controlId: 'RDS.5' });
 }
 
-class RDS_5_ControlRunbookDocument extends ControlRunbookDocument {
+class EnableMultiAZOnRDSInstanceDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     super(scope, id, {
       ...props,

--- a/source/playbooks/SC/ssmdocs/SC_RDS.6.ts
+++ b/source/playbooks/SC/ssmdocs/SC_RDS.6.ts
@@ -14,10 +14,10 @@ import {
 } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new RDS_6_ControlRunbookDocument(scope, id, { ...props, controlId: 'RDS.6' });
+  return new EnableEnhancedMonitoringOnRDSInstanceDocument(scope, id, { ...props, controlId: 'RDS.6' });
 }
 
-class RDS_6_ControlRunbookDocument extends ControlRunbookDocument {
+class EnableEnhancedMonitoringOnRDSInstanceDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     super(scope, id, {
       ...props,

--- a/source/playbooks/SC/ssmdocs/SC_RDS.7.ts
+++ b/source/playbooks/SC/ssmdocs/SC_RDS.7.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { DataTypeEnum, HardCodedString, Output, StringVariable } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new RDS_7_ControlRunbookDocument(scope, id, { ...props, controlId: 'RDS.7' });
+  return new EnableRDSClusterDeletionProtectionDocument(scope, id, { ...props, controlId: 'RDS.7' });
 }
 
-class RDS_7_ControlRunbookDocument extends ControlRunbookDocument {
+class EnableRDSClusterDeletionProtectionDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     super(scope, id, {
       ...props,

--- a/source/playbooks/SC/ssmdocs/SC_RDS.8.ts
+++ b/source/playbooks/SC/ssmdocs/SC_RDS.8.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { DataTypeEnum, HardCodedBoolean, HardCodedString, Output, StringVariable } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new RDS_8_ControlRunbookDocument(scope, id, { ...props, controlId: 'RDS.8' });
+  return new EnableRDSInstanceDeletionProtectionDocument(scope, id, { ...props, controlId: 'RDS.8' });
 }
 
-class RDS_8_ControlRunbookDocument extends ControlRunbookDocument {
+class EnableRDSInstanceDeletionProtectionDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     super(scope, id, {
       ...props,

--- a/source/playbooks/SC/ssmdocs/SC_Redshift.1.ts
+++ b/source/playbooks/SC/ssmdocs/SC_Redshift.1.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { HardCodedString } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new Redshift_1_ControlRunbookDocument(scope, id, { ...props, controlId: 'Redshift.1' });
+  return new DisablePublicAccessToRedshiftClusterDocument(scope, id, { ...props, controlId: 'Redshift.1' });
 }
 
-class Redshift_1_ControlRunbookDocument extends ControlRunbookDocument {
+class DisablePublicAccessToRedshiftClusterDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     super(scope, id, {
       ...props,

--- a/source/playbooks/SC/ssmdocs/SC_Redshift.3.ts
+++ b/source/playbooks/SC/ssmdocs/SC_Redshift.3.ts
@@ -17,10 +17,10 @@ import {
 } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new Redshift_3_ControlRunbookDocument(scope, id, { ...props, controlId: 'Redshift.3' });
+  return new EnableAutomaticSnapshotsOnRedshiftClusterDocument(scope, id, { ...props, controlId: 'Redshift.3' });
 }
 
-class Redshift_3_ControlRunbookDocument extends ControlRunbookDocument {
+class EnableAutomaticSnapshotsOnRedshiftClusterDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     super(scope, id, {
       ...props,

--- a/source/playbooks/SC/ssmdocs/SC_Redshift.4.ts
+++ b/source/playbooks/SC/ssmdocs/SC_Redshift.4.ts
@@ -21,10 +21,10 @@ import {
 } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new Redshift_4_ControlRunbookDocument(scope, id, { ...props, controlId: 'Redshift.4' });
+  return new EnableRedshiftClusterAuditLoggingDocument(scope, id, { ...props, controlId: 'Redshift.4' });
 }
 
-class Redshift_4_ControlRunbookDocument extends ControlRunbookDocument {
+class EnableRedshiftClusterAuditLoggingDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     super(scope, id, {
       ...props,

--- a/source/playbooks/SC/ssmdocs/SC_Redshift.6.ts
+++ b/source/playbooks/SC/ssmdocs/SC_Redshift.6.ts
@@ -17,10 +17,10 @@ import {
 } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new Redshift_6_ControlRunbookDocument(scope, id, { ...props, controlId: 'Redshift.6' });
+  return new EnableAutomaticVersionUpgradeOnRedshiftClusterDocument(scope, id, { ...props, controlId: 'Redshift.6' });
 }
 
-class Redshift_6_ControlRunbookDocument extends ControlRunbookDocument {
+class EnableAutomaticVersionUpgradeOnRedshiftClusterDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     super(scope, id, {
       ...props,

--- a/source/playbooks/SC/ssmdocs/SC_S3.1.ts
+++ b/source/playbooks/SC/ssmdocs/SC_S3.1.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { HardCodedBoolean, HardCodedString, StringVariable } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new S3_1_ControlRunbookDocument(scope, id, { ...props, controlId: 'S3.1' });
+  return new ConfigureS3PublicAccessBlockDocument(scope, id, { ...props, controlId: 'S3.1' });
 }
 
-class S3_1_ControlRunbookDocument extends ControlRunbookDocument {
+class ConfigureS3PublicAccessBlockDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     super(scope, id, {
       ...props,

--- a/source/playbooks/SC/ssmdocs/SC_S3.2.ts
+++ b/source/playbooks/SC/ssmdocs/SC_S3.2.ts
@@ -6,14 +6,14 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { HardCodedBoolean, HardCodedString, StringVariable } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new S3_2_ControlRunbookDocument(scope, id, {
+  return new ConfigureS3BucketPublicAccessBlockDocument(scope, id, {
     ...props,
     controlId: 'S3.2',
     otherControlIds: ['S3.3', 'S3.8'],
   });
 }
 
-export class S3_2_ControlRunbookDocument extends ControlRunbookDocument {
+export class ConfigureS3BucketPublicAccessBlockDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     super(scope, id, {
       ...props,

--- a/source/playbooks/SC/ssmdocs/SC_S3.4.ts
+++ b/source/playbooks/SC/ssmdocs/SC_S3.4.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { Input, StringFormat, StringVariable } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new S3_4_ControlRunbookDocument(scope, id, { ...props, controlId: 'S3.4' });
+  return new EnableDefaultEncryptionS3Document(scope, id, { ...props, controlId: 'S3.4' });
 }
 
-export class S3_4_ControlRunbookDocument extends ControlRunbookDocument {
+export class EnableDefaultEncryptionS3Document extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     const docInputs: Input[] = [
       Input.ofTypeString('KmsKeyAlias', {

--- a/source/playbooks/SC/ssmdocs/SC_S3.5.ts
+++ b/source/playbooks/SC/ssmdocs/SC_S3.5.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { HardCodedString, StringVariable } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new S3_5_ControlRunbookDocument(scope, id, { ...props, controlId: 'S3.5' });
+  return new SetSSLBucketPolicyDocument(scope, id, { ...props, controlId: 'S3.5' });
 }
 
-export class S3_5_ControlRunbookDocument extends ControlRunbookDocument {
+export class SetSSLBucketPolicyDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     super(scope, id, {
       ...props,

--- a/source/playbooks/SC/ssmdocs/SC_S3.6.ts
+++ b/source/playbooks/SC/ssmdocs/SC_S3.6.ts
@@ -17,10 +17,10 @@ import {
 } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new S3_6_ControlRunbookDocument(scope, id, { ...props, controlId: 'S3.6' });
+  return new S3BlockDenylistDocument(scope, id, { ...props, controlId: 'S3.6' });
 }
 
-class S3_6_ControlRunbookDocument extends ControlRunbookDocument {
+class S3BlockDenylistDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     super(scope, id, {
       ...props,

--- a/source/playbooks/SC/ssmdocs/SC_SNS.1.ts
+++ b/source/playbooks/SC/ssmdocs/SC_SNS.1.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { HardCodedString, Input, StringVariable } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new SNS_1_ControlRunbookDocument(scope, id, { ...props, controlId: 'SNS.1' });
+  return new EnableEncryptionForSNSTopicDocument(scope, id, { ...props, controlId: 'SNS.1' });
 }
 
-export class SNS_1_ControlRunbookDocument extends ControlRunbookDocument {
+export class EnableEncryptionForSNSTopicDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     const docInputs = [
       Input.ofTypeString('KmsKeyArn', {

--- a/source/playbooks/SC/ssmdocs/SC_SNS.2.ts
+++ b/source/playbooks/SC/ssmdocs/SC_SNS.2.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { HardCodedString, Input, StringVariable } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new SNS_2_ControlRunbookDocument(scope, id, { ...props, controlId: 'SNS.2' });
+  return new EnableDeliveryLoggingForSNSTopicDocument(scope, id, { ...props, controlId: 'SNS.2' });
 }
 
-export class SNS_2_ControlRunbookDocument extends ControlRunbookDocument {
+export class EnableDeliveryLoggingForSNSTopicDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     const docInputs = [
       Input.ofTypeString('LoggingRole', {

--- a/source/playbooks/SC/ssmdocs/SC_SQS.1.ts
+++ b/source/playbooks/SC/ssmdocs/SC_SQS.1.ts
@@ -6,10 +6,10 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { HardCodedString, Input, StringVariable } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new SQS_1_ControlRunbookDocument(scope, id, { ...props, controlId: 'SQS.1' });
+  return new EnableEncryptionForSQSQueueDocument(scope, id, { ...props, controlId: 'SQS.1' });
 }
 
-export class SQS_1_ControlRunbookDocument extends ControlRunbookDocument {
+export class EnableEncryptionForSQSQueueDocument extends ControlRunbookDocument {
   constructor(scope: Construct, id: string, props: ControlRunbookProps) {
     const docInputs = [
       Input.ofTypeString('KmsKeyArn', {


### PR DESCRIPTION
*Description of changes:*
Changed ControlRunbookDocument names to their remediations + document in order to meet SonarQube requirements.
This change will remove 43 minor bugs and code smells.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.