### PR TITLE
Speed up build by removing unneeded steps

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,25 +1,26 @@
 version: 0.2
-
 phases:
   install:
     runtime-versions:
       nodejs: 16
       python: 3.10
     commands:
-      - python3 -m pip install -U pip setuptools virtualenv
-      - npm install --location=global npm@latest
+    - python3 -m pip install -U pip setuptools virtualenv
+    - npm install --location=global npm@latest
   build:
     commands:
-      - cd ./deployment
-      - ./build-s3-dist.sh -b $DIST_OUTPUT_BUCKET -v $VERSION
-      - ./build-open-source-dist.sh $SOLUTION_NAME
-      - ./run-unit-tests.sh
+    - cd source
+    - npm ci
+    - cd ../deployment
+    - ./build-s3-dist.sh -b $DIST_OUTPUT_BUCKET -v $VERSION
+    - ./build-open-source-dist.sh $SOLUTION_NAME
+    - ./run-unit-tests.sh
 artifacts:
   files:
-    - .gitignore
-    - deployment/**/*
-    - source/**/*
-    - CHANGELOG.md
-    - buildspec.yml
-    - NOTICE.txt
-    - sonar-project.properties
+  - .gitignore
+  - deployment/**/*
+  - source/**/*
+  - CHANGELOG.md
+  - buildspec.yml
+  - NOTICE.txt
+  - sonar-project.properties


### PR DESCRIPTION
- don't copy entire source to temp dir
- copy synth-ed json templates rather than re-synth-ing for yaml
- add npm ci to buildspec

This takes the build from ~2m to ~45s. Tested with a deploy of the admin stack.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.