### PR TITLE
Add wait provider

### DIFF
--- a/deployment/build-s3-dist.sh
+++ b/deployment/build-s3-dist.sh
@@ -134,10 +134,12 @@ main() {
 
 	pushd "$temp_work_dir"/source/solution_deploy/source
 	zip ${build_dist_dir}/lambda/action_target_provider.zip action_target_provider.py cfnresponse.py
-	# Copy LambdaLayer modules in preparation for running tests
-	# These are not packaged with the Lambda
-	cp ../../LambdaLayers/*.py .
 	popd
+
+	header "[Pack] Wait Provider Lambda"
+
+	pushd "$temp_work_dir"/source/solution_deploy/source
+	zip ${build_dist_dir}/lambda/wait_provider.zip wait_provider.py cfnresponse.py
 
 	header "[Pack] Orchestrator Lambdas"
 
@@ -147,9 +149,6 @@ main() {
 			zip "$build_dist_dir"/lambda/"$file".zip "$file"
 		fi
 	done
-	# Copy LambdaLayer modules in preparation for running tests
-	# These are not packaged with the Lambda
-	cp ../LambdaLayers/*.py .
 	popd
 
 	header "[Create] Playbooks"

--- a/source/solution_deploy/source/test/test_wait_provider.py
+++ b/source/solution_deploy/source/test/test_wait_provider.py
@@ -1,0 +1,51 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Test the custom resource provider for arbitrary wait"""
+
+from unittest.mock import ANY, patch
+from wait_provider import lambda_handler
+from cfnresponse import SUCCESS
+
+
+def get_event(create, update, delete, request_type):
+    return {
+        "ResourceProperties": {
+            "CreateIntervalSeconds": str(create),
+            "UpdateIntervalSeconds": str(update),
+            "DeleteIntervalSeconds": str(delete),
+        },
+        "RequestType": request_type,
+    }
+
+
+@patch("cfnresponse.send")
+@patch("wait_provider.wait_seconds")
+def test_wait_create(mock_wait, mock_cfnresponse):
+    """Create request waits for the correct amount of time"""
+    create = 1.0
+    event = get_event(create, 2.0, 3.0, "Create")
+    lambda_handler(event, {})
+    mock_wait.assert_called_once_with(create)
+    mock_cfnresponse.assert_called_once_with(event, {}, SUCCESS, ANY)
+
+
+@patch("cfnresponse.send")
+@patch("wait_provider.wait_seconds")
+def test_wait_update(mock_wait, mock_cfnresponse):
+    """Update request waits for the correct amount of time"""
+    update = 2.0
+    event = get_event(1.0, update, 3.0, "Update")
+    lambda_handler(event, {})
+    mock_wait.assert_called_once_with(update)
+    mock_cfnresponse.assert_called_once_with(event, {}, SUCCESS, ANY)
+
+
+@patch("cfnresponse.send")
+@patch("wait_provider.wait_seconds")
+def test_wait_delete(mock_wait, mock_cfnresponse):
+    """Delete request waits for the correct amount of time"""
+    delete = 3.0
+    event = get_event(1.0, 2.0, delete, "Delete")
+    lambda_handler(event, {})
+    mock_wait.assert_called_once_with(delete)
+    mock_cfnresponse.assert_called_once_with(event, {}, SUCCESS, ANY)

--- a/source/solution_deploy/source/wait_provider.py
+++ b/source/solution_deploy/source/wait_provider.py
@@ -1,0 +1,59 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Custom resource provider that waits for a specified time, then returns success"""
+
+from os import getenv
+import json
+from logging import basicConfig, getLevelName, getLogger
+from time import sleep
+import cfnresponse
+
+basicConfig(level=getLevelName(getenv("LOG_LEVEL", "WARNING")))
+logger = getLogger(__name__)
+
+
+class InvalidRequest(Exception):
+    """Invalid wait request"""
+
+
+def wait_seconds(wait: float):
+    """Wait for `wait` seconds"""
+    sleep(wait)
+
+
+def lambda_handler(event, context):
+    """Handle the Lambda request for a wait"""
+    response_data = {}
+
+    try:
+        properties = event.get("ResourceProperties", {})
+        logger.info(json.dumps(properties))
+
+        wait_create = float(properties["CreateIntervalSeconds"])
+        wait_update = float(properties["UpdateIntervalSeconds"])
+        wait_delete = float(properties["DeleteIntervalSeconds"])
+
+        request_type = event["RequestType"]
+        if request_type == "Create":
+            logger.info("Create, waiting %f seconds", wait_create)
+            wait_seconds(wait_create)
+        elif request_type == "Update":
+            logger.info("Update, waiting %f seconds", wait_update)
+            wait_seconds(wait_update)
+        elif request_type == "Delete":
+            logger.info("Delete, waiting %f seconds", wait_delete)
+            wait_seconds(wait_delete)
+        else:
+            raise InvalidRequest(f"Invalid request type {request_type}")
+        logger.info("Success")
+
+        cfnresponse.send(event, context, cfnresponse.SUCCESS, response_data)
+    except Exception as exc:
+        logger.exception(exc)
+        cfnresponse.send(
+            event,
+            context,
+            cfnresponse.FAILED,
+            response_data,
+            reason=str(exc),
+        )


### PR DESCRIPTION
- Add custom resource provider for arbitrary wait

This change is to support future changes which will wait between deployments of SSM documents to avoid rate-limiting errors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.