### PR TITLE
Unfreeze testing requirements

### DIFF
--- a/deployment/testing_requirements.txt
+++ b/deployment/testing_requirements.txt
@@ -1,7 +1,7 @@
-pytest==7.2.1
-pytest-cov==4.0.0
-pytest-env==0.8.1
-pytest-mock==3.10.0
+pytest
+pytest-cov
+pytest-env
+pytest-mock
 ## boto3 and botocore should match Lambda runtime: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
 boto3==1.20.32
 botocore==1.23.32
@@ -11,11 +11,3 @@ python-dateutil==2.8.2
 s3transfer==0.5.2
 six==1.16.0
 urllib3==1.26.9
-## The following requirements were added by pip freeze:
-attrs==22.2.0
-coverage==7.1.0
-exceptiongroup==1.1.0
-iniconfig==2.0.0
-packaging==23.0
-pluggy==1.0.0
-tomli==2.0.1


### PR DESCRIPTION
- upgrade and unfreeze python testing dependencies - there is no reason to freeze these for local testing
- remove transitive dependency freezes except those frozen to match lambda runtime

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.