### PR TITLE
Add wait provider lambda cdk

### DIFF
--- a/deployment/build-s3-dist.sh
+++ b/deployment/build-s3-dist.sh
@@ -124,7 +124,7 @@ main() {
 
 	header "[Pack] Wait Provider Lambda"
 
-	pushd "$temp_work_dir"/source/solution_deploy/source
+	pushd "$source_dir"/solution_deploy/source
 	zip ${build_dist_dir}/lambda/wait_provider.zip wait_provider.py cfnresponse.py
 
 	header "[Pack] Orchestrator Lambdas"

--- a/source/lib/__snapshots__/member-stack.test.ts.snap
+++ b/source/lib/__snapshots__/member-stack.test.ts.snap
@@ -466,6 +466,12 @@ exports[`member stack snapshot matches 1`] = `
           "SecHubAdminAccount": {
             "Ref": "SecHubAdminAccount",
           },
+          "WaitProviderServiceToken": {
+            "Fn::GetAtt": [
+              "WaitProviderFunction3D90ED36",
+              "Arn",
+            ],
+          },
         },
         "TemplateURL": {
           "Fn::Join": [
@@ -506,6 +512,12 @@ exports[`member stack snapshot matches 1`] = `
         "Parameters": {
           "SecHubAdminAccount": {
             "Ref": "SecHubAdminAccount",
+          },
+          "WaitProviderServiceToken": {
+            "Fn::GetAtt": [
+              "WaitProviderFunction3D90ED36",
+              "Arn",
+            ],
           },
         },
         "TemplateURL": {
@@ -548,6 +560,12 @@ exports[`member stack snapshot matches 1`] = `
           "SecHubAdminAccount": {
             "Ref": "SecHubAdminAccount",
           },
+          "WaitProviderServiceToken": {
+            "Fn::GetAtt": [
+              "WaitProviderFunction3D90ED36",
+              "Arn",
+            ],
+          },
         },
         "TemplateURL": {
           "Fn::Join": [
@@ -588,6 +606,12 @@ exports[`member stack snapshot matches 1`] = `
         "Parameters": {
           "SecHubAdminAccount": {
             "Ref": "SecHubAdminAccount",
+          },
+          "WaitProviderServiceToken": {
+            "Fn::GetAtt": [
+              "WaitProviderFunction3D90ED36",
+              "Arn",
+            ],
           },
         },
         "TemplateURL": {
@@ -630,6 +654,12 @@ exports[`member stack snapshot matches 1`] = `
           "SecHubAdminAccount": {
             "Ref": "SecHubAdminAccount",
           },
+          "WaitProviderServiceToken": {
+            "Fn::GetAtt": [
+              "WaitProviderFunction3D90ED36",
+              "Arn",
+            ],
+          },
         },
         "TemplateURL": {
           "Fn::Join": [
@@ -662,6 +692,14 @@ exports[`member stack snapshot matches 1`] = `
     "RunbookStackNoRolesNestedStackRunbookStackNoRolesNestedStackResource37E060FD": {
       "DeletionPolicy": "Delete",
       "Properties": {
+        "Parameters": {
+          "WaitProviderServiceToken": {
+            "Fn::GetAtt": [
+              "WaitProviderFunction3D90ED36",
+              "Arn",
+            ],
+          },
+        },
         "TemplateURL": {
           "Fn::Join": [
             "",
@@ -977,6 +1015,93 @@ exports[`member stack snapshot matches 1`] = `
         },
       },
       "Type": "AWS::SSM::Parameter",
+    },
+    "WaitProviderFunction3D90ED36": {
+      "DependsOn": [
+        "WaitProviderRole83B0295F",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Fn::Join": [
+              "",
+              [
+                "sharrbukkit-",
+                {
+                  "Ref": "AWS::Region",
+                },
+              ],
+            ],
+          },
+          "S3Key": "my-solution-tmn/v9.9.9/lambda/wait_provider.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "LOG_LEVEL": "WARNING",
+          },
+        },
+        "Handler": "wait_provider.lambda_handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "WaitProviderRole83B0295F",
+            "Arn",
+          ],
+        },
+        "Runtime": "python3.9",
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "WaitProviderRole83B0295F": {
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Resource * is needed for CloudWatch Logs policies used on Lambda functions.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "cloudwatch:PutMetricData",
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+                {
+                  "Action": [
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "LambdaPolicy",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
     },
   },
 }

--- a/source/lib/member-stack.ts
+++ b/source/lib/member-stack.ts
@@ -42,8 +42,11 @@ export class MemberStack extends Stack {
       solutionVersion: props.solutionVersion,
     });
 
+    const waitProvider = new WaitProvider()
+
     const nestedStackNoRoles = nestedStackFactory.addNestedStack('RunbookStackNoRoles', {
       templateRelativePath: 'aws-sharr-remediations.template',
+      parameters: { WaitProviderServiceToken: }
     });
 
     this.nestedStacks.push(nestedStackNoRoles as Stack);

--- a/source/lib/member-stack.ts
+++ b/source/lib/member-stack.ts
@@ -10,6 +10,7 @@ import { MemberLogGroup } from './member/log-group';
 import { MemberBucketEncryption } from './member/bucket-encryption';
 import { MemberVersion } from './member/version';
 import { SerializedNestedStackFactory } from './cdk-helper/nested-stack';
+import { WaitProvider } from './wait-provider';
 
 export interface SolutionProps extends StackProps {
   solutionId: string;
@@ -42,11 +43,16 @@ export class MemberStack extends Stack {
       solutionVersion: props.solutionVersion,
     });
 
-    const waitProvider = new WaitProvider()
+    const waitProvider = WaitProvider.fromLambdaProps(this, 'WaitProvider', {
+      solutionVersion: props.solutionVersion,
+      solutionTMN: props.solutionTMN,
+      solutionDistBucket: props.solutionDistBucket,
+      runtimePython: props.runtimePython,
+    });
 
     const nestedStackNoRoles = nestedStackFactory.addNestedStack('RunbookStackNoRoles', {
       templateRelativePath: 'aws-sharr-remediations.template',
-      parameters: { WaitProviderServiceToken: }
+      parameters: { WaitProviderServiceToken: waitProvider.serviceToken },
     });
 
     this.nestedStacks.push(nestedStackNoRoles as Stack);
@@ -72,7 +78,10 @@ export class MemberStack extends Stack {
 
         const nestedStack = nestedStackFactory.addNestedStack(`PlaybookMemberStack${file}`, {
           templateRelativePath: `playbooks/${templateFile}`,
-          parameters: { SecHubAdminAccount: adminAccountParam.value },
+          parameters: {
+            SecHubAdminAccount: adminAccountParam.value,
+            WaitProviderServiceToken: waitProvider.serviceToken,
+          },
           condition: new CfnCondition(this, `load${file}Cond`, {
             expression: Fn.conditionEquals(memberStackOption, 'yes'),
           }),

--- a/source/lib/remediation_runbook-stack.ts
+++ b/source/lib/remediation_runbook-stack.ts
@@ -23,6 +23,7 @@ import { RunbookFactory } from './runbook_factory';
 import { SNS2DeliveryStatusLoggingRole } from './sns2-remediation-resources';
 import { SsmRole } from './ssmplaybook';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
+import { CfnParameter } from 'aws-cdk-lib';
 
 export interface MemberRoleStackProps extends cdk.StackProps {
   readonly solutionId: string;
@@ -65,6 +66,8 @@ export interface StackProps extends cdk.StackProps {
 export class RemediationRunbookStack extends cdk.Stack {
   constructor(scope: cdk.App, id: string, props: StackProps) {
     super(scope, id, props);
+
+    new CfnParameter(this, 'WaitProviderServiceToken');
 
     let ssmdocs = '';
     if (props.ssmdocs == undefined) {

--- a/source/lib/sharrplaybook-construct.ts
+++ b/source/lib/sharrplaybook-construct.ts
@@ -12,7 +12,7 @@ import { Trigger } from './ssmplaybook';
 import AdminAccountParam from './admin-account-param';
 import { RunbookFactory } from './runbook_factory';
 import { Construct } from 'constructs';
-import { StackProps } from 'aws-cdk-lib';
+import { CfnParameter, StackProps } from 'aws-cdk-lib';
 
 export interface IControl {
   control: string;
@@ -119,6 +119,8 @@ export class PlaybookMemberStack extends cdk.Stack {
     }
 
     new AdminAccountParam(this, 'AdminAccountParameter');
+
+    new CfnParameter(this, 'WaitProviderServiceToken');
 
     const processRemediation = function (controlSpec: IControl): void {
       // Create the ssm automation document only if this is not a remapped control

--- a/source/lib/wait-provider.ts
+++ b/source/lib/wait-provider.ts
@@ -1,0 +1,92 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { CustomResource, Duration, Stack } from 'aws-cdk-lib';
+import { PolicyDocument, PolicyStatement, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { Code, Function, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { Bucket } from 'aws-cdk-lib/aws-s3';
+import { NagSuppressions } from 'cdk-nag';
+import { Construct } from 'constructs';
+
+export interface WaitProviderProps {
+  readonly serviceToken: string;
+}
+
+export interface WaitProviderLambdaProps {
+  readonly solutionVersion: string;
+  readonly solutionTMN: string;
+  readonly solutionDistBucket: string;
+  readonly runtimePython: Runtime;
+}
+
+export interface WaitResourceProps {
+  readonly createIntervalSeconds: number;
+  readonly updateIntervalSeconds: number;
+  readonly deleteIntervalSeconds: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly extraResourceProps?: { [_: string]: any };
+}
+
+export class WaitProvider extends Construct {
+  readonly serviceToken: string;
+
+  protected constructor(scope: Construct, id: string, props: WaitProviderProps) {
+    super(scope, id);
+
+    this.serviceToken = props.serviceToken;
+  }
+
+  createWaitResource(scope: Construct, id: string, props: WaitResourceProps): CustomResource {
+    return new CustomResource(scope, id, {
+      serviceToken: this.serviceToken,
+      resourceType: 'Custom::Wait',
+      properties: {
+        ...props.extraResourceProps,
+        CreateIntervalSeconds: props.createIntervalSeconds,
+        UpdateIntervalSeconds: props.updateIntervalSeconds,
+        DeleteIntervalSeconds: props.deleteIntervalSeconds,
+      },
+    });
+  }
+
+  static fromServiceToken(scope: Construct, id: string, serviceToken: string): WaitProvider {
+    return new WaitProvider(scope, id, { serviceToken });
+  }
+
+  static fromLambdaProps(scope: Construct, id: string, props: WaitProviderLambdaProps): WaitProvider {
+    const policyDocument = new PolicyDocument({
+      statements: [
+        new PolicyStatement({ actions: ['cloudwatch:PutMetricData'], resources: ['*'] }),
+        new PolicyStatement({
+          actions: ['logs:CreateLogGroup', 'logs:CreateLogStream', 'logs:PutLogEvents'],
+          resources: ['*'],
+        }),
+      ],
+    });
+
+    const role = new Role(scope, `${id}Role`, {
+      assumedBy: new ServicePrincipal('lambda.amazonaws.com'),
+      inlinePolicies: { LambdaPolicy: policyDocument },
+    });
+
+    NagSuppressions.addResourceSuppressions(role, [
+      {
+        id: 'AwsSolutions-IAM5',
+        reason: 'Resource * is needed for CloudWatch Logs policies used on Lambda functions.',
+      },
+    ]);
+
+    const lambdaFunction = new Function(scope, `${id}Function`, {
+      role,
+      runtime: props.runtimePython,
+      code: Code.fromBucket(
+        Bucket.fromBucketName(scope, 'Bucket', `${props.solutionDistBucket}-${Stack.of(scope).region}`),
+        props.solutionTMN + '/' + props.solutionVersion + '/lambda/wait_provider.zip'
+      ),
+      handler: 'wait_provider.lambda_handler',
+      environment: { LOG_LEVEL: 'WARNING' },
+      timeout: Duration.minutes(15),
+    });
+
+    return new WaitProvider(scope, id, { serviceToken: lambdaFunction.functionArn });
+  }
+}

--- a/source/playbooks/AFSBP/test/__snapshots__/afsbp_stack.test.ts.snap
+++ b/source/playbooks/AFSBP/test/__snapshots__/afsbp_stack.test.ts.snap
@@ -62,6 +62,9 @@ exports[`Member Stack - AFSBP 1`] = `
       "Description": "Admin account number",
       "Type": "String",
     },
+    "WaitProviderServiceToken": {
+      "Type": "String",
+    },
   },
   "Resources": {
     "ControlAFSBPEC21": {

--- a/source/playbooks/CIS120/test/__snapshots__/cis_stack.test.ts.snap
+++ b/source/playbooks/CIS120/test/__snapshots__/cis_stack.test.ts.snap
@@ -441,6 +441,9 @@ exports[`default stack 2`] = `
       "Description": "Admin account number",
       "Type": "String",
     },
+    "WaitProviderServiceToken": {
+      "Type": "String",
+    },
   },
   "Resources": {
     "ControlCIS13": {

--- a/source/playbooks/CIS140/lib/cis140_playbook-construct.ts
+++ b/source/playbooks/CIS140/lib/cis140_playbook-construct.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Stack, App, StackProps } from 'aws-cdk-lib';
+import { Stack, App, StackProps, CfnParameter } from 'aws-cdk-lib';
 import { ControlRunbooks } from './control_runbooks-construct';
 import AdminAccountParam from '../../../lib/admin-account-param';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
@@ -28,6 +28,8 @@ export class CIS140PlaybookMemberStack extends Stack {
 
     // Not used, but required by top-level member stack
     new AdminAccountParam(this, 'AdminAccountParameter');
+
+    new CfnParameter(this, 'WaitProviderServiceToken');
 
     const controlRunbooks = new ControlRunbooks(this, 'ControlRunbooks', {
       standardShortName: props.securityStandard,

--- a/source/playbooks/CIS140/test/__snapshots__/cis_stack.test.ts.snap
+++ b/source/playbooks/CIS140/test/__snapshots__/cis_stack.test.ts.snap
@@ -441,6 +441,9 @@ exports[`default stack 2`] = `
       "Description": "Admin account number",
       "Type": "String",
     },
+    "WaitProviderServiceToken": {
+      "Type": "String",
+    },
   },
   "Resources": {
     "ControlCIS13": {

--- a/source/playbooks/NEWPLAYBOOK/test/__snapshots__/newplaybook_stack.test.ts.snap
+++ b/source/playbooks/NEWPLAYBOOK/test/__snapshots__/newplaybook_stack.test.ts.snap
@@ -374,6 +374,9 @@ exports[`member stack 1`] = `
       "Description": "Admin account number",
       "Type": "String",
     },
+    "WaitProviderServiceToken": {
+      "Type": "String",
+    },
   },
   "Resources": {
     "ControlNPBRDS6": {

--- a/source/playbooks/PCI321/test/__snapshots__/pci321_stack.test.ts.snap
+++ b/source/playbooks/PCI321/test/__snapshots__/pci321_stack.test.ts.snap
@@ -408,6 +408,9 @@ exports[`default stack 2`] = `
       "Description": "Admin account number",
       "Type": "String",
     },
+    "WaitProviderServiceToken": {
+      "Type": "String",
+    },
   },
   "Resources": {
     "ControlPCIPCIAutoScaling1": {

--- a/source/playbooks/SC/lib/security_controls_playbook-construct.ts
+++ b/source/playbooks/SC/lib/security_controls_playbook-construct.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Stack, CfnMapping, App, StackProps } from 'aws-cdk-lib';
+import { Stack, CfnMapping, App, StackProps, CfnParameter } from 'aws-cdk-lib';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import { Trigger } from '../../../lib/ssmplaybook';
 import { Construct } from 'constructs';
@@ -95,6 +95,8 @@ export class SecurityControlsPlaybookMemberStack extends Stack {
 
     // Not used, but required by top-level member stack
     new AdminAccountParam(this, 'AdminAccountParameter');
+
+    new CfnParameter(this, 'WaitProviderServiceToken');
 
     const controlRunbooks = new ControlRunbooks(this, 'ControlRunbooks', {
       standardShortName: props.securityStandard,

--- a/source/playbooks/SC/test/__snapshots__/security_controls_stack.test.ts.snap
+++ b/source/playbooks/SC/test/__snapshots__/security_controls_stack.test.ts.snap
@@ -1080,6 +1080,9 @@ exports[`member stack 1`] = `
       "Description": "Admin account number",
       "Type": "String",
     },
+    "WaitProviderServiceToken": {
+      "Type": "String",
+    },
   },
   "Resources": {
     "ControlRunbooksAutoScaling1BA109277": {

--- a/source/test/__snapshots__/runbook_stack.test.ts.snap
+++ b/source/test/__snapshots__/runbook_stack.test.ts.snap
@@ -227,6 +227,11 @@ exports[`Global Roles Stack 1`] = `
 exports[`Regional Documents 1`] = `
 {
   "Description": "test;",
+  "Parameters": {
+    "WaitProviderServiceToken": {
+      "Type": "String",
+    },
+  },
   "Resources": {
     "ASRConfigureS3BucketPublicAccessBlock": {
       "Properties": {


### PR DESCRIPTION
- add wait provider lambda cdk
- add CFN parameter so wait provider is available in all nested member stacks

Member stack deploys successfully.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.