### PR TITLE
Changed Custom Action Name and fixed NestedStack logical IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reduced duplicate code
 - Updated CIS playbook to Orchestrator architecture
 - Single Orchestrator deployment to enable multi-standard remediation with a single click
-- Custom Actions now consolidated to one: "Remediate with ASR"
+- Custom Actions now consolidated to one: "Remediate with SHARR"
 
 ### Removed
 - AWS Service Catalog for Playbook deployment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reduced duplicate code
 - Updated CIS playbook to Orchestrator architecture
 - Single Orchestrator deployment to enable multi-standard remediation with a single click
-- Custom Actions now consolidated to one: "Remediate with SHARR"
+- Custom Actions now consolidated to one: "Remediate with ASR"
 
 ### Removed
 - AWS Service Catalog for Playbook deployment

--- a/source/lib/__snapshots__/member-stack.test.ts.snap
+++ b/source/lib/__snapshots__/member-stack.test.ts.snap
@@ -459,7 +459,7 @@ exports[`member stack snapshot matches 1`] = `
       "Condition": "loadAFSBPCond",
       "DeletionPolicy": "Delete",
       "DependsOn": [
-        "RunbookStackNoRolesNestedStackRunbookStackNoRolesNestedStackResource37E060FD",
+        "RunbookStackNoRoles",
       ],
       "Properties": {
         "Parameters": {
@@ -506,7 +506,7 @@ exports[`member stack snapshot matches 1`] = `
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "NestedStackFactoryGatePlaybookMemberStackCIS120E08EFB8B",
-        "RunbookStackNoRolesNestedStackRunbookStackNoRolesNestedStackResource37E060FD",
+        "RunbookStackNoRoles",
       ],
       "Properties": {
         "Parameters": {
@@ -553,7 +553,7 @@ exports[`member stack snapshot matches 1`] = `
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "NestedStackFactoryGatePlaybookMemberStackCIS1402A4735A6",
-        "RunbookStackNoRolesNestedStackRunbookStackNoRolesNestedStackResource37E060FD",
+        "RunbookStackNoRoles",
       ],
       "Properties": {
         "Parameters": {
@@ -600,7 +600,7 @@ exports[`member stack snapshot matches 1`] = `
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "NestedStackFactoryGatePlaybookMemberStackPCI3214A12B906",
-        "RunbookStackNoRolesNestedStackRunbookStackNoRolesNestedStackResource37E060FD",
+        "RunbookStackNoRoles",
       ],
       "Properties": {
         "Parameters": {
@@ -647,7 +647,7 @@ exports[`member stack snapshot matches 1`] = `
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "NestedStackFactoryGatePlaybookMemberStackSC0515DB36",
-        "RunbookStackNoRolesNestedStackRunbookStackNoRolesNestedStackResource37E060FD",
+        "RunbookStackNoRoles",
       ],
       "Properties": {
         "Parameters": {
@@ -689,7 +689,7 @@ exports[`member stack snapshot matches 1`] = `
       "Type": "AWS::CloudFormation::Stack",
       "UpdateReplacePolicy": "Delete",
     },
-    "RunbookStackNoRolesNestedStackRunbookStackNoRolesNestedStackResource37E060FD": {
+    "RunbookStackNoRoles": {
       "DeletionPolicy": "Delete",
       "Properties": {
         "Parameters": {

--- a/source/lib/member-stack.ts
+++ b/source/lib/member-stack.ts
@@ -54,6 +54,8 @@ export class MemberStack extends Stack {
       templateRelativePath: 'aws-sharr-remediations.template',
       parameters: { WaitProviderServiceToken: waitProvider.serviceToken },
     });
+    const noRolesCfnResource = nestedStackNoRoles.nestedStackResource as CfnResource;
+    noRolesCfnResource.overrideLogicalId('RunbookStackNoRoles');
 
     this.nestedStacks.push(nestedStackNoRoles as Stack);
 

--- a/source/lib/solution_deploy-stack.ts
+++ b/source/lib/solution_deploy-stack.ts
@@ -691,7 +691,7 @@ export class SolutionDeployStack extends cdk.Stack {
     const orchestratorArn = orchArnParm.node.defaultChild as CfnParameter;
 
     //---------------------------------------------------------------------
-    // OneTrigger - Remediate with SHARR custom action
+    // OneTrigger - Remediate with ASR custom action
     //
     new OneTrigger(this, 'RemediateWithSharr', {
       targetArn: orchStateMachine.stateMachineArn,

--- a/source/lib/solution_deploy-stack.ts
+++ b/source/lib/solution_deploy-stack.ts
@@ -741,7 +741,7 @@ export class SolutionDeployStack extends cdk.Stack {
         });
         cfnStack.node.addDependency(stateMachineConstruct);
         cfnStack.node.addDependency(orchestratorArn);
-
+        cfnStack.overrideLogicalId(`PlaybookAdminStack${file}`);
         this.nestedStacks.push(adminStack as cdk.Stack);
       }
     });

--- a/source/lib/ssmplaybook.ts
+++ b/source/lib/ssmplaybook.ts
@@ -144,7 +144,7 @@ export class OneTrigger extends Construct {
     // Create CWE rule
     // Create custom action
 
-    let description = `Remediate with SHARR`;
+    let description = `Remediate with ASR`;
     if (props.description) {
       description = props.description;
     }
@@ -160,9 +160,9 @@ export class OneTrigger extends Construct {
       serviceToken: props.serviceToken,
       resourceType: 'Custom::ActionTarget',
       properties: {
-        Name: 'Remediate with SHARR',
+        Name: 'Remediate with ASR',
         Description: 'Submit the finding to AWS Security Hub Automated Response and Remediation',
-        Id: 'SHARRRemediation',
+        Id: 'ASRRemediation',
       },
     });
     {

--- a/source/solution_deploy/source/test/test_action_target_provider.py
+++ b/source/solution_deploy/source/test/test_action_target_provider.py
@@ -56,9 +56,9 @@ context = MockContext("SO0111-SHARR-Custom-Action-Lambda", "v1.0.0")
 def event(type):
     return {
         "ResourceProperties": {
-            "Name": "Remediate with SHARR Test",
-            "Description": "Test Submit the finding to AWS Security Hub Automated Response and Remediation",
-            "Id": "SHARRRemediationTest",
+            "Name": "Remediate with ASR Test",
+            "Description": "Test Submit the finding to Automated Security Response on AWS",
+            "Id": "ASRRemediationTest",
         },
         "RequestType": type,
         "ResponseURL": "https://bogus",
@@ -92,9 +92,9 @@ def test_create(mocker):
         "create_action_target",
         {"ActionTargetArn": "foobarbaz"},
         {
-            "Name": "Remediate with SHARR Test",
-            "Description": " Test Submit the finding to AWS Security Hub Automated Response and Remediation",
-            "Id": "SHARRRemediationTest",
+            "Name": "Remediate with ASR Test",
+            "Description": " Test Submit the finding to Automated Security Response on AWS",
+            "Id": "ASRRemediationTest",
         },
     )
     sechub_stub.activate()
@@ -119,9 +119,9 @@ def test_create_already_exists(mocker):
     customAction = CustomAction(
         "111122223333",
         {
-            "Name": "Remediate with SHARR Test",
-            "Description": "Test Submit the finding to AWS Security Hub Automated Response and Remediation",
-            "Id": "SHARRRemediationTest",
+            "Name": "Remediate with ASR Test",
+            "Description": "Test Submit the finding to Automated Security Response on AWS",
+            "Id": "ASRRemediationTest",
         },
     )
     assert customAction.create() == None
@@ -141,9 +141,9 @@ def test_create_no_sechub(mocker):
     customAction = CustomAction(
         "111122223333",
         {
-            "Name": "Remediate with SHARR Test",
-            "Description": "Test Submit the finding to AWS Security Hub Automated Response and Remediation",
-            "Id": "SHARRRemediationTest",
+            "Name": "Remediate with ASR Test",
+            "Description": "Test Submit the finding to Automated Security Response on AWS",
+            "Id": "ASRRemediationTest",
         },
     )
     assert customAction.create() == "FAILED"
@@ -163,9 +163,9 @@ def test_create_other_client_error(mocker):
     customAction = CustomAction(
         "111122223333",
         {
-            "Name": "Remediate with SHARR Test",
-            "Description": "Test Submit the finding to AWS Security Hub Automated Response and Remediation",
-            "Id": "SHARRRemediationTest",
+            "Name": "Remediate with ASR Test",
+            "Description": "Test Submit the finding to Automated Security Response on AWS",
+            "Id": "ASRRemediationTest",
         },
     )
     assert customAction.create() == "FAILED"
@@ -189,9 +189,9 @@ def test_delete(mocker):
     customAction = CustomAction(
         "111122223333",
         {
-            "Name": "Remediate with SHARR Test",
-            "Description": "Test Submit the finding to AWS Security Hub Automated Response and Remediation",
-            "Id": "SHARRRemediationTest",
+            "Name": "Remediate with ASR Test",
+            "Description": "Test Submit the finding to Automated Security Response on AWS",
+            "Id": "ASRRemediationTest",
         },
     )
     assert customAction.delete() == "SUCCESS"
@@ -211,9 +211,9 @@ def test_delete_already_exists(mocker):
     customAction = CustomAction(
         "111122223333",
         {
-            "Name": "Remediate with SHARR Test",
-            "Description": "Test Submit the finding to AWS Security Hub Automated Response and Remediation",
-            "Id": "SHARRRemediationTest",
+            "Name": "Remediate with ASR Test",
+            "Description": "Test Submit the finding to Automated Security Response on AWS",
+            "Id": "ASRRemediationTest",
         },
     )
     assert customAction.delete() == "SUCCESS"
@@ -232,9 +232,9 @@ def test_delete_no_sechub(mocker):
     customAction = CustomAction(
         "111122223333",
         {
-            "Name": "Remediate with SHARR Test",
-            "Description": "Test Submit the finding to AWS Security Hub Automated Response and Remediation",
-            "Id": "SHARRRemediationTest",
+            "Name": "Remediate with ASR Test",
+            "Description": "Test Submit the finding to Automated Security Response on AWS",
+            "Id": "ASRRemediationTest",
         },
     )
     assert customAction.delete() == "SUCCESS"
@@ -253,9 +253,9 @@ def test_delete_other_client_error(mocker):
     customAction = CustomAction(
         "111122223333",
         {
-            "Name": "Remediate with SHARR Test",
-            "Description": "Test Submit the finding to AWS Security Hub Automated Response and Remediation",
-            "Id": "SHARRRemediationTest",
+            "Name": "Remediate with ASR Test",
+            "Description": "Test Submit the finding to Automated Security Response on AWS",
+            "Id": "ASRRemediationTest",
         },
     )
     assert customAction.delete() == "FAILED"

--- a/source/test/__snapshots__/solution_deploy.test.ts.snap
+++ b/source/test/__snapshots__/solution_deploy.test.ts.snap
@@ -680,8 +680,8 @@ exports[`Test if the Stack has all the resources. 1`] = `
       ],
       "Properties": {
         "Description": "Submit the finding to AWS Security Hub Automated Response and Remediation",
-        "Id": "SHARRRemediation",
-        "Name": "Remediate with SHARR",
+        "Id": "ASRRemediation",
+        "Name": "Remediate with ASR",
         "ServiceToken": {
           "Fn::GetAtt": [
             "CreateCustomActionE7A973F5",
@@ -734,7 +734,7 @@ exports[`Test if the Stack has all the resources. 1`] = `
     },
     "RemediateWithSharrRemediateCustomAction40B496D2": {
       "Properties": {
-        "Description": "Remediate with SHARR",
+        "Description": "Remediate with ASR",
         "EventPattern": {
           "detail": {
             "findings": {

--- a/source/test/__snapshots__/solution_deploy.test.ts.snap
+++ b/source/test/__snapshots__/solution_deploy.test.ts.snap
@@ -289,7 +289,7 @@ exports[`Test if the Stack has all the resources. 1`] = `
     "AppRegistryResourceAssociation2BB1A3300": {
       "Condition": "loadAFSBPCond",
       "DependsOn": [
-        "PlaybookAdminStackAFSBPNestedStackPlaybookAdminStackAFSBPNestedStackResource649D3317",
+        "PlaybookAdminStackAFSBP",
       ],
       "Properties": {
         "Application": {
@@ -299,7 +299,7 @@ exports[`Test if the Stack has all the resources. 1`] = `
           ],
         },
         "Resource": {
-          "Ref": "PlaybookAdminStackAFSBPNestedStackPlaybookAdminStackAFSBPNestedStackResource649D3317",
+          "Ref": "PlaybookAdminStackAFSBP",
         },
         "ResourceType": "CFN_STACK",
       },
@@ -308,7 +308,7 @@ exports[`Test if the Stack has all the resources. 1`] = `
     "AppRegistryResourceAssociation3BEAC7BB7": {
       "Condition": "loadCIS120Cond",
       "DependsOn": [
-        "PlaybookAdminStackCIS120NestedStackPlaybookAdminStackCIS120NestedStackResource21DCA876",
+        "PlaybookAdminStackCIS120",
       ],
       "Properties": {
         "Application": {
@@ -318,7 +318,7 @@ exports[`Test if the Stack has all the resources. 1`] = `
           ],
         },
         "Resource": {
-          "Ref": "PlaybookAdminStackCIS120NestedStackPlaybookAdminStackCIS120NestedStackResource21DCA876",
+          "Ref": "PlaybookAdminStackCIS120",
         },
         "ResourceType": "CFN_STACK",
       },
@@ -327,7 +327,7 @@ exports[`Test if the Stack has all the resources. 1`] = `
     "AppRegistryResourceAssociation46F7B9873": {
       "Condition": "loadCIS140Cond",
       "DependsOn": [
-        "PlaybookAdminStackCIS140NestedStackPlaybookAdminStackCIS140NestedStackResource54008C57",
+        "PlaybookAdminStackCIS140",
       ],
       "Properties": {
         "Application": {
@@ -337,7 +337,7 @@ exports[`Test if the Stack has all the resources. 1`] = `
           ],
         },
         "Resource": {
-          "Ref": "PlaybookAdminStackCIS140NestedStackPlaybookAdminStackCIS140NestedStackResource54008C57",
+          "Ref": "PlaybookAdminStackCIS140",
         },
         "ResourceType": "CFN_STACK",
       },
@@ -346,7 +346,7 @@ exports[`Test if the Stack has all the resources. 1`] = `
     "AppRegistryResourceAssociation5FAA30631": {
       "Condition": "loadPCI321Cond",
       "DependsOn": [
-        "PlaybookAdminStackPCI321NestedStackPlaybookAdminStackPCI321NestedStackResourceB6A45DB0",
+        "PlaybookAdminStackPCI321",
       ],
       "Properties": {
         "Application": {
@@ -356,7 +356,7 @@ exports[`Test if the Stack has all the resources. 1`] = `
           ],
         },
         "Resource": {
-          "Ref": "PlaybookAdminStackPCI321NestedStackPlaybookAdminStackPCI321NestedStackResourceB6A45DB0",
+          "Ref": "PlaybookAdminStackPCI321",
         },
         "ResourceType": "CFN_STACK",
       },
@@ -365,7 +365,7 @@ exports[`Test if the Stack has all the resources. 1`] = `
     "AppRegistryResourceAssociation62B582FF5": {
       "Condition": "loadSCCond",
       "DependsOn": [
-        "PlaybookAdminStackSCNestedStackPlaybookAdminStackSCNestedStackResource269A112D",
+        "PlaybookAdminStackSC",
       ],
       "Properties": {
         "Application": {
@@ -375,7 +375,7 @@ exports[`Test if the Stack has all the resources. 1`] = `
           ],
         },
         "Resource": {
-          "Ref": "PlaybookAdminStackSCNestedStackPlaybookAdminStackSCNestedStackResource269A112D",
+          "Ref": "PlaybookAdminStackSC",
         },
         "ResourceType": "CFN_STACK",
       },
@@ -492,7 +492,7 @@ exports[`Test if the Stack has all the resources. 1`] = `
       },
       "Type": "AWS::ServiceCatalogAppRegistry::AttributeGroup",
     },
-    "PlaybookAdminStackAFSBPNestedStackPlaybookAdminStackAFSBPNestedStackResource649D3317": {
+    "PlaybookAdminStackAFSBP": {
       "Condition": "loadAFSBPCond",
       "DeletionPolicy": "Delete",
       "DependsOn": [
@@ -528,7 +528,7 @@ exports[`Test if the Stack has all the resources. 1`] = `
       "Type": "AWS::CloudFormation::Stack",
       "UpdateReplacePolicy": "Delete",
     },
-    "PlaybookAdminStackCIS120NestedStackPlaybookAdminStackCIS120NestedStackResource21DCA876": {
+    "PlaybookAdminStackCIS120": {
       "Condition": "loadCIS120Cond",
       "DeletionPolicy": "Delete",
       "DependsOn": [
@@ -564,7 +564,7 @@ exports[`Test if the Stack has all the resources. 1`] = `
       "Type": "AWS::CloudFormation::Stack",
       "UpdateReplacePolicy": "Delete",
     },
-    "PlaybookAdminStackCIS140NestedStackPlaybookAdminStackCIS140NestedStackResource54008C57": {
+    "PlaybookAdminStackCIS140": {
       "Condition": "loadCIS140Cond",
       "DeletionPolicy": "Delete",
       "DependsOn": [
@@ -600,7 +600,7 @@ exports[`Test if the Stack has all the resources. 1`] = `
       "Type": "AWS::CloudFormation::Stack",
       "UpdateReplacePolicy": "Delete",
     },
-    "PlaybookAdminStackPCI321NestedStackPlaybookAdminStackPCI321NestedStackResourceB6A45DB0": {
+    "PlaybookAdminStackPCI321": {
       "Condition": "loadPCI321Cond",
       "DeletionPolicy": "Delete",
       "DependsOn": [
@@ -636,7 +636,7 @@ exports[`Test if the Stack has all the resources. 1`] = `
       "Type": "AWS::CloudFormation::Stack",
       "UpdateReplacePolicy": "Delete",
     },
-    "PlaybookAdminStackSCNestedStackPlaybookAdminStackSCNestedStackResource269A112D": {
+    "PlaybookAdminStackSC": {
       "Condition": "loadSCCond",
       "DeletionPolicy": "Delete",
       "DependsOn": [


### PR DESCRIPTION
*Description of changes:*
Changed custom action name to 'Remediate with ASR' and changed all mentions of Remediate with SHARR.
Overrode logical ids for NestedStacks as the construct will automatically name them to something else. 

Passes all unit tests, deploys on its own and remediates successfully. Also deployed as an update from 1.5.1, it deploys successfully and runs remediations as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.