### PR TITLE
Added GetApplication permissions to AFSBP CF1

### DIFF
--- a/source/lib/remediation_runbook-stack.ts
+++ b/source/lib/remediation_runbook-stack.ts
@@ -1357,6 +1357,12 @@ export class RemediationRunbookStack extends cdk.Stack {
       );
       inlinePolicy.addStatements(snsPerms);
 
+      const remediationPolicy = new PolicyStatement();
+      remediationPolicy.addActions('servicecatalog:GetApplication');
+      remediationPolicy.effect = Effect.ALLOW;
+      remediationPolicy.addResources('*');
+      inlinePolicy.addStatements(remediationPolicy);
+
       new SsmRole(props.roleStack, 'RemediationRole ' + remediationName, {
         solutionId: props.solutionId,
         ssmDocName: remediationName,


### PR DESCRIPTION
*Description of changes:*
Theory is that this always failed on AppRegistry stacks, but it was never tested on it. This PR adds the 'servicecatalog:GetApplication' permission to fix it.

Verified working, deploys successfully, passes pipeline.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.