### PR TITLE
Changed wait provider log level to info

### DIFF
--- a/source/lib/__snapshots__/member-stack.test.ts.snap
+++ b/source/lib/__snapshots__/member-stack.test.ts.snap
@@ -1037,7 +1037,7 @@ exports[`member stack snapshot matches 1`] = `
         },
         "Environment": {
           "Variables": {
-            "LOG_LEVEL": "WARNING",
+            "LOG_LEVEL": "INFO",
           },
         },
         "Handler": "wait_provider.lambda_handler",

--- a/source/lib/wait-provider.ts
+++ b/source/lib/wait-provider.ts
@@ -83,7 +83,7 @@ export class WaitProvider extends Construct {
         props.solutionTMN + '/' + props.solutionVersion + '/lambda/wait_provider.zip'
       ),
       handler: 'wait_provider.lambda_handler',
-      environment: { LOG_LEVEL: 'WARNING' },
+      environment: { LOG_LEVEL: 'INFO' },
       timeout: Duration.minutes(15),
     });
 

--- a/source/solution_deploy/source/wait_provider.py
+++ b/source/solution_deploy/source/wait_provider.py
@@ -8,7 +8,7 @@ from logging import basicConfig, getLevelName, getLogger
 from time import sleep
 import cfnresponse
 
-basicConfig(level=getLevelName(getenv("LOG_LEVEL", "WARNING")))
+basicConfig(level=getLevelName(getenv("LOG_LEVEL", "INFO")))
 logger = getLogger(__name__)
 
 


### PR DESCRIPTION
*Description of changes:*
Changing log level to info to address a security hotspot that came up in SonarQube

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.