### PR TITLE
Fix SC rule pattern, fix AutoScaling group name regex

### DIFF
--- a/source/playbooks/SC/lib/security_controls_playbook-construct.ts
+++ b/source/playbooks/SC/lib/security_controls_playbook-construct.ts
@@ -65,7 +65,7 @@ export class SecurityControlsPlaybookPrimaryStack extends Stack {
           stringValue: `${controlSpec.executes}`,
         });
       }
-      const generatorId = `control/${controlSpec.control}`;
+      const generatorId = `security-control/${controlSpec.control}`;
       new Trigger(stack, `${props.securityStandard} ${controlSpec.control}`, {
         securityStandard: props.securityStandard,
         securityStandardVersion: props.securityStandardVersion,

--- a/source/playbooks/SC/ssmdocs/SC_AutoScaling.1.ts
+++ b/source/playbooks/SC/ssmdocs/SC_AutoScaling.1.ts
@@ -17,7 +17,7 @@ class EnableAutoScalingGroupELBHealthCheckDocument extends ControlRunbookDocumen
       remediationName: 'EnableAutoScalingGroupELBHealthCheck',
       scope: RemediationScope.REGIONAL,
       resourceIdName: 'AutoScalingGroupName',
-      resourceIdRegex: String.raw`^arn:(?:aws|aws-cn|aws-us-gov):autoscaling:(?:[a-z]{2}(?:-gov)?-[a-z]+-\d):\d{12}:autoScalingGroup:(?:[0-9a-fA-F]{11}-(?:[0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}):autoScalingGroupName\/(.*)$`,
+      resourceIdRegex: String.raw`^arn:(?:aws|aws-cn|aws-us-gov):autoscaling:(?:[a-z]{2}(?:-gov)?-[a-z]+-\d):\d{12}:autoScalingGroup:(?:[0-9a-fA-F]{8}-(?:[0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}):autoScalingGroupName/(.{1,255})$`,
       updateDescription: HardCodedString.of('ASG health check type updated to ELB'),
     });
   }

--- a/source/playbooks/SC/test/__snapshots__/security_controls_stack.test.ts.snap
+++ b/source/playbooks/SC/test/__snapshots__/security_controls_stack.test.ts.snap
@@ -1137,7 +1137,7 @@ Default: 30 seconds
                   "expected_control_id": [
                     "AutoScaling.1",
                   ],
-                  "parse_id_pattern": "^arn:(?:aws|aws-cn|aws-us-gov):autoscaling:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:autoScalingGroup:(?:[0-9a-fA-F]{11}-(?:[0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}):autoScalingGroupName\\/(.*)$",
+                  "parse_id_pattern": "^arn:(?:aws|aws-cn|aws-us-gov):autoscaling:(?:[a-z]{2}(?:-gov)?-[a-z]+-\\d):\\d{12}:autoScalingGroup:(?:[0-9a-fA-F]{8}-(?:[0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}):autoScalingGroupName/(.{1,255})$",
                 },
                 "Runtime": "python3.8",
                 "Script": "# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/source/playbooks/SC/test/__snapshots__/security_controls_stack.test.ts.snap
+++ b/source/playbooks/SC/test/__snapshots__/security_controls_stack.test.ts.snap
@@ -50,7 +50,7 @@ exports[`admin stack 1`] = `
                 ],
               },
               "GeneratorId": [
-                "control/Example.1",
+                "security-control/Example.1",
               ],
               "RecordState": [
                 "ACTIVE",
@@ -143,7 +143,7 @@ exports[`admin stack 1`] = `
                 ],
               },
               "GeneratorId": [
-                "control/Example.3",
+                "security-control/Example.3",
               ],
               "RecordState": [
                 "ACTIVE",
@@ -236,7 +236,7 @@ exports[`admin stack 1`] = `
                 ],
               },
               "GeneratorId": [
-                "control/Example.5",
+                "security-control/Example.5",
               ],
               "RecordState": [
                 "ACTIVE",


### PR DESCRIPTION
- fix generator ID pattern used by SC auto-trigger EventBridge rules
- fix regex used by SC control runbook to validate AutoScaling group names

With auto-trigger rule enabled, SC AutoScaling.1 remediation triggers and succeeds.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.