### PR TITLE
Adding all endpoint types to SNS.2 Remediation

### DIFF
--- a/source/remediation_runbooks/scripts/enable_delivery_status_logging.py
+++ b/source/remediation_runbooks/scripts/enable_delivery_status_logging.py
@@ -98,8 +98,9 @@ def reset_to_recognized_state(topic_arn):
     Used in case of error, will unset all delivery status logging parameters.
     """
     sns = connect_to_sns()
-
     for endpoint in endpointTypes:
-        sns.set_topic_attributes(TopicArn=topic_arn, AttributeName=f'{endpoint}SuccessFeedbackRoleArn', AttributeValue='')
-        sns.set_topic_attributes(TopicArn=topic_arn, AttributeName=f'{endpoint}FailureFeedbackRoleArn', AttributeValue='')
-    
+        try:
+            sns.set_topic_attributes(TopicArn=topic_arn, AttributeName=f'{endpoint}SuccessFeedbackRoleArn', AttributeValue='')
+            sns.set_topic_attributes(TopicArn=topic_arn, AttributeName=f'{endpoint}FailureFeedbackRoleArn', AttributeValue='')
+        except Exception:
+            print(f'There was an error while resetting SNS Topic {topic_arn}, please manually turn off delivery status logging for protocol {endpoint}')

--- a/source/remediation_runbooks/scripts/enable_delivery_status_logging.py
+++ b/source/remediation_runbooks/scripts/enable_delivery_status_logging.py
@@ -11,9 +11,7 @@ boto_config = Config(
         }
     )
 
-failureFeedbackRoleValue = "LambdaFailureFeedbackRoleArn"
-successFeedbackRoleValue = "LambdaSuccessFeedbackRoleArn"
-successRateRoleValue = "LambdaSuccessFeedbackSampleRate"
+endpointTypes = ['HTTP', 'Firehose', 'Lambda', 'Application', 'SQS']
 
 def connect_to_sns():
     return boto3.client('sns', config=boto_config)
@@ -39,9 +37,21 @@ def lambda_handler(event, _):
     topic_attributes = get_topic_attributes(topic_arn)
 
     return {
-        "FailureFeedbackRole": topic_attributes["Attributes"][failureFeedbackRoleValue],
-        "SuccessFeedbackRole": topic_attributes["Attributes"][successFeedbackRoleValue],
-        "SuccessSampleRate": topic_attributes["Attributes"][successRateRoleValue]
+        "HTTPFailureFeedbackRoleArn": topic_attributes["Attributes"]["HTTPFailureFeedbackRoleArn"],
+        "HTTPSuccessFeedbackRoleArn": topic_attributes["Attributes"]["HTTPSuccessFeedbackRoleArn"],
+        "HTTPSuccessFeedbackSampleRate": topic_attributes["Attributes"]["HTTPSuccessFeedbackSampleRate"],
+        "FirehoseFailureFeedbackRoleArn": topic_attributes["Attributes"]["FirehoseFailureFeedbackRoleArn"],
+        "FirehoseSuccessFeedbackRoleArn": topic_attributes["Attributes"]["FirehoseSuccessFeedbackRoleArn"],
+        "FirehoseSuccessFeedbackSampleRate": topic_attributes["Attributes"]["FirehoseSuccessFeedbackSampleRate"],
+        "LambdaFailureFeedbackRoleArn": topic_attributes["Attributes"]["LambdaFailureFeedbackRoleArn"],
+        "LambdaSuccessFeedbackRoleArn": topic_attributes["Attributes"]["LambdaSuccessFeedbackRoleArn"],
+        "LambdaSuccessFeedbackSampleRate": topic_attributes["Attributes"]["LambdaSuccessFeedbackSampleRate"],
+        "ApplicationFailureFeedbackRoleArn": topic_attributes["Attributes"]["ApplicationFailureFeedbackRoleArn"],
+        "ApplicationSuccessFeedbackRoleArn": topic_attributes["Attributes"]["ApplicationSuccessFeedbackRoleArn"],
+        "ApplicationSuccessFeedbackSampleRate": topic_attributes["Attributes"]["ApplicationSuccessFeedbackSampleRate"],
+        "SQSFailureFeedbackRoleArn": topic_attributes["Attributes"]["SQSFailureFeedbackRoleArn"],
+        "SQSSuccessFeedbackRoleArn": topic_attributes["Attributes"]["SQSSuccessFeedbackRoleArn"],
+        "SQSSuccessFeedbackSampleRate": topic_attributes["Attributes"]["SQSSuccessFeedbackSampleRate"]
     }
 
 def add_roles_to_topic(logging_role, topic_arn):
@@ -50,12 +60,13 @@ def add_roles_to_topic(logging_role, topic_arn):
     """  
     sns = connect_to_sns()
     try:
-        sns.set_topic_attributes(TopicArn=topic_arn, AttributeName=successFeedbackRoleValue, AttributeValue=logging_role)
-        sns.set_topic_attributes(TopicArn=topic_arn, AttributeName=failureFeedbackRoleValue, AttributeValue=logging_role)
+        for endpoint in endpointTypes:
+            sns.set_topic_attributes(TopicArn=topic_arn, AttributeName=f'{endpoint}SuccessFeedbackRoleArn', AttributeValue=logging_role)
+            sns.set_topic_attributes(TopicArn=topic_arn, AttributeName=f'{endpoint}FailureFeedbackRoleArn', AttributeValue=logging_role)
 
     except Exception as e:
         reset_to_recognized_state(topic_arn)
-        exit(f'Failed to set success/failure role of topic '+topic_arn+': '+str(e))
+        exit(f'Failed to set success/failure role of topic {topic_arn}: {str(e)}')
 
 def add_sample_rate_to_topic(topic_arn, sample_rate):
     """
@@ -63,11 +74,12 @@ def add_sample_rate_to_topic(topic_arn, sample_rate):
     """    
     sns = connect_to_sns()
     try:
-        sns.set_topic_attributes(TopicArn=topic_arn, AttributeName=successRateRoleValue, AttributeValue=sample_rate)
+        for endpoint in endpointTypes:
+            sns.set_topic_attributes(TopicArn=topic_arn, AttributeName=f'{endpoint}SuccessFeedbackSampleRate', AttributeValue=sample_rate)
 
     except Exception as e:
         reset_to_recognized_state(topic_arn)
-        exit(f'Failed to set success sample rate of SNS topic '+topic_arn+': '+str(e))
+        exit(f'Failed to set success sample rate of SNS topic {topic_arn}: {str(e)}')
 
 def get_topic_attributes(topic_arn):
     """
@@ -79,13 +91,15 @@ def get_topic_attributes(topic_arn):
         return topic_attributes
 
     except Exception as e:
-        exit(f'Failed to get attributes of SNS topic '+topic_arn+': '+str(e))
+        exit(f'Failed to get attributes of SNS topic {topic_arn}: {str(e)}')
 
 def reset_to_recognized_state(topic_arn):
     """
     Used in case of error, will unset all delivery status logging parameters.
     """
     sns = connect_to_sns()
+
+    for endpoint in endpointTypes:
+        sns.set_topic_attributes(TopicArn=topic_arn, AttributeName=f'{endpoint}SuccessFeedbackRoleArn', AttributeValue='')
+        sns.set_topic_attributes(TopicArn=topic_arn, AttributeName=f'{endpoint}FailureFeedbackRoleArn', AttributeValue='')
     
-    sns.set_topic_attributes(TopicArn=topic_arn, AttributeName=successFeedbackRoleValue, AttributeValue='')
-    sns.set_topic_attributes(TopicArn=topic_arn, AttributeName=failureFeedbackRoleValue, AttributeValue='')

--- a/source/remediation_runbooks/scripts/test/test_enable_delivery_status_logging.py
+++ b/source/remediation_runbooks/scripts/test/test_enable_delivery_status_logging.py
@@ -27,22 +27,22 @@ def test_enables_delivery_status_logging(mocker):
     logging_arn = 'logging_arn'
     topic_arn = f'arn:aws:sns:{my_region}:111111111111:sharr-test'
 
-    response = { 'Attributes' : {
+    stub_response = { 'Attributes' : {
       "LambdaFailureFeedbackRoleArn": logging_arn,
       "LambdaSuccessFeedbackRoleArn": logging_arn,
-      "LambdaSuccessFeedbackSampleRate": logging_arn,
+      "LambdaSuccessFeedbackSampleRate": '0',
       "HTTPFailureFeedbackRoleArn": logging_arn,
       "HTTPSuccessFeedbackRoleArn": logging_arn,
-      "HTTPSuccessFeedbackSampleRate": logging_arn,
+      "HTTPSuccessFeedbackSampleRate": '0',
       "FirehoseFailureFeedbackRoleArn": logging_arn,
       "FirehoseSuccessFeedbackRoleArn": logging_arn,
-      "FirehoseSuccessFeedbackSampleRate": logging_arn,
+      "FirehoseSuccessFeedbackSampleRate": '0',
       "ApplicationFailureFeedbackRoleArn": logging_arn,
       "ApplicationSuccessFeedbackRoleArn": logging_arn,
-      "ApplicationSuccessFeedbackSampleRate": logging_arn,
+      "ApplicationSuccessFeedbackSampleRate": '0',
       "SQSFailureFeedbackRoleArn": logging_arn,
       "SQSSuccessFeedbackRoleArn": logging_arn,
-      "SQSSuccessFeedbackSampleRate": logging_arn
+      "SQSSuccessFeedbackSampleRate": '0'
     }}
     for endpoint in endpointTypes:
       stub_sns.add_response(
@@ -67,7 +67,7 @@ def test_enables_delivery_status_logging(mocker):
         'AttributeValue': '0'})
 
     stub_sns.add_response('get_topic_attributes',
-    response, 
+    stub_response, 
     { 'TopicArn': topic_arn })
 
     stub_sns.activate()
@@ -78,18 +78,18 @@ def test_enables_delivery_status_logging(mocker):
         assert response == { 
             "LambdaFailureFeedbackRoleArn": logging_arn,
             "LambdaSuccessFeedbackRoleArn": logging_arn,
-            "LambdaSuccessFeedbackSampleRate": logging_arn,
+            "LambdaSuccessFeedbackSampleRate": '0',
             "HTTPFailureFeedbackRoleArn": logging_arn,
             "HTTPSuccessFeedbackRoleArn": logging_arn,
-            "HTTPSuccessFeedbackSampleRate": logging_arn,
+            "HTTPSuccessFeedbackSampleRate": '0',
             "FirehoseFailureFeedbackRoleArn": logging_arn,
             "FirehoseSuccessFeedbackRoleArn": logging_arn,
-            "FirehoseSuccessFeedbackSampleRate": logging_arn,
+            "FirehoseSuccessFeedbackSampleRate": '0',
             "ApplicationFailureFeedbackRoleArn": logging_arn,
             "ApplicationSuccessFeedbackRoleArn": logging_arn,
-            "ApplicationSuccessFeedbackSampleRate": logging_arn,
+            "ApplicationSuccessFeedbackSampleRate": '0',
             "SQSFailureFeedbackRoleArn": logging_arn,
             "SQSSuccessFeedbackRoleArn": logging_arn,
-            "SQSSuccessFeedbackSampleRate": logging_arn }
+            "SQSSuccessFeedbackSampleRate": '0' }
     
 

--- a/source/remediation_runbooks/scripts/test/test_enable_delivery_status_logging.py
+++ b/source/remediation_runbooks/scripts/test/test_enable_delivery_status_logging.py
@@ -9,6 +9,7 @@ from botocore.config import Config
 from enable_delivery_status_logging import lambda_handler
 
 def test_enables_delivery_status_logging(mocker):
+    endpointTypes = ['HTTP', 'Firehose', 'Lambda', 'Application', 'SQS']
 
     my_session = boto3.session.Session()
     my_region = my_session.region_name  
@@ -29,28 +30,41 @@ def test_enables_delivery_status_logging(mocker):
     response = { 'Attributes' : {
       "LambdaFailureFeedbackRoleArn": logging_arn,
       "LambdaSuccessFeedbackRoleArn": logging_arn,
-      "LambdaSuccessFeedbackSampleRate": logging_arn
+      "LambdaSuccessFeedbackSampleRate": logging_arn,
+      "HTTPFailureFeedbackRoleArn": logging_arn,
+      "HTTPSuccessFeedbackRoleArn": logging_arn,
+      "HTTPSuccessFeedbackSampleRate": logging_arn,
+      "FirehoseFailureFeedbackRoleArn": logging_arn,
+      "FirehoseSuccessFeedbackRoleArn": logging_arn,
+      "FirehoseSuccessFeedbackSampleRate": logging_arn,
+      "ApplicationFailureFeedbackRoleArn": logging_arn,
+      "ApplicationSuccessFeedbackRoleArn": logging_arn,
+      "ApplicationSuccessFeedbackSampleRate": logging_arn,
+      "SQSFailureFeedbackRoleArn": logging_arn,
+      "SQSSuccessFeedbackRoleArn": logging_arn,
+      "SQSSuccessFeedbackSampleRate": logging_arn
     }}
+    for endpoint in endpointTypes:
+      stub_sns.add_response(
+        'set_topic_attributes',
+        {},
+        { 
+          'TopicArn': topic_arn , 
+          'AttributeName': f"{endpoint}SuccessFeedbackRoleArn",
+          'AttributeValue': logging_arn})
 
-    stub_sns.add_response(
-      'set_topic_attributes',
+      stub_sns.add_response('set_topic_attributes', 
       {},
-      { 
-        'TopicArn': topic_arn , 
-        'AttributeName': "LambdaSuccessFeedbackRoleArn",
+      { 'TopicArn': topic_arn , 
+        'AttributeName': f"{endpoint}FailureFeedbackRoleArn" ,
         'AttributeValue': logging_arn})
-
-    stub_sns.add_response('set_topic_attributes', 
-    {},
-    { 'TopicArn': topic_arn , 
-      'AttributeName': "LambdaFailureFeedbackRoleArn" ,
-      'AttributeValue': logging_arn})
-    
-    stub_sns.add_response('set_topic_attributes',
-    {}, 
-    { 'TopicArn': topic_arn , 
-      'AttributeName': "LambdaSuccessFeedbackSampleRate" ,
-      'AttributeValue': '0'})
+      
+    for endpoint in endpointTypes:  
+      stub_sns.add_response('set_topic_attributes',
+      {}, 
+      { 'TopicArn': topic_arn , 
+        'AttributeName': f"{endpoint}SuccessFeedbackSampleRate" ,
+        'AttributeValue': '0'})
 
     stub_sns.add_response('get_topic_attributes',
     response, 
@@ -62,8 +76,20 @@ def test_enables_delivery_status_logging(mocker):
         event = { 'topic_arn': topic_arn, 'logging_role': logging_arn, 'sample_rate': '0' }
         response = lambda_handler(event, {})
         assert response == { 
-            "FailureFeedbackRole": logging_arn,
-            "SuccessFeedbackRole": logging_arn,
-            "SuccessSampleRate": logging_arn }
+            "LambdaFailureFeedbackRoleArn": logging_arn,
+            "LambdaSuccessFeedbackRoleArn": logging_arn,
+            "LambdaSuccessFeedbackSampleRate": logging_arn,
+            "HTTPFailureFeedbackRoleArn": logging_arn,
+            "HTTPSuccessFeedbackRoleArn": logging_arn,
+            "HTTPSuccessFeedbackSampleRate": logging_arn,
+            "FirehoseFailureFeedbackRoleArn": logging_arn,
+            "FirehoseSuccessFeedbackRoleArn": logging_arn,
+            "FirehoseSuccessFeedbackSampleRate": logging_arn,
+            "ApplicationFailureFeedbackRoleArn": logging_arn,
+            "ApplicationSuccessFeedbackRoleArn": logging_arn,
+            "ApplicationSuccessFeedbackSampleRate": logging_arn,
+            "SQSFailureFeedbackRoleArn": logging_arn,
+            "SQSSuccessFeedbackRoleArn": logging_arn,
+            "SQSSuccessFeedbackSampleRate": logging_arn }
     
 

--- a/source/test/__snapshots__/runbook_stack.test.ts.snap
+++ b/source/test/__snapshots__/runbook_stack.test.ts.snap
@@ -3872,9 +3872,7 @@ boto_config = Config(
         }
     )
 
-failureFeedbackRoleValue = "LambdaFailureFeedbackRoleArn"
-successFeedbackRoleValue = "LambdaSuccessFeedbackRoleArn"
-successRateRoleValue = "LambdaSuccessFeedbackSampleRate"
+endpointTypes = ['HTTP', 'Firehose', 'Lambda', 'Application', 'SQS']
 
 def connect_to_sns():
     return boto3.client('sns', config=boto_config)
@@ -3900,9 +3898,21 @@ def lambda_handler(event, _):
     topic_attributes = get_topic_attributes(topic_arn)
 
     return {
-        "FailureFeedbackRole": topic_attributes["Attributes"][failureFeedbackRoleValue],
-        "SuccessFeedbackRole": topic_attributes["Attributes"][successFeedbackRoleValue],
-        "SuccessSampleRate": topic_attributes["Attributes"][successRateRoleValue]
+        "HTTPFailureFeedbackRoleArn": topic_attributes["Attributes"]["HTTPFailureFeedbackRoleArn"],
+        "HTTPSuccessFeedbackRoleArn": topic_attributes["Attributes"]["HTTPSuccessFeedbackRoleArn"],
+        "HTTPSuccessFeedbackSampleRate": topic_attributes["Attributes"]["HTTPSuccessFeedbackSampleRate"],
+        "FirehoseFailureFeedbackRoleArn": topic_attributes["Attributes"]["FirehoseFailureFeedbackRoleArn"],
+        "FirehoseSuccessFeedbackRoleArn": topic_attributes["Attributes"]["FirehoseSuccessFeedbackRoleArn"],
+        "FirehoseSuccessFeedbackSampleRate": topic_attributes["Attributes"]["FirehoseSuccessFeedbackSampleRate"],
+        "LambdaFailureFeedbackRoleArn": topic_attributes["Attributes"]["LambdaFailureFeedbackRoleArn"],
+        "LambdaSuccessFeedbackRoleArn": topic_attributes["Attributes"]["LambdaSuccessFeedbackRoleArn"],
+        "LambdaSuccessFeedbackSampleRate": topic_attributes["Attributes"]["LambdaSuccessFeedbackSampleRate"],
+        "ApplicationFailureFeedbackRoleArn": topic_attributes["Attributes"]["ApplicationFailureFeedbackRoleArn"],
+        "ApplicationSuccessFeedbackRoleArn": topic_attributes["Attributes"]["ApplicationSuccessFeedbackRoleArn"],
+        "ApplicationSuccessFeedbackSampleRate": topic_attributes["Attributes"]["ApplicationSuccessFeedbackSampleRate"],
+        "SQSFailureFeedbackRoleArn": topic_attributes["Attributes"]["SQSFailureFeedbackRoleArn"],
+        "SQSSuccessFeedbackRoleArn": topic_attributes["Attributes"]["SQSSuccessFeedbackRoleArn"],
+        "SQSSuccessFeedbackSampleRate": topic_attributes["Attributes"]["SQSSuccessFeedbackSampleRate"]
     }
 
 def add_roles_to_topic(logging_role, topic_arn):
@@ -3911,12 +3921,13 @@ def add_roles_to_topic(logging_role, topic_arn):
     """  
     sns = connect_to_sns()
     try:
-        sns.set_topic_attributes(TopicArn=topic_arn, AttributeName=successFeedbackRoleValue, AttributeValue=logging_role)
-        sns.set_topic_attributes(TopicArn=topic_arn, AttributeName=failureFeedbackRoleValue, AttributeValue=logging_role)
+        for endpoint in endpointTypes:
+            sns.set_topic_attributes(TopicArn=topic_arn, AttributeName=f'{endpoint}SuccessFeedbackRoleArn', AttributeValue=logging_role)
+            sns.set_topic_attributes(TopicArn=topic_arn, AttributeName=f'{endpoint}FailureFeedbackRoleArn', AttributeValue=logging_role)
 
     except Exception as e:
         reset_to_recognized_state(topic_arn)
-        exit(f'Failed to set success/failure role of topic '+topic_arn+': '+str(e))
+        exit(f'Failed to set success/failure role of topic {topic_arn}: {str(e)}')
 
 def add_sample_rate_to_topic(topic_arn, sample_rate):
     """
@@ -3924,11 +3935,12 @@ def add_sample_rate_to_topic(topic_arn, sample_rate):
     """    
     sns = connect_to_sns()
     try:
-        sns.set_topic_attributes(TopicArn=topic_arn, AttributeName=successRateRoleValue, AttributeValue=sample_rate)
+        for endpoint in endpointTypes:
+            sns.set_topic_attributes(TopicArn=topic_arn, AttributeName=f'{endpoint}SuccessFeedbackSampleRate', AttributeValue=sample_rate)
 
     except Exception as e:
         reset_to_recognized_state(topic_arn)
-        exit(f'Failed to set success sample rate of SNS topic '+topic_arn+': '+str(e))
+        exit(f'Failed to set success sample rate of SNS topic {topic_arn}: {str(e)}')
 
 def get_topic_attributes(topic_arn):
     """
@@ -3940,16 +3952,18 @@ def get_topic_attributes(topic_arn):
         return topic_attributes
 
     except Exception as e:
-        exit(f'Failed to get attributes of SNS topic '+topic_arn+': '+str(e))
+        exit(f'Failed to get attributes of SNS topic {topic_arn}: {str(e)}')
 
 def reset_to_recognized_state(topic_arn):
     """
     Used in case of error, will unset all delivery status logging parameters.
     """
     sns = connect_to_sns()
-    
-    sns.set_topic_attributes(TopicArn=topic_arn, AttributeName=successFeedbackRoleValue, AttributeValue='')
-    sns.set_topic_attributes(TopicArn=topic_arn, AttributeName=failureFeedbackRoleValue, AttributeValue='')",
+
+    for endpoint in endpointTypes:
+        sns.set_topic_attributes(TopicArn=topic_arn, AttributeName=f'{endpoint}SuccessFeedbackRoleArn', AttributeValue='')
+        sns.set_topic_attributes(TopicArn=topic_arn, AttributeName=f'{endpoint}FailureFeedbackRoleArn', AttributeValue='')
+    ",
               },
               "isEnd": true,
               "name": "EnableDeliveryStatusLogging",
@@ -7737,7 +7751,7 @@ def add_ssl_bucket_policy(event, _):
       "Properties": {
         "CreateIntervalSeconds": 1,
         "DeleteIntervalSeconds": 0,
-        "DocumentPropertiesHash": "76a143310018a965418e9379eb90670ea780456ea33047bd55f0b597443d59ba",
+        "DocumentPropertiesHash": "b42ae5288be2b2fc9d51a65e9e550f73561d42ffcae96dd81b6c35f46fdf25fe",
         "ServiceToken": {
           "Ref": "WaitProviderServiceToken",
         },
@@ -7931,7 +7945,7 @@ def add_ssl_bucket_policy(event, _):
       "Properties": {
         "CreateIntervalSeconds": 0,
         "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "76a143310018a965418e9379eb90670ea780456ea33047bd55f0b597443d59ba",
+        "DocumentPropertiesHash": "b42ae5288be2b2fc9d51a65e9e550f73561d42ffcae96dd81b6c35f46fdf25fe",
         "ServiceToken": {
           "Ref": "WaitProviderServiceToken",
         },

--- a/source/test/__snapshots__/runbook_stack.test.ts.snap
+++ b/source/test/__snapshots__/runbook_stack.test.ts.snap
@@ -3959,11 +3959,12 @@ def reset_to_recognized_state(topic_arn):
     Used in case of error, will unset all delivery status logging parameters.
     """
     sns = connect_to_sns()
-
     for endpoint in endpointTypes:
-        sns.set_topic_attributes(TopicArn=topic_arn, AttributeName=f'{endpoint}SuccessFeedbackRoleArn', AttributeValue='')
-        sns.set_topic_attributes(TopicArn=topic_arn, AttributeName=f'{endpoint}FailureFeedbackRoleArn', AttributeValue='')
-    ",
+        try:
+            sns.set_topic_attributes(TopicArn=topic_arn, AttributeName=f'{endpoint}SuccessFeedbackRoleArn', AttributeValue='')
+            sns.set_topic_attributes(TopicArn=topic_arn, AttributeName=f'{endpoint}FailureFeedbackRoleArn', AttributeValue='')
+        except Exception:
+            print(f'There was an error while resetting SNS Topic {topic_arn}, please manually turn off delivery status logging for protocol {endpoint}')",
               },
               "isEnd": true,
               "name": "EnableDeliveryStatusLogging",
@@ -7751,7 +7752,7 @@ def add_ssl_bucket_policy(event, _):
       "Properties": {
         "CreateIntervalSeconds": 1,
         "DeleteIntervalSeconds": 0,
-        "DocumentPropertiesHash": "b42ae5288be2b2fc9d51a65e9e550f73561d42ffcae96dd81b6c35f46fdf25fe",
+        "DocumentPropertiesHash": "dff26ffe5bc8a2eb7a84297f591aa46181b17efa8b7c977636db9cf3beeec61c",
         "ServiceToken": {
           "Ref": "WaitProviderServiceToken",
         },
@@ -7945,7 +7946,7 @@ def add_ssl_bucket_policy(event, _):
       "Properties": {
         "CreateIntervalSeconds": 0,
         "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "b42ae5288be2b2fc9d51a65e9e550f73561d42ffcae96dd81b6c35f46fdf25fe",
+        "DocumentPropertiesHash": "dff26ffe5bc8a2eb7a84297f591aa46181b17efa8b7c977636db9cf3beeec61c",
         "ServiceToken": {
           "Ref": "WaitProviderServiceToken",
         },


### PR DESCRIPTION
*Description of changes:*
Adding all endpoint types to SNS.2 Remediation, rather than just Lambda. Edited unit testing to reflect this.

Passes all unit tests, deploys successfully, tested and works as expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.