### PR TITLE
Added Cloudtrail.3 as an alternative control for Cloudtrail.1

### DIFF
--- a/source/playbooks/SC/bin/security_controls.ts
+++ b/source/playbooks/SC/bin/security_controls.ts
@@ -31,6 +31,7 @@ const remediations: IControl[] = [
   { control: 'AutoScaling.1' },
   { control: 'CloudTrail.1' },
   { control: 'CloudTrail.2' },
+  { control: 'CloudTrail.3', executes: 'CloudTrail.1' },
   { control: 'CloudTrail.4' },
   { control: 'CloudTrail.5' },
   { control: 'CloudTrail.6' },

--- a/source/playbooks/SC/ssmdocs/SC_CloudTrail.1.ts
+++ b/source/playbooks/SC/ssmdocs/SC_CloudTrail.1.ts
@@ -6,7 +6,11 @@ import { PlaybookProps } from '../lib/control_runbooks-construct';
 import { HardCodedString, StringVariable } from '@cdklabs/cdk-ssm-documents';
 
 export function createControlRunbook(scope: Construct, id: string, props: PlaybookProps): ControlRunbookDocument {
-  return new CreateCloudTrailMultiRegionTrailDocument(scope, id, { ...props, controlId: 'CloudTrail.1' });
+  return new CreateCloudTrailMultiRegionTrailDocument(scope, id, {
+    ...props,
+    controlId: 'CloudTrail.1',
+    otherControlIds: ['CloudTrail.3'],
+  });
 }
 
 export class CreateCloudTrailMultiRegionTrailDocument extends ControlRunbookDocument {

--- a/source/playbooks/SC/test/__snapshots__/security_controls_stack.test.ts.snap
+++ b/source/playbooks/SC/test/__snapshots__/security_controls_stack.test.ts.snap
@@ -1851,6 +1851,7 @@ Note: this remediation will create a NEW trail.
                   "Finding": "{{ Finding }}",
                   "expected_control_id": [
                     "CloudTrail.1",
+                    "CloudTrail.3",
                   ],
                   "parse_id_pattern": "",
                 },


### PR DESCRIPTION
*Description of changes:*
Added Cloudtrail.3 as an alternative control for Cloudtrail.1

Deploys successfully, goes through pipeline and passes all unit tests. This remediation still needs to be tested as we cannot get the finding to appear as failed in our accounts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.