### PR TITLE
fix: set object writer as bucket ownership property when creating logging buckets

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -34,19 +34,18 @@ ts-jest under the MIT License
 ts-node under the MIT License
 typescript under the Apache License 2.0
 
+aws-lambda-powertools under the MIT License
 boto3 under the Apache License 2.0
+boto3-stubs-lite under the MIT License
 botocore under the Apache License 2.0
-certifi under the Mozilla Public License 2.0
-coverage under the Apache License 2.0
-idna under the BSD 3-Clause "New" or "Revised" License
 jmespath under the MIT License
+moto under the Apache License 2.0
 pip under the MIT License
 pytest under the MIT License
 pytest-cov under the MIT License
 pytest-env under the MIT License
 pytest-mock under the MIT License
 python-dateutil under the Apache License 2.0 and the BSD 3-Clause "New" or "Revised" License
-requests under the Apache License 2.0
 s3transfer under the Apache License 2.0
 setuptools under the MIT License
 six under the MIT License

--- a/deployment/testing_requirements.txt
+++ b/deployment/testing_requirements.txt
@@ -1,3 +1,6 @@
+moto[s3]
+aws-lambda-powertools
+boto3-stubs-lite[s3]
 pytest
 pytest-cov
 pytest-env

--- a/source/lib/remediation_runbook-stack.ts
+++ b/source/lib/remediation_runbook-stack.ts
@@ -108,7 +108,8 @@ export class RemediationRunbookStack extends cdk.Stack {
         's3:PutBucketPublicAccessBlock',
         's3:PutBucketLogging',
         's3:PutBucketAcl',
-        's3:PutBucketPolicy'
+        's3:PutBucketPolicy',
+        's3:PutBucketOwnershipControls'
       );
       s3Perms.effect = Effect.ALLOW;
       s3Perms.addResources(`arn:${this.partition}:s3:::so0111-*`);
@@ -638,7 +639,12 @@ export class RemediationRunbookStack extends cdk.Stack {
       const remediationName = 'CreateAccessLoggingBucket';
       const inlinePolicy = new Policy(props.roleStack, `SHARR-Remediation-Policy-${remediationName}`);
       const s3Perms = new PolicyStatement();
-      s3Perms.addActions('s3:CreateBucket', 's3:PutEncryptionConfiguration', 's3:PutBucketAcl');
+      s3Perms.addActions(
+        's3:CreateBucket',
+        's3:PutEncryptionConfiguration',
+        's3:PutBucketAcl',
+        's3:PutBucketOwnershipControls'
+      );
       s3Perms.effect = Effect.ALLOW;
       s3Perms.addResources('*');
 

--- a/source/remediation_runbooks/scripts/test/test_createcloudtrailmultiregiontrail.py
+++ b/source/remediation_runbooks/scripts/test/test_createcloudtrailmultiregiontrail.py
@@ -261,6 +261,7 @@ def test_create_logging_bucket(mocker):
     kwargs = {
         "Bucket": "so0111-access-logs-" + get_region() + "-111111111111",
         "ACL": "private",
+        "ObjectOwnership": "ObjectWriter",
     }
     if get_region() != "us-east-1":
         kwargs["CreateBucketConfiguration"] = {"LocationConstraint": get_region()}

--- a/source/test/__snapshots__/runbook_stack.test.ts.snap
+++ b/source/test/__snapshots__/runbook_stack.test.ts.snap
@@ -778,13 +778,21 @@ Creates an S3 bucket for access logging.
 import boto3
 from botocore.exceptions import ClientError
 from botocore.config import Config
+from typing import TYPE_CHECKING, Dict
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3 import S3Client
+    from aws_lambda_powertools.utilities.typing import LambdaContext
+else:
+    S3Client = object
+    LambdaContext = object
 
 
-def connect_to_s3(boto_config):
+def connect_to_s3(boto_config: Config) -> S3Client:
     return boto3.client("s3", config=boto_config)
 
 
-def create_logging_bucket(event, _):
+def create_logging_bucket(event: Dict, _: LambdaContext) -> Dict:
     boto_config = Config(retries={"mode": "standard"})
     s3 = connect_to_s3(boto_config)
 
@@ -793,6 +801,7 @@ def create_logging_bucket(event, _):
             "Bucket": event["BucketName"],
             "GrantWrite": "uri=http://acs.amazonaws.com/groups/s3/LogDelivery",
             "GrantReadACP": "uri=http://acs.amazonaws.com/groups/s3/LogDelivery",
+            "ObjectOwnership": "ObjectWriter",
         }
         if event["AWS_REGION"] != "us-east-1":
             kwargs["CreateBucketConfiguration"] = {
@@ -895,21 +904,26 @@ Note: this remediation will create a NEW trail.
 import boto3
 from botocore.config import Config
 from botocore.exceptions import ClientError
+from typing import TYPE_CHECKING, Dict
 
-ERROR_CREATING_BUCKET = "Error creating bucket "
+if TYPE_CHECKING:
+    from mypy_boto3_s3 import S3Client
+    from aws_lambda_powertools.utilities.typing import LambdaContext
+else:
+    S3Client = object
+    LambdaContext = object
 
 
-def connect_to_s3(boto_config):
-    return boto3.client("s3", config=boto_config)
+def connect_to_s3() -> S3Client:
+    return boto3.client("s3", config=Config(retries={"mode": "standard"}))
 
 
-def create_logging_bucket(event, _):
-    boto_config = Config(retries={"mode": "standard"})
-    s3 = connect_to_s3(boto_config)
+def create_logging_bucket(event: Dict, _: LambdaContext) -> Dict:
+    s3 = connect_to_s3()
 
-    kms_key_arn = event["kms_key_arn"]
-    aws_account = event["account"]
-    aws_region = event["region"]
+    kms_key_arn: str = event["kms_key_arn"]
+    aws_account: str = event["account"]
+    aws_region: str = event["region"]
     bucket_name = "so0111-access-logs-" + aws_region + "-" + aws_account
 
     if create_bucket(s3, bucket_name, aws_region) == "bucket_exists":
@@ -921,14 +935,18 @@ def create_logging_bucket(event, _):
     return {"logging_bucket": bucket_name}
 
 
-def create_bucket(s3, bucket_name, aws_region):
+def create_bucket(s3: S3Client, bucket_name: str, aws_region: str) -> str:
     try:
-        kwargs = {"Bucket": bucket_name, "ACL": "private"}
+        kwargs = {
+            "Bucket": bucket_name,
+            "ACL": "private",
+            "ObjectOwnership": "ObjectWriter",
+        }
         if aws_region != "us-east-1":
             kwargs["CreateBucketConfiguration"] = {"LocationConstraint": aws_region}
 
         s3.create_bucket(**kwargs)
-
+        return "success"
     except ClientError as ex:
         exception_type = ex.response["Error"]["Code"]
         # bucket already exists - return
@@ -937,13 +955,13 @@ def create_bucket(s3, bucket_name, aws_region):
             return "bucket_exists"
         else:
             print(ex)
-            exit(ERROR_CREATING_BUCKET + bucket_name)
+            exit("Error creating bucket " + bucket_name)
     except Exception as e:
         print(e)
-        exit(ERROR_CREATING_BUCKET + bucket_name)
+        exit("Error creating bucket " + bucket_name)
 
 
-def encrypt_bucket(s3, bucket_name, kms_key_arn):
+def encrypt_bucket(s3: S3Client, bucket_name: str, kms_key_arn: str) -> None:
     try:
         s3.put_bucket_encryption(
             Bucket=bucket_name,
@@ -962,7 +980,7 @@ def encrypt_bucket(s3, bucket_name, kms_key_arn):
         exit("Error encrypting bucket " + bucket_name + ": " + str(e))
 
 
-def put_access_block(s3, bucket_name):
+def put_access_block(s3: S3Client, bucket_name: str) -> None:
     try:
         s3.put_public_access_block(
             Bucket=bucket_name,
@@ -982,7 +1000,7 @@ def put_access_block(s3, bucket_name):
         )
 
 
-def put_bucket_acl(s3, bucket_name):
+def put_bucket_acl(s3: S3Client, bucket_name: str) -> None:
     try:
         s3.put_bucket_acl(
             Bucket=bucket_name,
@@ -7616,7 +7634,7 @@ def add_ssl_bucket_policy(event, _):
       "Properties": {
         "CreateIntervalSeconds": 1,
         "DeleteIntervalSeconds": 0,
-        "DocumentPropertiesHash": "719574aea3525db420a0be68782edf4dab8ea536d6223b758a5f774a63d050b8",
+        "DocumentPropertiesHash": "745c05bc80a76c7b162d697b58125375f920159a74e215966a32f7ae82f8707b",
         "ServiceToken": {
           "Ref": "WaitProviderServiceToken",
         },
@@ -7633,7 +7651,7 @@ def add_ssl_bucket_policy(event, _):
       "Properties": {
         "CreateIntervalSeconds": 1,
         "DeleteIntervalSeconds": 0,
-        "DocumentPropertiesHash": "6ab2b917f1465b034999281244e7b4c1611300ea4929b3896fc7615dd3ba7e1f",
+        "DocumentPropertiesHash": "ed6f0fed953f12a30fce8949d3584bea716efea4cf8d55d2b8d6bff413b7c3ee",
         "ServiceToken": {
           "Ref": "WaitProviderServiceToken",
         },
@@ -7773,7 +7791,7 @@ def add_ssl_bucket_policy(event, _):
       "Properties": {
         "CreateIntervalSeconds": 0,
         "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "719574aea3525db420a0be68782edf4dab8ea536d6223b758a5f774a63d050b8",
+        "DocumentPropertiesHash": "745c05bc80a76c7b162d697b58125375f920159a74e215966a32f7ae82f8707b",
         "ServiceToken": {
           "Ref": "WaitProviderServiceToken",
         },
@@ -7795,7 +7813,7 @@ def add_ssl_bucket_policy(event, _):
       "Properties": {
         "CreateIntervalSeconds": 0,
         "DeleteIntervalSeconds": 0.5,
-        "DocumentPropertiesHash": "6ab2b917f1465b034999281244e7b4c1611300ea4929b3896fc7615dd3ba7e1f",
+        "DocumentPropertiesHash": "ed6f0fed953f12a30fce8949d3584bea716efea4cf8d55d2b8d6bff413b7c3ee",
         "ServiceToken": {
           "Ref": "WaitProviderServiceToken",
         },


### PR DESCRIPTION
- set object writer as bucket ownership property when creating logging buckets

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.