### PR TITLE
chore: add test.ts to sonar exclusions

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,6 +6,7 @@ sonar.sources = source/
 sonar.exclusions = \
     **/test/**/*, \
     source/jest.config.ts, \
+    source/**/*.test.ts, \
     source/coverage/**/*
 
 sonar.tests = \


### PR DESCRIPTION
- add test.ts to sonar exclusions

This prevents test files from showing as uncovered in our coverage metrics.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.