### PR TITLE
chore: viperlight ignore dep brought in by moto

### DIFF
--- a/.viperlightignore
+++ b/.viperlightignore
@@ -21,3 +21,4 @@ Config
 
 [python-pipoutdated]
 boto3=1.20.32 # Should match Lambda runtime: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
+py-partiql-parser=0.1.0 # trust moto to resolve its own dependencies


### PR DESCRIPTION
- add viperlight ignore for older dependency brought in by moto

Internal pipeline passes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.